### PR TITLE
refactor: rename project from CCPM to AGPM

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -1,4 +1,4 @@
-# Claude Code Agents for CCPM
+# Claude Code Agents for AGPM
 
 ## Agent Architecture
 

--- a/.claude/agents/rust-doc-advanced.md
+++ b/.claude/agents/rust-doc-advanced.md
@@ -40,7 +40,7 @@ You are an advanced Rust documentation specialist powered by Opus 4.1, designed 
 //!
 //! ## High-Level Design
 //!
-//! The CCPM system follows a layered architecture with clear separation of concerns:
+//! The AGPM system follows a layered architecture with clear separation of concerns:
 //!
 //! ```text
 //! ┌─────────────────┐
@@ -57,7 +57,7 @@ You are an advanced Rust documentation specialist powered by Opus 4.1, designed 
 //! The resolver component acts as the central coordinator:
 //!
 //! ```rust
-//! use ccpm::{Resolver, Manifest, Lockfile, Cache};
+//! use agpm::{Resolver, Manifest, Lockfile, Cache};
 //!
 //! let resolver = Resolver::new()
 //!     .with_cache(cache)
@@ -77,7 +77,7 @@ You are an advanced Rust documentation specialist powered by Opus 4.1, designed 
 //!
 //! ### Why Lockfiles?
 //!
-//! The decision to use lockfiles (ccpm.lock) provides:
+//! The decision to use lockfiles (agpm.lock) provides:
 //! - Reproducible builds across environments
 //! - Explicit dependency version tracking
 //! - Faster resolution on subsequent runs
@@ -391,9 +391,9 @@ pub mod path_utils {
 
 ### 1. Custom HTML/CSS
 ```rust
-#![doc(html_root_url = "https://docs.rs/ccpm/")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/aig787/ccpm/main/assets/logo.png")]
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/aig787/ccpm/main/assets/favicon.ico")]
+#![doc(html_root_url = "https://docs.rs/agpm/")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/aig787/agpm/main/assets/logo.png")]
+#![doc(html_favicon_url = "https://raw.githubusercontent.com/aig787/agpm/main/assets/favicon.ico")]
 #![doc(html_playground_url = "https://play.rust-lang.org/")]
 
 //! <div class="warning">
@@ -414,7 +414,7 @@ pub mod path_utils {
 /// See also:
 /// - [`Manifest::dependencies`] for dependency specification
 /// - [`Lockfile::resolved`] for cached resolution results
-/// - [The dependency resolution guide](https://ccpm.dev/guide/resolution)
+/// - [The dependency resolution guide](https://agpm.dev/guide/resolution)
 ///
 /// # Related Types
 ///
@@ -447,7 +447,7 @@ cargo rustdoc -- -Z unstable-options --show-coverage
 
 # Link checking
 cargo doc --no-deps --open
-linkchecker target/doc/ccpm/index.html
+linkchecker target/doc/agpm/index.html
 ```
 
 ## Integration with rust-doc-standard
@@ -467,7 +467,7 @@ The standard rust-doc-standard agent should delegate to this advanced version wh
 
 ```markdown
 This documentation task requires advanced architectural analysis:
-- System: CCPM dependency resolution system
+- System: AGPM dependency resolution system
 - Scope: Multi-module interaction patterns, performance characteristics
 - Complexity: Advanced type system usage, concurrent safety guarantees
 
@@ -487,4 +487,4 @@ I provide comprehensive, sophisticated documentation that:
 - **Creates learning resources** beyond basic API documentation
 - **Maintains documentation accuracy** through automated testing
 
-When working on CCPM specifically, I focus on documenting the complex interactions between the resolver, cache, git operations, and cross-platform considerations that make this system robust and reliable.
+When working on AGPM specifically, I focus on documenting the complex interactions between the resolver, cache, git operations, and cross-platform considerations that make this system robust and reliable.

--- a/.claude/agents/rust-doc-standard.md
+++ b/.claude/agents/rust-doc-standard.md
@@ -131,9 +131,9 @@ pub fn my_function(param1: &str, param2: i32) -> Result<String, Error> {
 - Integration examples
 - Troubleshooting guides
 
-## CCPM-Specific Documentation Focus
+## AGPM-Specific Documentation Focus
 
-For the CCPM project, prioritize documenting:
+For the AGPM project, prioritize documenting:
 
 ### Core Modules
 - **manifest/**: TOML structure, validation rules, source definitions
@@ -149,9 +149,9 @@ For the CCPM project, prioritize documenting:
 - Error messages and recovery
 
 ### Configuration
-- ccpm.toml format with all options
-- ccpm.lock structure and purpose
-- Global config (~/.ccpm/config.toml) settings
+- agpm.toml format with all options
+- agpm.lock structure and purpose
+- Global config (~/.agpm/config.toml) settings
 - Environment variable support
 
 ### Security Considerations
@@ -330,4 +330,4 @@ I'm the documentation specialist who:
 - **Improves** existing documentation for clarity
 - **Validates** documentation accuracy and completeness
 
-When documenting the CCPM project, I focus on making the codebase accessible to new contributors and ensuring users understand how to effectively use the package manager. I ensure all security considerations are well-documented and that the documentation serves as both reference and learning material.
+When documenting the AGPM project, I focus on making the codebase accessible to new contributors and ensuring users understand how to effectively use the package manager. I ensure all security considerations are well-documented and that the documentation serves as both reference and learning material.

--- a/.claude/agents/rust-test-advanced.md
+++ b/.claude/agents/rust-test-advanced.md
@@ -37,7 +37,7 @@ You are an advanced Rust testing specialist powered by Opus 4.1, designed to han
 ### 1. Property-Based Testing with Proptest
 ```rust
 use proptest::prelude::*;
-use ccpm::{Manifest, Dependency, Version};
+use agpm::{Manifest, Dependency, Version};
 
 /// Property-based test for dependency resolution invariants
 #[cfg(test)]
@@ -132,7 +132,7 @@ mod dependency_properties {
 
 ### 2. Fuzz Testing Integration
 ```rust
-/// Fuzzing setup for CCPM manifest parsing
+/// Fuzzing setup for AGPM manifest parsing
 ///
 /// This module sets up comprehensive fuzzing for the TOML manifest parser
 /// to find edge cases and potential panics.
@@ -140,7 +140,7 @@ mod dependency_properties {
 #[cfg(fuzzing)]
 pub mod fuzz_targets {
     use libfuzzer_sys::fuzz_target;
-    use ccpm::Manifest;
+    use agpm::Manifest;
 
     /// Fuzz target for manifest parsing
     ///
@@ -247,7 +247,7 @@ mod fuzz_integration_tests {
 mod loom_tests {
     use loom::sync::{Arc, Mutex};
     use loom::thread;
-    use ccpm::Cache;
+    use agpm::Cache;
 
     /// Test concurrent cache access for race conditions
     #[test]
@@ -358,7 +358,7 @@ mod performance_tests {
         criterion_group, criterion_main, Criterion, BenchmarkId, 
         Throughput, measurement::WallTime
     };
-    use ccpm::{Resolver, Manifest, Cache};
+    use agpm::{Resolver, Manifest, Cache};
     use std::time::Duration;
 
     /// Benchmark dependency resolution with varying complexity
@@ -498,7 +498,7 @@ mod integration_scenarios {
     use tempfile::TempDir;
     use tokio::time::{sleep, Duration};
 
-    /// Test complete CCPM workflow with network failures
+    /// Test complete AGPM workflow with network failures
     #[tokio::test]
     async fn test_resilient_installation_workflow() {
         let test_env = TestEnvironment::new().await;
@@ -533,7 +533,7 @@ mod integration_scenarios {
         assert!(result.is_ok(), "Installation failed: {:?}", result.err());
         
         // Verify all dependencies were installed
-        let lockfile = Lockfile::load(&test_env.project_dir.join("ccpm.lock")).await?;
+        let lockfile = Lockfile::load(&test_env.project_dir.join("agpm.lock")).await?;
         assert_eq!(lockfile.resolved_dependencies().len(), 3);
         
         // Verify files exist in correct locations
@@ -550,7 +550,7 @@ mod integration_scenarios {
     #[tokio::test]
     async fn test_concurrent_process_safety() {
         let test_env = TestEnvironment::new().await;
-        let manifest_path = test_env.project_dir.join("ccpm.toml");
+        let manifest_path = test_env.project_dir.join("agpm.toml");
         
         // Setup manifest
         let manifest = create_complex_test_manifest();
@@ -566,7 +566,7 @@ mod integration_scenarios {
                 sleep(Duration::from_millis(i * 100)).await;
                 
                 // Each process tries to install
-                let result = run_ccpm_install(&project_dir).await;
+                let result = run_agpm_install(&project_dir).await;
                 (i, result)
             });
             handles.push(handle);
@@ -586,7 +586,7 @@ mod integration_scenarios {
         assert!(success_count > 0, "No installations succeeded");
         
         // Final state should be consistent
-        let final_lockfile = Lockfile::load(&test_env.project_dir.join("ccpm.lock")).await?;
+        let final_lockfile = Lockfile::load(&test_env.project_dir.join("agpm.lock")).await?;
         assert!(final_lockfile.is_valid());
         
         // No corrupted files
@@ -635,7 +635,7 @@ mod integration_scenarios {
         assert!(v2_content.contains("v2 API"));
         
         // Lockfile should reflect the update
-        let lockfile = Lockfile::load(&test_env.project_dir.join("ccpm.lock")).await?;
+        let lockfile = Lockfile::load(&test_env.project_dir.join("agpm.lock")).await?;
         let resolved_version = lockfile.get_resolved_version("breaking-change-agent").unwrap();
         assert_eq!(resolved_version, Version::parse("2.0.0").unwrap());
     }
@@ -646,7 +646,7 @@ mod integration_scenarios {
 
 ### 1. Custom Test Framework
 ```rust
-/// Advanced test framework for CCPM integration testing
+/// Advanced test framework for AGPM integration testing
 pub struct TestEnvironment {
     pub project_dir: PathBuf,
     pub cache_dir: PathBuf,
@@ -830,4 +830,4 @@ I provide sophisticated testing capabilities that:
 - **Analyze test quality and coverage** with actionable improvement suggestions
 - **Handle complex integration testing** with realistic failure scenarios
 
-When working on CCPM specifically, I focus on testing the complex interactions between git operations, concurrent cache access, dependency resolution algorithms, and cross-platform behavior that require sophisticated testing approaches beyond simple unit tests.
+When working on AGPM specifically, I focus on testing the complex interactions between git operations, concurrent cache access, dependency resolution algorithms, and cross-platform behavior that require sophisticated testing approaches beyond simple unit tests.

--- a/.claude/agents/rust-troubleshooter-standard.md
+++ b/.claude/agents/rust-troubleshooter-standard.md
@@ -336,28 +336,28 @@ rustup update stable          # Update toolchain
 cargo update                   # Update dependencies
 ```
 
-## Integration with CCPM Project
+## Integration with AGPM Project
 
-For CCPM-specific issues, I focus on:
+For AGPM-specific issues, I focus on:
 
-### Common CCPM Problems
+### Common AGPM Problems
 - **Git Operation Failures**: Authentication, network issues, invalid repositories
 - **Path Handling**: Cross-platform path problems, Windows-specific issues
 - **Manifest Parsing**: TOML syntax errors, invalid dependency specifications
 - **Lockfile Issues**: Corrupted lockfiles, version conflicts
 - **Cache Problems**: Permission issues, corrupted cache entries
 
-### CCPM Diagnostic Commands
+### AGPM Diagnostic Commands
 ```bash
-# CCPM-specific debugging
-ccpm validate                  # Check manifest syntax
-ccpm list                      # Show installed packages
-ccpm cache clean              # Clear cache
-RUST_LOG=debug ccpm install   # Verbose installation
+# AGPM-specific debugging
+agpm validate                  # Check manifest syntax
+agpm list                      # Show installed packages
+agpm cache clean              # Clear cache
+RUST_LOG=debug agpm install   # Verbose installation
 
-# Check CCPM configuration
-ccpm config get               # Show current config
-git config --list | grep ccpm # Check git integration
+# Check AGPM configuration
+agpm config get               # Show current config
+git config --list | grep agpm # Check git integration
 ```
 
 Remember: I'm the first line of defense for Rust problems. I handle the common 80% efficiently and escalate the complex 20% to the right specialist. This keeps troubleshooting fast and ensures problems get appropriate expertise levels.

--- a/.claude/commands/fact-check-docs.md
+++ b/.claude/commands/fact-check-docs.md
@@ -56,7 +56,7 @@ Systematically verify the accuracy of all documentation files against the curren
    - Design patterns described are actually used
 
    **Configuration claims**:
-   - Config file formats are accurate (ccpm.toml, ccpm.lock)
+   - Config file formats are accurate (agpm.toml, agpm.lock)
    - Field names and types match schema
    - Default configuration values are correct
    - Environment variable names are accurate
@@ -132,7 +132,7 @@ Systematically verify the accuracy of all documentation files against the curren
 
 6. Special areas requiring careful verification:
 
-   **CCPM-specific**:
+   **AGPM-specific**:
    - Git worktree architecture descriptions
    - SHA-based resolution claims
    - Parallel installation capabilities
@@ -163,8 +163,8 @@ Systematically verify the accuracy of all documentation files against the curren
    ## File: docs/example.md
 
    ### Line 42: Incorrect command syntax
-   - Documentation says: `ccpm install --parallel`
-   - Actually should be: `ccpm install --max-parallel N`
+   - Documentation says: `agpm install --parallel`
+   - Actually should be: `agpm install --max-parallel N`
    - Severity: Important
 
    ### Line 78: Outdated module structure

--- a/.claude/commands/lint.md
+++ b/.claude/commands/lint.md
@@ -6,11 +6,11 @@ argument-hint: [ --fix | --check ] [ --all ] [ --doc ] - e.g., "--fix" or "--che
 
 ## Context
 
-- Project name: CCPM (Claude Code Package Manager)
+- Project name: AGPM (Claude Code Package Manager)
 
 ## Your task
 
-Run code quality checks for the CCPM project using specialized Rust agents:
+Run code quality checks for the AGPM project using specialized Rust agents:
 
 1. Parse the arguments:
    - `--fix`: Apply automatic fixes where possible (uses rust-linting-standard)

--- a/.claude/commands/lint.md
+++ b/.claude/commands/lint.md
@@ -10,10 +10,10 @@ argument-hint: [ --fix | --check ] [ --all ] [ --doc ] - e.g., "--fix" or "--che
 
 ## Your task
 
-Run code quality checks for the AGPM project using specialized Rust agents:
+Run code quality checks for the AGPM project using specialized Rust agents with automatic escalation:
 
 1. Parse the arguments:
-   - `--fix`: Apply automatic fixes where possible (uses rust-linting-standard)
+   - `--fix`: Apply automatic fixes where possible (uses escalating agents)
    - `--check`: Run in CI mode (strict checking, fail on warnings)
    - `--all`: Run all checks including test compilation
    - `--doc`: Add comprehensive documentation (uses rust-doc-standard)
@@ -22,23 +22,51 @@ Run code quality checks for the AGPM project using specialized Rust agents:
 
 2. **CRITICAL**: Use the Task tool to delegate to specialized agents. Do NOT run cargo commands directly.
 
-3. Based on the arguments, delegate to the appropriate specialized agent using Task:
+3. **AUTOMATIC ESCALATION STRATEGY** - Based on the arguments, use this multi-phase approach:
 
-   **For linting and formatting (`--fix` or standard checks):**
-   - Use Task with subagent_type="rust-linting-standard" for quick fixes:
-     ```
-     Task(description="Fix linting issues",
-          prompt="Run cargo fmt and clippy with --fix flag. Apply automatic fixes for all features and test code...",
-          subagent_type="rust-linting-standard")
-     ```
-   - Or use Task with subagent_type="rust-linting-advanced" for complex issues
-   - The agents will:
-     - Run `cargo fmt --all` (or `cargo fmt --all --check` if `--check` mode)
-     - Run `cargo clippy --all-features --tests` with appropriate flags
-     - Apply automatic fixes if `--fix` is specified with `--all-features`
-     - The agent will delegate complex refactoring to rust-expert if needed
-     - **Important**: Always use `--all-features` to check feature-gated code
-     - **Important**: Always include `--tests` to check test code
+   **Phase 1: Fast Fixes (`--fix` mode)**
+
+   a) First, use `rust-linting-standard` (Haiku) for quick automatic fixes:
+   ```
+   Task(description="Apply automatic linting fixes",
+        prompt="Run cargo fmt and clippy with --fix flag. Apply all automatic fixes for all features and test code. Report any remaining warnings that require manual intervention.",
+        subagent_type="rust-linting-standard")
+   ```
+
+   b) **Analyze the result**: If the agent reports remaining warnings, issues, or manual intervention needed, proceed to Phase 2.
+
+   **Phase 2: Advanced Fixes (Automatic Escalation)**
+
+   If Phase 1 reports remaining issues, automatically escalate to `rust-linting-advanced` (Sonnet):
+   ```
+   Task(description="Fix remaining linting issues",
+        prompt="Fix the remaining clippy warnings and code quality issues. The following issues were identified:
+        [summarize issues from Phase 1]
+
+        Address all fixable warnings including:
+        - Redundant else blocks
+        - Documentation improvements (add # Errors sections)
+        - Code simplification opportunities
+        - Naming conventions
+        - Function complexity
+
+        Run cargo clippy --all-features --all-targets -- -D warnings to verify all warnings are fixed.",
+        subagent_type="rust-linting-advanced")
+   ```
+
+   c) The advanced agent will:
+     - Fix redundant code patterns
+     - Add missing documentation sections
+     - Simplify complex logic
+     - Delegate architectural changes to rust-expert if needed
+     - Verify with strict warning mode
+
+   **For linting basics (what agents do):**
+   - Run `cargo fmt --all` (or `cargo fmt --all --check` if `--check` mode)
+   - Run `cargo clippy --all-features --all-targets` with appropriate flags
+   - Apply automatic fixes if `--fix` is specified
+   - **Important**: Always use `--all-features` to check feature-gated code
+   - **Important**: Always use `--all-targets` to include tests, benches, examples
 
    **For documentation (`--doc` flag):**
    - Use Task with subagent_type="rust-doc-standard" for documentation:
@@ -55,25 +83,41 @@ Run code quality checks for the AGPM project using specialized Rust agents:
      - Run `cargo doc --all-features --no-deps` to verify documentation
 
    **For standard checks without --fix:**
-   - Use `rust-linting-standard` for quick analysis or `rust-linting-advanced` for detailed review
-   - Always include `--all-features` and `--tests` flags
+   - Use `rust-linting-standard` for quick analysis
+   - No escalation needed - just report findings
 
 4. Agent delegation strategy:
-   - `rust-linting-standard` (Haiku) handles fast, mechanical fixes
-   - `rust-linting-advanced` (Sonnet) handles complex linting and refactoring suggestions
-   - Complex refactoring is delegated to `rust-expert-standard` or `rust-expert-advanced`
-   - Memory issues or undefined behavior are delegated to `rust-troubleshooter-advanced`
-   - Documentation improvements use `rust-doc-standard` or `rust-doc-advanced`
+   - `rust-linting-standard` (Haiku) → Fast, mechanical fixes → **Escalates if issues remain**
+   - `rust-linting-advanced` (Sonnet) → Complex linting and refactoring → **Escalates to rust-expert if needed**
+   - `rust-expert-standard` or `rust-expert-advanced` → Architectural changes
+   - `rust-troubleshooter-advanced` → Memory issues or undefined behavior
+   - `rust-doc-standard` or `rust-doc-advanced` → Documentation improvements
 
-5. Provide a clear summary of actions taken and any remaining issues
+5. Provide a clear summary of:
+   - What Phase 1 fixed (if applicable)
+   - Whether escalation occurred and why
+   - What Phase 2 fixed (if applicable)
+   - Any remaining issues (should be none after Phase 2)
 
 Examples of usage:
 
 - `/lint` - Run standard checks with --all-features (fmt, clippy, doc)
-- `/lint --fix` - Apply automatic fixes for formatting and clippy issues (includes test code)
+- `/lint --fix` - **Two-phase fix with auto-escalation**:
+  - Phase 1: rust-linting-standard applies quick fixes
+  - Phase 2: Auto-escalates to rust-linting-advanced if issues remain
+  - Result: All fixable warnings resolved
 - `/lint --check` - CI mode with strict validation (all features and tests)
 - `/lint --check --all` - Full CI validation including test compilation with all features
 - `/lint --all` - Run all checks including test compilation with all features
 - `/lint --doc` - Add/improve documentation using rust-doc-standard or rust-doc-advanced
 
-Note: All commands automatically include `--all-features` and check test code to ensure complete coverage.
+Note: All commands automatically include `--all-features` and `--all-targets` to ensure complete coverage.
+
+**Escalation Flow for --fix:**
+```
+rust-linting-standard (Phase 1)
+    ↓ (if warnings remain)
+rust-linting-advanced (Phase 2)
+    ↓ (if architectural changes needed)
+rust-expert-standard/advanced (Phase 3)
+```

--- a/.claude/commands/pr-self-review.md
+++ b/.claude/commands/pr-self-review.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Task, Bash(git diff:*), Bash(git status:*), Bash(git log:*), Bash(git show:*), Bash(cargo fmt:*), Bash(cargo clippy:*), Bash(cargo test:*), Bash(cargo nextest:*), Bash(cargo build:*), Bash(cargo doc:*), Bash(cargo check:*), Read, Edit, MultiEdit, Glob, Grep, TodoWrite, WebSearch, WebFetch
-description: Perform comprehensive PR review for CCPM project
+description: Perform comprehensive PR review for AGPM project
 argument-hint: [ <commit> | <range> ] [ --quick | --full | --security | --performance ] - e.g., "abc123 --quick" for single commit, "main..HEAD --full" for range
 ---
 
@@ -12,7 +12,7 @@ argument-hint: [ <commit> | <range> ] [ --quick | --full | --security | --perfor
 
 ## Your task
 
-Perform a comprehensive pull request review for the CCPM project based on the arguments provided.
+Perform a comprehensive pull request review for the AGPM project based on the arguments provided.
 
 **IMPORTANT**: Batch related operations thoughtfully; schedule tool calls in Claude Code only in parallel when the workflow benefits from it.
 
@@ -127,7 +127,7 @@ Perform a comprehensive pull request review for the CCPM project based on the ar
    - No circular dependencies
 
    **Security**:
-   - No credentials in ccpm.toml
+   - No credentials in agpm.toml
    - Input validation for git commands
    - Atomic file operations
 

--- a/.claude/commands/update-claude.md
+++ b/.claude/commands/update-claude.md
@@ -64,7 +64,7 @@ Review the current changes and ensure both CLAUDE.md and AGENTS.md accurately re
    - **Testing Strategy**: New test types, coverage changes, testing patterns
    - **Security Rules**: New security considerations or validations
    - **Development Guidelines**: Updated practices or requirements
-   - **Example Formats**: ccpm.toml and ccpm.lock format changes
+   - **Example Formats**: agpm.toml and agpm.lock format changes
    - **Build and Release**: New build steps or requirements
 
    **Key sections to check in AGENTS.md**:

--- a/.claude/commands/update-docs.md
+++ b/.claude/commands/update-docs.md
@@ -137,8 +137,8 @@ Review the current changes and ensure README.md, all documentation files, and Cl
    - Put detailed content in appropriate docs/ files
    - Ensure cross-references between docs are accurate
 
-8. Special considerations for CCPM:
-   - Lockfile behavior (ccpm.lock) must be accurately described
+8. Special considerations for AGPM:
+   - Lockfile behavior (agpm.lock) must be accurately described
    - Git-based distribution model should be clear
    - Cross-platform support claims must be accurate
    - Security considerations should be mentioned where relevant

--- a/.claude/commands/update-docstrings.md
+++ b/.claude/commands/update-docstrings.md
@@ -88,7 +88,7 @@ Review the current code changes and ensure all related documentation (doc commen
    - Update CLAUDE.md if architecture changed
    - Ensure error messages are documented
 
-6. Focus areas for CCPM project:
+6. Focus areas for AGPM project:
 
    **Critical documentation to maintain**:
    - **Public API documentation**: All pub functions and structs

--- a/.claude/snippets/prompts/fix-failing-tests.md
+++ b/.claude/snippets/prompts/fix-failing-tests.md
@@ -14,7 +14,7 @@
 
 ## Overview
 
-You are tasked with fixing ALL failing tests in the CCPM (Claude Code Package Manager) project. This is an iterative process where you will continuously discover, fix, and validate until every single test passes.
+You are tasked with fixing ALL failing tests in the AGPM (Claude Code Package Manager) project. This is an iterative process where you will continuously discover, fix, and validate until every single test passes.
 
 **⏱️ IMPORTANT: The full test suite may take up to 5 minutes to run.** Plan accordingly and be patient when running `cargo test --all`. Individual test categories typically run faster, but doc tests in particular can be slow due to compilation overhead.
 
@@ -186,7 +186,7 @@ Doc tests have unique issues that differ from regular tests:
 #### Missing Imports in Doc Examples
 ```rust
 /// ```
-/// # use ccpm::utils::progress::MultiPhaseProgress;  // Add hidden import
+/// # use agpm::utils::progress::MultiPhaseProgress;  // Add hidden import
 /// let progress = MultiPhaseProgress::new(true);
 /// ```
 ```
@@ -207,18 +207,18 @@ Doc tests have unique issues that differ from regular tests:
 #### Incomplete Examples
 ```rust
 /// ```
-/// # use ccpm::manifest::Manifest;
+/// # use agpm::manifest::Manifest;
 /// # let manifest = Manifest::default();  // Add setup code
 /// let deps = manifest.all_dependencies();
 /// # assert!(deps.is_empty());  // Add assertion if needed
 /// ```
 ```
 
-### Step 6: Common CCPM-Specific Fixes
+### Step 6: Common AGPM-Specific Fixes
 
 #### Missing Test Utilities
 
-CCPM tests often need test utilities that may be missing:
+AGPM tests often need test utilities that may be missing:
 
 ```rust
 // In tests/fixtures/mod.rs or similar
@@ -233,7 +233,7 @@ pub fn temp_dir_with_git() -> TempDir {
 
 #### Async Test Issues
 
-Many CCPM tests are async and need proper runtime:
+Many AGPM tests are async and need proper runtime:
 
 ```rust
 #[tokio::test]  // Not #[test]
@@ -421,7 +421,7 @@ Consider delegating to rust-expert-advanced when:
 - Performance problems in tests indicate algorithmic issues
 - Complex generic or trait bound problems
 
-## Notes for CCPM Specifics
+## Notes for AGPM Specifics
 
 - The project uses **cargo nextest** for faster test execution when available
 - Tests may involve Git operations - ensure Git is configured in test environment

--- a/.claude/snippets/prompts/improve-test-coverage.md
+++ b/.claude/snippets/prompts/improve-test-coverage.md
@@ -1,8 +1,8 @@
-# Test Coverage Improvement Instructions for CCPM
+# Test Coverage Improvement Instructions for AGPM
 
 ## Overview
 
-You are tasked with improving test coverage for the CCPM (Claude Code Package Manager) project. The target is 70%
+You are tasked with improving test coverage for the AGPM (Claude Code Package Manager) project. The target is 70%
 minimum coverage. All existing tests must remain passing throughout this process.
 
 **IMPORTANT**: This is an iterative process. You will:
@@ -46,10 +46,10 @@ cargo test --all
 
 ```bash
 # Save baseline coverage output to a tmp file for reference (avoid re-running)
-cargo llvm-cov --ignore-filename-regex "test_utils" --text | tee /tmp/ccpm_coverage_baseline.txt
+cargo llvm-cov --ignore-filename-regex "test_utils" --text | tee /tmp/agpm_coverage_baseline.txt
 
 # Check current coverage percentage quickly from saved file
-tail -5 /tmp/ccpm_coverage_baseline.txt
+tail -5 /tmp/agpm_coverage_baseline.txt
 
 # Generate HTML coverage report only when needed for detailed analysis
 cargo llvm-cov --ignore-filename-regex "test_utils" --html --output-dir target/coverage
@@ -75,7 +75,7 @@ make coverage
 
 ```bash
 # Extract coverage ratios from the summary section (format: "src/file.rs: 123/456")
-grep -E "src/[^:]+: [0-9]+/[0-9]+" /tmp/ccpm_coverage_baseline.txt | while read line; do
+grep -E "src/[^:]+: [0-9]+/[0-9]+" /tmp/agpm_coverage_baseline.txt | while read line; do
     # Extract file path and coverage
     file=$(echo "$line" | cut -d: -f1 | sed 's/|| //')
     coverage_part=$(echo "$line" | cut -d: -f2 | cut -d' ' -f2)
@@ -197,7 +197,7 @@ mod tests {
 Location: `tests/` directory
 
 ```rust
-use ccpm::cli;
+use agpm::cli;
 use tempfile::TempDir;
 
 #[test]
@@ -207,7 +207,7 @@ fn test_install_command() {
 }
 ```
 
-### Step 6: CCPM-Specific Testing Requirements
+### Step 6: AGPM-Specific Testing Requirements
 
 #### Critical Testing Rules
 
@@ -226,7 +226,7 @@ fn test_install_command() {
     - Each test should be completely independent
     - Use dependency injection for configuration
 
-#### Testing Patterns for CCPM
+#### Testing Patterns for AGPM
 
 **Manifest Testing**
 
@@ -282,7 +282,7 @@ When selecting modules to test, use this decision matrix:
 # Quick analysis to find best targets
 echo "=== High Impact Modules (test these first) ==="
 # Modules with >50 uncovered lines and <50% coverage
-grep "^|| src/" /tmp/ccpm_coverage_*.txt | awk -F': ' '{
+grep "^|| src/" /tmp/agpm_coverage_*.txt | awk -F': ' '{
     split($2, a, " ");
     split(a[1], b, "/");
     if (b[2] > 0) {
@@ -297,7 +297,7 @@ grep "^|| src/" /tmp/ccpm_coverage_*.txt | awk -F': ' '{
 
 echo -e "\n=== Quick Wins (small modules to boost percentage) ==="
 # Modules with <20 uncovered lines that can reach 90%+
-grep "^|| src/" /tmp/ccpm_coverage_*.txt | awk -F': ' '{
+grep "^|| src/" /tmp/agpm_coverage_*.txt | awk -F': ' '{
     split($2, a, " ");
     split(a[1], b, "/");
     if (b[2] > 0) {
@@ -318,7 +318,7 @@ If you're within 1% of the target (e.g., at 69.91% aiming for 70%):
 1. **Calculate Exact Need:**
    ```bash
    # Extract actual numbers from coverage report
-   coverage_line=$(tail -1 /tmp/ccpm_coverage_baseline.txt)
+   coverage_line=$(tail -1 /tmp/agpm_coverage_baseline.txt)
    # Example line: "69.91% coverage, 3609/5162 lines covered, +0.00% change in coverage"
    
    current_pct=$(echo "$coverage_line" | grep -oE "[0-9]+\.[0-9]+%" | head -1 | tr -d '%')
@@ -350,13 +350,13 @@ If you're within 1% of the target (e.g., at 69.91% aiming for 70%):
 1. **Measure Current State**
    ```bash
    # IMPORTANT: Save coverage output to avoid expensive re-runs
-   cargo llvm-cov --text | tee /tmp/ccpm_coverage_current.txt
+   cargo llvm-cov --text | tee /tmp/agpm_coverage_current.txt
 
    # Check specific module coverage from saved output
-   grep "src/module_name" /tmp/ccpm_coverage_current.txt
+   grep "src/module_name" /tmp/agpm_coverage_current.txt
 
    # Or reference previous runs
-   cat /tmp/ccpm_coverage_*.txt | tail -1 | grep "src/module_name"
+   cat /tmp/agpm_coverage_*.txt | tail -1 | grep "src/module_name"
    ```
 
 2. **Pick ONE Module to Improve**
@@ -384,11 +384,11 @@ If you're within 1% of the target (e.g., at 69.91% aiming for 70%):
 5. **Measure Improvement**
    ```bash
    # Save new coverage measurement
-   cargo llvm-cov --text | tee /tmp/ccpm_coverage_after_$(date +%Y%m%d_%H%M%S).txt
+   cargo llvm-cov --text | tee /tmp/agpm_coverage_after_$(date +%Y%m%d_%H%M%S).txt
 
    # Compare with previous baseline
-   echo "=== Before ===" && grep "src/module_name" /tmp/ccpm_coverage_current.txt
-   echo "=== After ===" && grep "src/module_name" /tmp/ccpm_coverage_after_*.txt | tail -1
+   echo "=== Before ===" && grep "src/module_name" /tmp/agpm_coverage_current.txt
+   echo "=== After ===" && grep "src/module_name" /tmp/agpm_coverage_after_*.txt | tail -1
 
    # Generate HTML report only when needed for detailed analysis
    # cargo llvm-cov --html --output-dir target/coverage
@@ -409,7 +409,7 @@ If you're within 1% of the target (e.g., at 69.91% aiming for 70%):
 **Remember**: Small, incremental improvements are better than large, risky changes. Each iteration should leave the
 codebase in a stable, working state.
 
-### Step 8: Common Testing Scenarios for CCPM
+### Step 8: Common Testing Scenarios for AGPM
 
 #### Testing CLI Commands
 
@@ -423,7 +423,7 @@ fn test_install_with_dependencies() {
     let result = cli::install::execute(temp_dir.path()).await;
 
     // Verify lockfile created
-    assert!(temp_dir.path().join("ccpm.lock").exists());
+    assert!(temp_dir.path().join("agpm.lock").exists());
 }
 ```
 
@@ -457,20 +457,20 @@ Track coverage improvements efficiently:
 
 ```bash
 # Save coverage runs with descriptive names
-cargo llvm-cov --text --no-run | tee /tmp/ccpm_coverage_no_tests.txt
+cargo llvm-cov --text --no-run | tee /tmp/agpm_coverage_no_tests.txt
 
 # Focus on specific modules (save output)
-cargo llvm-cov --text -- module_name:: | tee /tmp/ccpm_coverage_module_$(date +%Y%m%d).txt
+cargo llvm-cov --text -- module_name:: | tee /tmp/agpm_coverage_module_$(date +%Y%m%d).txt
 
 # Skip problematic tests temporarily (save output)
-cargo llvm-cov --text -- --skip 'test_name_pattern' | tee /tmp/ccpm_coverage_skip_problematic.txt
+cargo llvm-cov --text -- --skip 'test_name_pattern' | tee /tmp/agpm_coverage_skip_problematic.txt
 
 # Compare coverage over time
-ls -la /tmp/ccpm_coverage_*.txt
-diff /tmp/ccpm_coverage_current.txt /tmp/ccpm_coverage_after_*.txt | tail -1
+ls -la /tmp/agpm_coverage_*.txt
+diff /tmp/agpm_coverage_current.txt /tmp/agpm_coverage_after_*.txt | tail -1
 
 # Quick coverage check from saved results
-tail -20 /tmp/ccpm_coverage_current.txt
+tail -20 /tmp/agpm_coverage_current.txt
 ```
 
 ## Red Flags to Avoid
@@ -520,17 +520,17 @@ Based on module importance:
 cargo test --all
 
 # Generate and save coverage report (EXPENSIVE - save output!)
-cargo llvm-cov --ignore-filename-regex "test_utils" --text | tee /tmp/ccpm_coverage_baseline.txt
+cargo llvm-cov --ignore-filename-regex "test_utils" --text | tee /tmp/agpm_coverage_baseline.txt
 
 # Generate HTML report only when needed for detailed analysis
 cargo llvm-cov --ignore-filename-regex "test_utils" --html --output-dir target/coverage
 
 # Run coverage for specific module (save output)
-cargo llvm-cov --text -- module_name:: | tee /tmp/ccpm_coverage_module.txt
+cargo llvm-cov --text -- module_name:: | tee /tmp/agpm_coverage_module.txt
 
 # View saved coverage reports
-ls -la /tmp/ccpm_coverage_*.txt
-cat /tmp/ccpm_coverage_current.txt
+ls -la /tmp/agpm_coverage_*.txt
+cat /tmp/agpm_coverage_current.txt
 
 # Run tests with single thread (for debugging)
 cargo test -- --test-threads=1
@@ -542,10 +542,10 @@ cargo test -- --nocapture
 cargo test test_name -- --exact
 
 # Check coverage without running tests (save output)
-cargo llvm-cov --text --no-run | tee /tmp/ccpm_coverage_no_tests.txt
+cargo llvm-cov --text --no-run | tee /tmp/agpm_coverage_no_tests.txt
 
 # Compare coverage between runs
-diff /tmp/ccpm_coverage_current.txt /tmp/ccpm_coverage_after_*.txt | tail -1
+diff /tmp/agpm_coverage_current.txt /tmp/agpm_coverage_after_*.txt | tail -1
 ```
 
 ## When to Use Each Agent
@@ -557,14 +557,14 @@ diff /tmp/ccpm_coverage_current.txt /tmp/ccpm_coverage_after_*.txt | tail -1
 - **Complex issues**: Use `rust-troubleshooter-opus` for deep debugging
 - **Code quality**: Use `rust-linting-expert` for test code style
 
-## Real-World Example: Improving CCPM Coverage from 69.91% to 70.11%
+## Real-World Example: Improving AGPM Coverage from 69.91% to 70.11%
 
 This is an actual example of how the coverage was improved:
 
 ### 1. Initial Assessment
 ```bash
 # Check baseline
-tail -5 /tmp/ccpm_coverage_baseline.txt
+tail -5 /tmp/agpm_coverage_baseline.txt
 # Output: 69.91% coverage, 3609/5162 lines covered
 ```
 
@@ -587,7 +587,7 @@ Added 3 strategic tests to `src/cli/remove.rs`:
 ### 4. Result
 ```bash
 # After adding tests
-tail -5 /tmp/ccpm_coverage_after.txt
+tail -5 /tmp/agpm_coverage_after.txt
 # Output: 70.11% coverage, 3619/5162 lines covered, +0.19% change
 ```
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,23 +104,23 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            binary_name: ccpm
+            binary_name: agpm
 
           - os: ubuntu-24.04-arm # Native ARM64 Linux runner
             target: aarch64-unknown-linux-gnu
-            binary_name: ccpm
+            binary_name: agpm
 
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-            binary_name: ccpm.exe
+            binary_name: agpm.exe
 
           - os: macos-latest
             target: x86_64-apple-darwin
-            binary_name: ccpm
+            binary_name: agpm
 
           - os: macos-latest
             target: aarch64-apple-darwin
-            binary_name: ccpm
+            binary_name: agpm
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -42,8 +42,8 @@ examples/projects/
 # Claude
 **/.claude/settings.local.json
 
-# CCPM managed directories
-.claude/ccpm/
+# AGPM managed directories
+.claude/agpm/
 
 # Windows reserved device names (prevent sync issues)
 NUL

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,16 +1,16 @@
-# AGENTS.md - CCPM Project Context (Codex)
+# AGENTS.md - AGPM Project Context (Codex)
 
 **IMPORTANT**: This file must remain under 20,000 characters.
 
-This document mirrors the CCPM context from `CLAUDE.md` but focuses on architecture, workflows, and guardrails that are
-especially relevant when contributing through Codex. CCPM is still the Claude Code Package Manager, so references to
+This document mirrors the AGPM context from `CLAUDE.md` but focuses on architecture, workflows, and guardrails that are
+especially relevant when contributing through Codex. AGPM is still the Claude Code Package Manager, so references to
 `.claude/...` paths and Claude-specific resource types remain accurate; Codex contributors should respect them when
 working in this repository.
 
 ## Overview
 
-CCPM (Claude Code Package Manager) is a Git-based package manager for Claude Code resources (agents, snippets, commands,
-scripts, hooks, MCP servers), written in Rust. It uses a lockfile model (ccpm.toml + ccpm.lock) like Cargo for
+AGPM (Claude Code Package Manager) is a Git-based package manager for Claude Code resources (agents, snippets, commands,
+scripts, hooks, MCP servers), written in Rust. It uses a lockfile model (agpm.toml + agpm.lock) like Cargo for
 reproducible installations from Git repositories.
 
 ## Architecture
@@ -34,8 +34,8 @@ src/
 ├── git/         # Git CLI wrapper + worktrees
 ├── hooks/       # Hook integrations for Claude Code environments
 ├── installer.rs # Parallel resource installation
-├── lockfile/    # ccpm.lock management
-├── manifest/    # ccpm.toml parsing + transitive dependencies
+├── lockfile/    # agpm.lock management
+├── manifest/    # agpm.toml parsing + transitive dependencies
 │   └── dependency_spec.rs  # DependencySpec and DependencyMetadata structures
 ├── markdown/    # Markdown file operations
 ├── mcp/         # MCP server management
@@ -57,10 +57,10 @@ src/
 
 ## CLI Commands
 
-- `install [--frozen] [--no-cache] [--max-parallel N]` - Install from ccpm.toml
+- `install [--frozen] [--no-cache] [--max-parallel N]` - Install from agpm.toml
 - `update [dep]` - Update dependencies
 - `outdated [--check] [--no-fetch] [--format json]` - Check for dependency updates
-- `upgrade [--check] [--status] [--force] [--rollback] [--no-backup] [VERSION]` - Self-update CCPM
+- `upgrade [--check] [--status] [--force] [--rollback] [--no-backup] [VERSION]` - Self-update AGPM
 - `list` - List installed resources
 - `validate [--check-lock] [--resolve]` - Validate manifest
 - `cache [clean|list]` - Manage cache
@@ -208,7 +208,7 @@ Conflict detection is integrated into the core resolution logic (`resolver::mod.
 Cache uses Git worktrees with SHA-based resolution for maximum efficiency:
 
 ```
-~/.ccpm/cache/
+~/.agpm/cache/
 ├── sources/        # Bare repositories (.git suffix)
 │   └── github_owner_repo.git/
 ├── worktrees/      # SHA-based worktrees (deduplicated)
@@ -235,17 +235,17 @@ Cache uses Git worktrees with SHA-based resolution for maximum efficiency:
 - **Use Task tool** for complex operations
 - **Cross-platform**: Windows, macOS, Linux
 - **NO git2**: Use system git command
-- **Security**: Credentials only in ~/.ccpm/config.toml, path traversal prevention, checksums
+- **Security**: Credentials only in ~/.agpm/config.toml, path traversal prevention, checksums
 - **Atomic ops**: Temp file + rename
 - **Resources**: .md, .json, .sh/.js/.py files
 - **Hooks**: Configure in .claude/settings.local.json
 - **MCP**: Configure in .mcp.json
 
-## Example ccpm.toml Format
+## Example agpm.toml Format
 
 ```toml
 [sources]
-community = "https://github.com/aig787/ccpm-community.git"
+community = "https://github.com/aig787/agpm-community.git"
 local = "../my-local-resources"  # Local directory support
 
 [agents]
@@ -278,7 +278,7 @@ filesystem = { source = "community", path = "mcp-servers/filesystem.json", versi
 postgres = { source = "local", path = "mcp-servers/postgres.json" }
 ```
 
-## Example ccpm.lock
+## Example agpm.lock
 
 ```toml
 # Auto-generated lockfile
@@ -295,7 +295,7 @@ installed_at = ".claude/agents/example-agent.md"
 
 ## Config Priority
 
-1. `~/.ccpm/config.toml` - Global config with auth tokens (not in git)
-2. `ccpm.toml` - Project manifest (in git)
+1. `~/.agpm/config.toml` - Global config with auth tokens (not in git)
+2. `agpm.toml` - Project manifest (in git)
 
 Keeps secrets out of version control.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,11 @@
-# CLAUDE.md - CCPM Project Context
+# CLAUDE.md - AGPM Project Context
 
 **IMPORTANT**: This file must remain under 20,000 characters.
 
 ## Overview
 
-CCPM (Claude Code Package Manager) is a Git-based package manager for Claude Code resources (agents, snippets, commands,
-scripts, hooks, MCP servers), written in Rust. It uses a lockfile model (ccpm.toml + ccpm.lock) like Cargo for
+AGPM (Claude Code Package Manager) is a Git-based package manager for Claude Code resources (agents, snippets, commands,
+scripts, hooks, MCP servers), written in Rust. It uses a lockfile model (agpm.toml + agpm.lock) like Cargo for
 reproducible installations from Git repositories.
 
 ## Architecture
@@ -29,8 +29,8 @@ src/
 ├── git/         # Git CLI wrapper + worktrees
 ├── hooks/       # Claude Code hooks
 ├── installer.rs # Parallel resource installation + artifact cleanup
-├── lockfile/    # ccpm.lock management + staleness detection
-├── manifest/    # ccpm.toml parsing + transitive dependencies
+├── lockfile/    # agpm.lock management + staleness detection
+├── manifest/    # agpm.toml parsing + transitive dependencies
 │   └── dependency_spec.rs  # DependencySpec and DependencyMetadata structures
 ├── markdown/    # Markdown file operations
 ├── mcp/         # MCP server management
@@ -93,10 +93,10 @@ src/
 
 ## CLI Commands
 
-- `install [--frozen] [--no-cache] [--max-parallel N]` - Install from ccpm.toml
+- `install [--frozen] [--no-cache] [--max-parallel N]` - Install from agpm.toml
 - `update [dep]` - Update dependencies
 - `outdated [--check] [--no-fetch] [--format json]` - Check for dependency updates
-- `upgrade [--check] [--status] [--force] [--rollback] [--no-backup] [VERSION]` - Self-update CCPM
+- `upgrade [--check] [--status] [--force] [--rollback] [--no-backup] [VERSION]` - Self-update AGPM
 - `list` - List installed resources
 - `validate [--check-lock] [--resolve]` - Validate manifest
 - `cache [clean|list]` - Manage cache
@@ -246,7 +246,7 @@ dependencies:
 Cache uses Git worktrees with SHA-based resolution for maximum efficiency:
 
 ```
-~/.ccpm/cache/
+~/.agpm/cache/
 ├── sources/        # Bare repositories (.git suffix)
 │   └── github_owner_repo.git/
 ├── worktrees/      # SHA-based worktrees (deduplicated)
@@ -273,17 +273,17 @@ Cache uses Git worktrees with SHA-based resolution for maximum efficiency:
 - **Use Task tool** for complex operations
 - **Cross-platform**: Windows, macOS, Linux
 - **NO git2**: Use system git command
-- **Security**: Credentials only in ~/.ccpm/config.toml, path traversal prevention, checksums
+- **Security**: Credentials only in ~/.agpm/config.toml, path traversal prevention, checksums
 - **Atomic ops**: Temp file + rename
 - **Resources**: .md, .json, .sh/.js/.py files
 - **Hooks**: Configure in .claude/settings.local.json
 - **MCP**: Configure in .mcp.json
 
-## Example ccpm.toml Format
+## Example agpm.toml Format
 
 ```toml
 [sources]
-community = "https://github.com/aig787/ccpm-community.git"
+community = "https://github.com/aig787/agpm-community.git"
 local = "../my-local-resources"  # Local directory support
 
 [agents]
@@ -323,7 +323,7 @@ filesystem = { source = "community", path = "mcp-servers/filesystem.json", versi
 postgres = { source = "local", path = "mcp-servers/postgres.json" }
 ```
 
-## Example ccpm.lock
+## Example agpm.lock
 
 ```toml
 # Auto-generated lockfile
@@ -349,7 +349,7 @@ installed_at = ".claude/agents/ai/gpt.md"  # Preserves subdirectory structure
 
 ## Config Priority
 
-1. `~/.ccpm/config.toml` - Global config with auth tokens (not in git)
-2. `ccpm.toml` - Project manifest (in git)
+1. `~/.agpm/config.toml` - Global config with auth tokens (not in git)
+2. `agpm.toml` - Project manifest (in git)
 
 Keeps secrets out of version control.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to CCPM
+# Contributing to AGPM
 
-Thank you for your interest in contributing to CCPM (Claude Code Package Manager)! We welcome contributions from everyone and are grateful for even the smallest fixes or features.
+Thank you for your interest in contributing to AGPM (AGent Package Manager)! We welcome contributions from everyone and are grateful for even the smallest fixes or features.
 
 ## Table of Contents
 
@@ -67,13 +67,13 @@ When creating an issue:
 1. **Fork and clone the repository:**
    ```bash
    # Fork via GitHub UI, then:
-   git clone https://github.com/YOUR_USERNAME/ccpm.git
-   cd ccpm
+   git clone https://github.com/YOUR_USERNAME/agpm.git
+   cd agpm
    ```
 
 2. **Add upstream remote:**
    ```bash
-   git remote add upstream https://github.com/aig787/ccpm.git
+   git remote add upstream https://github.com/aig787/agpm.git
    ```
 
 3. **Install development tools:**
@@ -156,8 +156,8 @@ When creating an issue:
    cargo llvm-cov --html
 
    # Test on different parallelism levels
-   CCPM_MAX_PARALLEL=1 cargo nextest run
-   CCPM_MAX_PARALLEL=16 cargo nextest run
+   AGPM_MAX_PARALLEL=1 cargo nextest run
+   AGPM_MAX_PARALLEL=16 cargo nextest run
    ```
 
 4. **Commit your changes:**
@@ -270,7 +270,7 @@ Example:
 ///
 /// # Example
 /// ```
-/// let manifest = Manifest::load("ccpm.toml")?;
+/// let manifest = Manifest::load("agpm.toml")?;
 /// let lockfile = resolve_dependencies(&manifest)?;
 /// ```
 pub fn resolve_dependencies(manifest: &Manifest) -> Result<Lockfile> {
@@ -321,7 +321,7 @@ Place integration tests in the `tests/` directory. Focus on testing full workflo
 
 ```rust
 // tests/integration_parallel_install.rs
-use ccpm::cli;
+use agpm::cli;
 use tempfile::TempDir;
 use std::sync::Arc;
 
@@ -441,7 +441,7 @@ We value all contributions! Contributors are recognized through:
 
 ## Release Process
 
-CCPM uses [semantic-release](https://semantic-release.gitbook.io/) for automated versioning and release management based on conventional commits.
+AGPM uses [semantic-release](https://semantic-release.gitbook.io/) for automated versioning and release management based on conventional commits.
 
 ### Creating a Release
 
@@ -497,7 +497,7 @@ If you have questions about contributing, please:
 2. Create a new discussion if your question hasn't been answered
 3. Be patient - we're all volunteers!
 
-Thank you for contributing to CCPM! Your efforts help make package management better for the entire Claude Code community.
+Thank you for contributing to AGPM! Your efforts help make package management better for the entire Claude Code community.
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "agpm"
+version = "0.3.17"
+dependencies = [
+ "agpm",
+ "anyhow",
+ "assert_cmd",
+ "chrono",
+ "clap",
+ "colored",
+ "dashmap",
+ "dirs",
+ "fs4",
+ "futures",
+ "glob",
+ "hex",
+ "indicatif",
+ "is-terminal",
+ "once_cell",
+ "petgraph",
+ "predicates",
+ "pubgrub",
+ "regex",
+ "reqwest",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "sha2",
+ "shellexpand",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "toml",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+ "walkdir",
+ "which",
+ "zip",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,48 +281,6 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
-]
-
-[[package]]
-name = "ccpm"
-version = "0.3.17"
-dependencies = [
- "anyhow",
- "assert_cmd",
- "ccpm",
- "chrono",
- "clap",
- "colored",
- "dashmap",
- "dirs",
- "fs4",
- "futures",
- "glob",
- "hex",
- "indicatif",
- "is-terminal",
- "once_cell",
- "petgraph",
- "predicates",
- "pubgrub",
- "regex",
- "reqwest",
- "semver",
- "serde",
- "serde_json",
- "serde_yaml",
- "sha2",
- "shellexpand",
- "tempfile",
- "thiserror",
- "tokio",
- "toml",
- "tracing",
- "tracing-subscriber",
- "uuid",
- "walkdir",
- "which",
- "zip",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "ccpm"
+name = "agpm"
 version = "0.3.17"
 edition = "2024"
 authors = ["Aaron Griffin <aig787@icloud.com>"]
-description = "Claude Code Package Manager - A Git-based package manager for Claude agents"
+description = "AGent Package Manager - A Git-based package manager for Claude agents"
 license = "MIT"
-repository = "https://github.com/aig787/ccpm"
+repository = "https://github.com/aig787/agpm"
 readme = "README.md"
 keywords = ["claude", "ai", "package-manager", "agent", "cli"]
 categories = ["command-line-utilities", "development-tools"]
@@ -53,7 +53,7 @@ pubgrub = { version = "0.3.0", default-features = false }
 assert_cmd = "2.0"
 predicates = "3.1"
 tempfile = "3.10"
-ccpm = { path = ".", features = ["test-utils"] }
+agpm = { path = ".", features = ["test-utils"] }
 
 # Config for 'dist'
 [workspace.metadata.dist]
@@ -78,7 +78,7 @@ post-announce-jobs = ["./update-release-notes", "./publish-crates"]
 
 # cargo-binstall metadata for binary installation
 [package.metadata.binstall]
-pkg-url = "https://github.com/aig787/ccpm/releases/download/v{ version }/{ name }-{ target }{ archive-suffix }"
+pkg-url = "https://github.com/aig787/agpm/releases/download/v{ version }/{ name }-{ target }{ archive-suffix }"
 bin-dir = "{ bin }{ binary-ext }"
 
 [profile.release]

--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ dist-build:
 
 # Display help
 help:
-	@echo "CCPM Makefile Commands:"
+	@echo "AGPM Makefile Commands:"
 	@echo "  make build         - Build in debug mode"
 	@echo "  make release       - Build in release mode"
 	@echo "  make test          - Run all tests"

--- a/Makefile
+++ b/Makefile
@@ -113,29 +113,29 @@ cross-all: cross-setup
 	@echo ""
 	@echo "Building for current platform..."
 	@cargo build --release
-	@echo "  Built: target/release/ccpm"
+	@echo "  Built: target/release/agpm"
 	@echo ""
 	@echo "Cross-compiling for: $(CROSS_NAMES)"
 	@for target in $(CROSS_TARGETS); do \
 		echo "Building for $$target..."; \
 		cargo zigbuild --release --target $$target || exit 1; \
 		if echo $$target | grep -q windows; then \
-			echo "  Built: target/$$target/release/ccpm.exe"; \
+			echo "  Built: target/$$target/release/agpm.exe"; \
 		else \
-			echo "  Built: target/$$target/release/ccpm"; \
+			echo "  Built: target/$$target/release/agpm"; \
 		fi; \
 	done
 	@echo ""
 	@echo "All builds complete!"
 	@echo "Binaries available:"
-	@echo "  - $(CURRENT_PLATFORM): target/release/ccpm"
+	@echo "  - $(CURRENT_PLATFORM): target/release/agpm"
 	@for target in $(CROSS_TARGETS); do \
 		if echo $$target | grep -q windows; then \
-			echo "  - Windows: target/$$target/release/ccpm.exe"; \
+			echo "  - Windows: target/$$target/release/agpm.exe"; \
 		elif echo $$target | grep -q linux; then \
-			echo "  - Linux: target/$$target/release/ccpm"; \
+			echo "  - Linux: target/$$target/release/agpm"; \
 		elif echo $$target | grep -q darwin; then \
-			echo "  - macOS: target/$$target/release/ccpm"; \
+			echo "  - macOS: target/$$target/release/agpm"; \
 		fi; \
 	done
 
@@ -149,7 +149,7 @@ cross-windows:
 		rustup target add x86_64-pc-windows-gnullvm || exit 1; \
 	}
 	cargo zigbuild --release --target x86_64-pc-windows-gnullvm
-	@echo "Windows binary built at: target/x86_64-pc-windows-gnullvm/release/ccpm.exe"
+	@echo "Windows binary built at: target/x86_64-pc-windows-gnullvm/release/agpm.exe"
 
 cross-linux:
 	@command -v cargo-binstall >/dev/null 2>&1 || { echo "Installing cargo-binstall..."; cargo install cargo-binstall; }
@@ -160,7 +160,7 @@ cross-linux:
 		rustup target add x86_64-unknown-linux-gnu || exit 1; \
 	}
 	cargo zigbuild --release --target x86_64-unknown-linux-gnu
-	@echo "Linux binary built at: target/x86_64-unknown-linux-gnu/release/ccpm"
+	@echo "Linux binary built at: target/x86_64-unknown-linux-gnu/release/agpm"
 
 cross-macos:
 	@command -v cargo-binstall >/dev/null 2>&1 || { echo "Installing cargo-binstall..."; cargo install cargo-binstall; }
@@ -171,7 +171,7 @@ cross-macos:
 		rustup target add x86_64-apple-darwin || exit 1; \
 	}
 	cargo zigbuild --release --target x86_64-apple-darwin
-	@echo "macOS binary built at: target/x86_64-apple-darwin/release/ccpm"
+	@echo "macOS binary built at: target/x86_64-apple-darwin/release/agpm"
 
 # Install cargo-dist for distribution tasks
 dist-setup:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CCPM - Claude Code Package Manager
+# AGPM - Claude Code Package Manager
 
 > ⚠️ **Beta Software**: This project is in active development and may contain breaking changes. Use with caution in
 > production environments.
@@ -24,24 +24,24 @@ dependency management, similar to Cargo.
 
 ## Quick Start
 
-### Install CCPM
+### Install AGPM
 
 **Using installer script (Recommended):**
 
 ```bash
 # Unix/Linux/macOS
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/aig787/ccpm/releases/latest/download/ccpm-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/aig787/agpm/releases/latest/download/agpm-installer.sh | sh
 
 # Windows PowerShell
-irm https://github.com/aig787/ccpm/releases/latest/download/ccpm-installer.ps1 | iex
+irm https://github.com/aig787/agpm/releases/latest/download/agpm-installer.ps1 | iex
 ```
 
 **Using Cargo:**
 
 ```bash
-cargo install ccpm                                    # From crates.io
-cargo binstall ccpm                                   # Pre-built binaries (faster)
-cargo install --git https://github.com/aig787/ccpm.git  # Latest development
+cargo install agpm                                    # From crates.io
+cargo binstall agpm                                   # Pre-built binaries (faster)
+cargo install --git https://github.com/aig787/agpm.git  # Latest development
 ```
 
 For more installation options, see the [Installation Guide](docs/installation.md).
@@ -49,15 +49,15 @@ For more installation options, see the [Installation Guide](docs/installation.md
 ### Create a Project
 
 ```bash
-# Initialize a new CCPM project
-ccpm init
+# Initialize a new AGPM project
+agpm init
 
-# Or manually create ccpm.toml:
+# Or manually create agpm.toml:
 ```
 
 ```toml
 [sources]
-community = "https://github.com/aig787/ccpm-community.git"
+community = "https://github.com/aig787/agpm-community.git"
 
 [agents]
 # Single file - installed at .claude/agents/example.md
@@ -75,54 +75,54 @@ react-utils = { source = "community", path = "snippets/react/*.md", version = "^
 
 ```bash
 # Install all dependencies (auto-updates lockfile like Cargo)
-ccpm install
+agpm install
 
 # Use exact lockfile versions (for CI/CD - like cargo build --locked)
-ccpm install --frozen
+agpm install --frozen
 
 # Control parallelism (default: max(10, 2 × CPU cores))
-ccpm install --max-parallel 8
+agpm install --max-parallel 8
 
 # Bypass cache for fresh installation
-ccpm install --no-cache
+agpm install --no-cache
 ```
 
 ### Adding Dependencies
 
 ```bash
 # Add a Git source repository
-ccpm add source community https://github.com/aig787/ccpm-community.git
+agpm add source community https://github.com/aig787/agpm-community.git
 
 # Add dependencies from Git sources
-ccpm add dep agent community:agents/rust-expert.md@v1.0.0
-ccpm add dep snippet community:snippets/react.md --name react-utils
+agpm add dep agent community:agents/rust-expert.md@v1.0.0
+agpm add dep snippet community:snippets/react.md --name react-utils
 
 # Add local file dependencies
-ccpm add dep agent ./local-agents/helper.md --name my-helper
-ccpm add dep script ../shared/scripts/build.sh
+agpm add dep agent ./local-agents/helper.md --name my-helper
+agpm add dep script ../shared/scripts/build.sh
 
 # Add pattern dependencies (bulk installation)
-ccpm add dep agent "community:agents/ai/*.md@v1.0.0" --name ai-agents
+agpm add dep agent "community:agents/ai/*.md@v1.0.0" --name ai-agents
 ```
 
 ### Dependency Validation
 
-CCPM provides comprehensive validation and automatic conflict resolution:
+AGPM provides comprehensive validation and automatic conflict resolution:
 
 ```bash
 # Basic manifest validation
-ccpm validate
+agpm validate
 
 # Full validation with all checks
-ccpm validate --resolve --sources --paths --check-lock
+agpm validate --resolve --sources --paths --check-lock
 
 # JSON output for CI/CD integration
-ccpm validate --format json
+agpm validate --format json
 ```
 
 #### Transitive Dependencies and Conflict Resolution
 
-CCPM supports **transitive dependencies** - when your dependencies have their own dependencies. Resources can declare dependencies in their metadata, and CCPM automatically resolves the entire dependency tree.
+AGPM supports **transitive dependencies** - when your dependencies have their own dependencies. Resources can declare dependencies in their metadata, and AGPM automatically resolves the entire dependency tree.
 
 **What is a Conflict?**
 
@@ -132,7 +132,7 @@ A conflict occurs when the same resource (same source and path) is required at d
 
 **Automatic Resolution Strategy:**
 
-When conflicts are detected, CCPM automatically resolves them:
+When conflicts are detected, AGPM automatically resolves them:
 1. **Specific over "latest"**: If one version is specific and another is "latest", use the specific version
 2. **Higher version**: When both are specific versions, use the higher version
 3. **Transparent logging**: All conflict resolutions are logged for visibility
@@ -161,15 +161,15 @@ Error: Version conflict for agents/helper.md
   resolution: no compatible tag satisfies both constraints
 ```
 
-Use `ccpm validate --resolve --format json` or `RUST_LOG=debug ccpm install` to see the exact dependency chain. Typical fixes:
-- Pin the manifest entry to a single version (`version = "v2.0.0"`) and run `ccpm install` to auto-update.
+Use `agpm validate --resolve --format json` or `RUST_LOG=debug agpm install` to see the exact dependency chain. Typical fixes:
+- Pin the manifest entry to a single version (`version = "v2.0.0"`) and run `agpm install` to auto-update.
 - Split competing resources into separate manifests or disable the conflicting dependency in one branch.
 - If a transitive dependency is too new, override it by forking the source repo or requesting an upstream fix.
 - For duplicate install paths reported during expansion, add `filename` or `target` overrides so each resource installs cleanly.
 
 **Circular Dependencies:**
 
-CCPM detects and prevents circular dependencies in the dependency graph:
+AGPM detects and prevents circular dependencies in the dependency graph:
 ```text
 Error: Circular dependency detected: A → B → C → A
 ```
@@ -224,11 +224,11 @@ dependencies:
 - Supports all resource types: agents, snippets, commands, scripts, hooks, mcp-servers
 - Graph-based resolution with topological ordering ensures correct installation order
 - Circular dependency detection prevents infinite loops
-- Override transitive version mismatches by declaring an explicit `version` in the resource metadata or by pinning the parent entry in `ccpm.toml`
+- Override transitive version mismatches by declaring an explicit `version` in the resource metadata or by pinning the parent entry in `agpm.toml`
 
 **Lockfile Format:**
 
-Dependencies are tracked in `ccpm.lock` using the format `resource_type/name@version`:
+Dependencies are tracked in `agpm.lock` using the format `resource_type/name@version`:
 ```toml
 [[commands]]
 name = "my-command"
@@ -243,28 +243,28 @@ dependencies = [
 
 | Command         | Description                                                  |
 |-----------------|--------------------------------------------------------------|
-| `ccpm init`     | Initialize a new project                                     |
-| `ccpm install`  | Install dependencies from ccpm.toml with parallel processing |
-| `ccpm update`   | Update dependencies within version constraints               |
-| `ccpm outdated` | Check for available updates to installed dependencies        |
-| `ccpm upgrade`  | Self-update CCPM to the latest version                       |
-| `ccpm list`     | List installed resources                                     |
-| `ccpm validate` | Validate manifest and dependencies                           |
-| `ccpm add`      | Add sources or dependencies                                  |
-| `ccpm remove`   | Remove sources or dependencies                               |
-| `ccpm config`   | Manage global configuration                                  |
-| `ccpm cache`    | Manage the Git cache                                         |
+| `agpm init`     | Initialize a new project                                     |
+| `agpm install`  | Install dependencies from agpm.toml with parallel processing |
+| `agpm update`   | Update dependencies within version constraints               |
+| `agpm outdated` | Check for available updates to installed dependencies        |
+| `agpm upgrade`  | Self-update AGPM to the latest version                       |
+| `agpm list`     | List installed resources                                     |
+| `agpm validate` | Validate manifest and dependencies                           |
+| `agpm add`      | Add sources or dependencies                                  |
+| `agpm remove`   | Remove sources or dependencies                               |
+| `agpm config`   | Manage global configuration                                  |
+| `agpm cache`    | Manage the Git cache                                         |
 
-Run `ccpm --help` for full command reference.
+Run `agpm --help` for full command reference.
 
 ## Resource Types
 
-CCPM manages six types of resources:
+AGPM manages six types of resources:
 
 - **Agents** - AI assistant configurations (`.claude/agents/`)
-- **Snippets** - Reusable code templates (`.claude/ccpm/snippets/`)
+- **Snippets** - Reusable code templates (`.claude/agpm/snippets/`)
 - **Commands** - Claude Code slash commands (`.claude/commands/`)
-- **Scripts** - Executable automation files (`.claude/ccpm/scripts/`)
+- **Scripts** - Executable automation files (`.claude/agpm/scripts/`)
 - **Hooks** - Event-based automation (merged into `.claude/settings.local.json`)
 - **MCP Servers** - Model Context Protocol servers (merged into `.mcp.json`)
 
@@ -284,9 +284,9 @@ CCPM manages six types of resources:
 ## Example Project
 
 ```toml
-# ccpm.toml
+# agpm.toml
 [sources]
-community = "https://github.com/aig787/ccpm-community.git"
+community = "https://github.com/aig787/agpm-community.git"
 local = "./local-resources"
 
 [agents]
@@ -302,10 +302,10 @@ code-reviewer = { source = "community", path = "agents/ai/code-reviewer.md", ver
 ai-agents = { source = "community", path = "agents/ai/*.md", version = "^1.0.0" }
 
 [snippets]
-# Single file - installed at .claude/ccpm/snippets/react-hooks.md
+# Single file - installed at .claude/agpm/snippets/react-hooks.md
 react-hooks = { source = "community", path = "snippets/react-hooks.md", version = "~1.2.0" }
 
-# Nested pattern - snippets/python/utils.md → .claude/ccpm/snippets/python/utils.md
+# Nested pattern - snippets/python/utils.md → .claude/agpm/snippets/python/utils.md
 python-tools = { source = "community", path = "snippets/python/*.md", version = "v1.0.0" }
 
 [scripts]
@@ -320,7 +320,7 @@ filesystem = { source = "community", path = "mcp/filesystem.json", version = "la
 
 ## Performance Architecture
 
-CCPM v0.3.2+ features a high-performance SHA-based architecture:
+AGPM v0.3.2+ features a high-performance SHA-based architecture:
 
 ### Centralized Version Resolution
 
@@ -336,7 +336,7 @@ CCPM v0.3.2+ features a high-performance SHA-based architecture:
 
 ## Versioning
 
-CCPM uses Git-based versioning at the repository level with enhanced constraint support:
+AGPM uses Git-based versioning at the repository level with enhanced constraint support:
 
 - **Git tags** (recommended): `version = "v1.0.0"` or `version = "^1.0.0"`
 - **Semver constraints**: `^1.0`, `~2.1`, `>=1.0.0, <2.0.0`
@@ -348,14 +348,14 @@ See the [Versioning Guide](docs/versioning.md) for details.
 
 ## Security
 
-CCPM separates credentials from project configuration:
+AGPM separates credentials from project configuration:
 
-- ✅ **Project manifest** (`ccpm.toml`) - Safe to commit
-- ❌ **Global config** (`~/.ccpm/config.toml`) - Contains secrets, never commit
+- ✅ **Project manifest** (`agpm.toml`) - Safe to commit
+- ❌ **Global config** (`~/.agpm/config.toml`) - Contains secrets, never commit
 
 ```bash
 # Add private source with authentication (global config only)
-ccpm config add-source private "https://oauth2:TOKEN@github.com/org/private.git"
+agpm config add-source private "https://oauth2:TOKEN@github.com/org/private.git"
 ```
 
 ## Contributing
@@ -364,7 +364,7 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 
 ## Project Status
 
-CCPM is actively developed with comprehensive test coverage and automated releases:
+AGPM is actively developed with comprehensive test coverage and automated releases:
 
 - ✅ All core commands implemented
 - ✅ Cross-platform support (Windows, macOS, Linux)
@@ -376,7 +376,7 @@ CCPM is actively developed with comprehensive test coverage and automated releas
 
 ### Automated Releases
 
-CCPM uses [semantic-release](https://semantic-release.gitbook.io/) for automated versioning and publishing:
+AGPM uses [semantic-release](https://semantic-release.gitbook.io/) for automated versioning and publishing:
 
 - **Conventional Commits**: Version bumps based on commit messages (`feat:` → minor, `fix:` → patch)
 - **Cross-Platform Binaries**: Automatic builds for Linux, macOS, and Windows
@@ -389,8 +389,8 @@ MIT License - see [LICENSE.md](LICENSE.md) for details.
 
 ## Support
 
-- 🐛 [Issue Tracker](https://github.com/aig787/ccpm/issues)
-- 💬 [Discussions](https://github.com/aig787/ccpm/discussions)
+- 🐛 [Issue Tracker](https://github.com/aig787/agpm/issues)
+- 💬 [Discussions](https://github.com/aig787/agpm/discussions)
 - 📖 [Documentation](docs/user-guide.md)
 
 ---

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 > ⚠️ **Beta Software**: This project is in active development and may contain breaking changes. Use with caution in
 > production environments.
 
-A Git-based package manager for Claude Code and other agentic tools that enables reproducible installations using lockfile-based
+A Git-based package manager for Claude Code and other agentic tools that enables reproducible installations using
+lockfile-based
 dependency management, similar to Cargo.
 
 ## Features
@@ -14,13 +15,9 @@ dependency management, similar to Cargo.
 - 🔒 **Cargo-style lockfile handling** - Auto-updates by default, strict validation with `--frozen`
 - 🔧 **Six resource types** - Agents, Snippets, Commands, Scripts, Hooks, MCP Servers
 - 🎯 **Pattern-based dependencies** - Use glob patterns (`agents/*.md`, `**/*.md`) for batch installation
-- 🧹 **Automatic artifact cleanup** - Old files removed when paths change
-- ⚠️ **Path conflict detection** - Prevents multiple dependencies from overwriting the same file
 - 🖥️ **Cross-platform** - Windows, macOS, and Linux support with enhanced path handling
 - 📁 **Local and remote sources** - Support for both Git repositories and local filesystem paths
 - 🔄 **Transitive dependencies** - Resources declare dependencies in YAML/JSON, automatic graph-based resolution
-- 🛡️ **Circular dependency detection** - Prevents circular references with comprehensive error reporting
-- 🧩 **Intelligent conflict resolution** - Automatic version resolution with transparent logging
 
 ## Quick Start
 
@@ -122,22 +119,26 @@ agpm validate --format json
 
 #### Transitive Dependencies and Conflict Resolution
 
-AGPM supports **transitive dependencies** - when your dependencies have their own dependencies. Resources can declare dependencies in their metadata, and AGPM automatically resolves the entire dependency tree.
+AGPM supports **transitive dependencies** - when your dependencies have their own dependencies. Resources can declare
+dependencies in their metadata, and AGPM automatically resolves the entire dependency tree.
 
 **What is a Conflict?**
 
 A conflict occurs when the same resource (same source and path) is required at different versions:
+
 - **Direct conflict**: Your manifest requires `helper.md@v1.0.0` and `helper.md@v2.0.0`
 - **Transitive conflict**: Agent A depends on `helper.md@v1.0.0`, Agent B depends on `helper.md@v2.0.0`
 
 **Automatic Resolution Strategy:**
 
 When conflicts are detected, AGPM automatically resolves them:
+
 1. **Specific over "latest"**: If one version is specific and another is "latest", use the specific version
 2. **Higher version**: When both are specific versions, use the higher version
 3. **Transparent logging**: All conflict resolutions are logged for visibility
 
 **Example Conflict Resolution:**
+
 ```text
 Direct dependencies:
   - app-agent requires helper.md v1.0.0
@@ -161,22 +162,27 @@ Error: Version conflict for agents/helper.md
   resolution: no compatible tag satisfies both constraints
 ```
 
-Use `agpm validate --resolve --format json` or `RUST_LOG=debug agpm install` to see the exact dependency chain. Typical fixes:
+Use `agpm validate --resolve --format json` or `RUST_LOG=debug agpm install` to see the exact dependency chain. Typical
+fixes:
+
 - Pin the manifest entry to a single version (`version = "v2.0.0"`) and run `agpm install` to auto-update.
 - Split competing resources into separate manifests or disable the conflicting dependency in one branch.
 - If a transitive dependency is too new, override it by forking the source repo or requesting an upstream fix.
-- For duplicate install paths reported during expansion, add `filename` or `target` overrides so each resource installs cleanly.
+- For duplicate install paths reported during expansion, add `filename` or `target` overrides so each resource installs
+  cleanly.
 
 **Circular Dependencies:**
 
 AGPM detects and prevents circular dependencies in the dependency graph:
+
 ```text
 Error: Circular dependency detected: A → B → C → A
 ```
 
 **No Conflicts:**
 
-When there are no conflicts, all dependencies are installed as requested. The system builds a complete dependency graph and installs resources in topological order (dependencies before dependents).
+When there are no conflicts, all dependencies are installed as requested. The system builds a complete dependency graph
+and installs resources in topological order (dependencies before dependents).
 
 See the [Command Reference](docs/command-reference.md#add-dependency) for all supported dependency formats.
 
@@ -185,6 +191,7 @@ See the [Command Reference](docs/command-reference.md#add-dependency) for all su
 Resources can declare their own dependencies within their files, creating a complete dependency graph:
 
 **Markdown files (.md)** use YAML frontmatter:
+
 ```markdown
 ---
 title: My Agent
@@ -202,9 +209,12 @@ dependencies:
 ```
 
 **JSON files (.json)** use a top-level `dependencies` field:
+
 ```json
 {
-  "events": ["SessionStart"],
+  "events": [
+    "SessionStart"
+  ],
   "type": "command",
   "command": "echo 'Starting session'",
   "dependencies": {
@@ -219,16 +229,19 @@ dependencies:
 ```
 
 **Key Features:**
+
 - Dependencies inherit the source from their parent resource
 - Version is optional - defaults to parent's version if not specified
 - Supports all resource types: agents, snippets, commands, scripts, hooks, mcp-servers
 - Graph-based resolution with topological ordering ensures correct installation order
 - Circular dependency detection prevents infinite loops
-- Override transitive version mismatches by declaring an explicit `version` in the resource metadata or by pinning the parent entry in `agpm.toml`
+- Override transitive version mismatches by declaring an explicit `version` in the resource metadata or by pinning the
+  parent entry in `agpm.toml`
 
 **Lockfile Format:**
 
 Dependencies are tracked in `agpm.lock` using the format `resource_type/name@version`:
+
 ```toml
 [[commands]]
 name = "my-command"
@@ -254,6 +267,7 @@ dependencies = [
 | `agpm remove`   | Remove sources or dependencies                               |
 | `agpm config`   | Manage global configuration                                  |
 | `agpm cache`    | Manage the Git cache                                         |
+| `agpm migrate`  | Migrate from legacy CCPM naming to AGPM                      |
 
 Run `agpm --help` for full command reference.
 
@@ -369,10 +383,9 @@ AGPM is actively developed with comprehensive test coverage and automated releas
 - ✅ All core commands implemented
 - ✅ Cross-platform support (Windows, macOS, Linux)
 - ✅ Comprehensive test suite (70%+ coverage)
-- ✅ Specialized Rust development agents (standard/advanced tiers)
 - ✅ Automated semantic releases with conventional commits
 - ✅ Cross-platform binary builds for all releases
-- ✅ Publishing to crates.io (automated via semantic-release)
+- ✅ Publishing to crates.io
 
 ### Automated Releases
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# AGPM - Claude Code Package Manager
+# AGPM - AGentic Package Manager
 
 > ⚠️ **Beta Software**: This project is in active development and may contain breaking changes. Use with caution in
 > production environments.
 
-A Git-based package manager for Claude Code resources that enables reproducible installations using lockfile-based
+A Git-based package manager for Claude Code and other agentic tools that enables reproducible installations using lockfile-based
 dependency management, similar to Cargo.
 
 ## Features

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,17 +1,17 @@
 # Architecture
 
-This document describes CCPM's technical architecture and design decisions.
+This document describes AGPM's technical architecture and design decisions.
 
 ## Overview
 
-CCPM is built with Rust for performance, safety, and reliability. It uses system Git commands for maximum compatibility and respects existing Git configurations.
+AGPM is built with Rust for performance, safety, and reliability. It uses system Git commands for maximum compatibility and respects existing Git configurations.
 
 ## Core Components
 
 ### Module Structure
 
 ```
-ccpm/
+agpm/
 ├── cli/          # Command implementations
 ├── cache/        # Cache management and file locking
 ├── config/       # Configuration handling
@@ -32,12 +32,12 @@ ccpm/
 
 ### Key Components
 
-**manifest**: Parses and validates ccpm.toml files
+**manifest**: Parses and validates agpm.toml files
 - TOML deserialization with serde
 - Schema validation
 - Pattern expansion for glob dependencies
 
-**lockfile**: Manages ccpm.lock files
+**lockfile**: Manages agpm.lock files
 - Atomic writes for safety
 - Preserves exact commit hashes
 - Tracks installation metadata
@@ -75,7 +75,7 @@ ccpm/
 
 ### Copy-Based Installation
 
-CCPM copies files from cache to project directories rather than using symlinks:
+AGPM copies files from cache to project directories rather than using symlinks:
 
 - **Maximum compatibility** across Windows, macOS, Linux
 - **Git-friendly** - Real files can be tracked
@@ -113,7 +113,7 @@ Separates project manifest from global config:
 
 ### Installation Process
 
-1. **Parse manifest** - Read ccpm.toml
+1. **Parse manifest** - Read agpm.toml
 2. **Load global config** - Merge sources
 3. **Resolve dependencies** - Match versions
 4. **Fetch repositories** - Clone/update cache
@@ -131,14 +131,14 @@ Separates project manifest from global config:
 6. **SHA validation** - Validate all resolved SHAs are valid 40-character hex strings
 7. **Conflict detection** - Check compatibility across all resolved dependencies
 8. **Worktree optimization** - SHA-based worktree creation maximizes reuse for identical commits
-9. **Lock generation** - Record exact SHAs and resolved references in ccpm.lock
+9. **Lock generation** - Record exact SHAs and resolved references in agpm.lock
 
 ## File Locking
 
-CCPM uses file locking to prevent corruption during concurrent operations:
+AGPM uses file locking to prevent corruption during concurrent operations:
 
 ```
-~/.ccpm/cache/.locks/
+~/.agpm/cache/.locks/
 ├── source1.lock
 ├── source2.lock
 └── source3.lock
@@ -153,10 +153,10 @@ CCPM uses file locking to prevent corruption during concurrent operations:
 
 ### Cache Structure
 
-CCPM v0.3.2+ uses a sophisticated SHA-based caching architecture with centralized version resolution:
+AGPM v0.3.2+ uses a sophisticated SHA-based caching architecture with centralized version resolution:
 
 ```
-~/.ccpm/cache/
+~/.agpm/cache/
 ├── sources/                 # Bare repositories (shared storage)
 │   ├── github_org1_repo1.git/         # Single bare repo per source
 │   ├── github_org2_repo2.git/         # Optimized for worktree creation
@@ -198,7 +198,7 @@ CCPM v0.3.2+ uses a sophisticated SHA-based caching architecture with centralize
 
 ### Credential Handling
 
-- Never store credentials in ccpm.toml
+- Never store credentials in agpm.toml
 - Global config for sensitive data
 - Environment variable expansion
 - Token masking in output
@@ -219,7 +219,7 @@ CCPM v0.3.2+ uses a sophisticated SHA-based caching architecture with centralize
 
 ## Concurrency Model
 
-CCPM v0.3.0 implements a sophisticated concurrency system designed for maximum performance while maintaining safety:
+AGPM v0.3.0 implements a sophisticated concurrency system designed for maximum performance while maintaining safety:
 
 ### Command-Level Parallelism
 
@@ -339,7 +339,7 @@ Each error includes:
 
 ## Worktree-Based Parallel Architecture
 
-CCPM's advanced parallel processing system uses Git worktrees to enable safe concurrent access to different versions of the same repository, dramatically improving installation performance.
+AGPM's advanced parallel processing system uses Git worktrees to enable safe concurrent access to different versions of the same repository, dramatically improving installation performance.
 
 ### Core Benefits
 
@@ -360,7 +360,7 @@ CCPM's advanced parallel processing system uses Git worktrees to enable safe con
 ### Enhanced Directory Structure
 
 ```
-~/.ccpm/cache/
+~/.agpm/cache/
 ├── sources/                           # Bare repositories for worktree use
 │   ├── github_owner_repo.git/         # Optimized bare repo
 │   └── gitlab_org_project.git/        # Multiple sources supported
@@ -383,7 +383,7 @@ CCPM's advanced parallel processing system uses Git worktrees to enable safe con
 
 ## Advanced Concurrency Control
 
-CCPM implements a sophisticated multi-layered concurrency system designed for optimal performance while maintaining safety across all operations.
+AGPM implements a sophisticated multi-layered concurrency system designed for optimal performance while maintaining safety across all operations.
 
 ### User-Controlled Parallelism
 
@@ -403,7 +403,7 @@ CCPM implements a sophisticated multi-layered concurrency system designed for op
 #### Repository-Level Locking
 - **Per-Source Isolation**: Each repository source has its own lock file
 - **Atomic Operations**: Lock acquisition prevents race conditions during repository modifications
-- **Cross-Process Safety**: Multiple CCPM instances can run simultaneously without conflicts
+- **Cross-Process Safety**: Multiple AGPM instances can run simultaneously without conflicts
 - **Platform Compatibility**: Uses `fs4` crate for consistent cross-platform file locking
 
 #### Worktree Isolation
@@ -428,7 +428,7 @@ CCPM implements a sophisticated multi-layered concurrency system designed for op
 
 ### Enhanced Debugging and Monitoring
 
-CCPM provides comprehensive logging and monitoring capabilities for understanding parallel operations.
+AGPM provides comprehensive logging and monitoring capabilities for understanding parallel operations.
 
 #### Context-Aware Logging
 - **Dependency Context**: All Git operations include the dependency name being processed
@@ -446,7 +446,7 @@ CCPM provides comprehensive logging and monitoring capabilities for understandin
 
 ```bash
 # Context-aware Git operation logging
-DEBUG git: (rust-expert-agent) Cloning bare repository: https://github.com/community/ccpm-resources.git
+DEBUG git: (rust-expert-agent) Cloning bare repository: https://github.com/community/agpm-resources.git
 DEBUG git: (rust-expert-agent) Creating worktree at commit abc123: agents/rust-expert.md
 DEBUG git: (react-snippets) Reusing existing bare repository cache
 DEBUG git: (react-snippets) Creating worktree at tag v2.1.0: snippets/react/*.md
@@ -489,7 +489,7 @@ Updating configurations... █████████████████�
 
 ## Self-Update Architecture
 
-CCPM implements its own self-update mechanism to handle platform-specific release archives from GitHub.
+AGPM implements its own self-update mechanism to handle platform-specific release archives from GitHub.
 
 ### Archive Format Support
 - **Unix systems**: `.tar.xz` archives with binary extraction from nested directories
@@ -512,7 +512,7 @@ CCPM implements its own self-update mechanism to handle platform-specific releas
 
 ## Dependencies
 
-Key dependencies and their purposes in CCPM's architecture:
+Key dependencies and their purposes in AGPM's architecture:
 
 ### Core Framework
 - **tokio** - Async runtime enabling non-blocking I/O and concurrent operations

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -810,7 +810,7 @@ react-hooks = { source = "community", path = "snippets/react-hooks.md", version 
 # agpm.toml
 [sources]
 community = "https://github.com/aig787/agpm-community.git"
-tools = "https://github.com/myorg/ccpm-tools.git"
+tools = "https://github.com/myorg/agpm-tools.git"
 local = "./local-resources"
 
 [agents]

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -640,6 +640,37 @@ agpm cache clean --all
 agpm cache list
 ```
 
+### `agpm migrate`
+
+Migrate from legacy CCPM naming to AGPM. This is a one-time migration command for projects upgrading from the legacy CCPM naming scheme.
+
+```bash
+agpm migrate [OPTIONS]
+
+Options:
+  -p, --path <PATH>    Path to directory containing ccpm.toml/ccpm.lock (default: current directory)
+      --dry-run        Show what would be renamed without actually renaming files
+  -h, --help           Print help information
+```
+
+**Examples:**
+```bash
+# Migrate in current directory
+agpm migrate
+
+# Migrate with custom path
+agpm migrate --path /path/to/project
+
+# Dry run to preview changes
+agpm migrate --dry-run
+```
+
+**Behavior:**
+- Detects `ccpm.toml` and `ccpm.lock` files in the specified directory
+- Renames them to `agpm.toml` and `agpm.lock` respectively
+- Fails with an error if target files already exist (conflict detection)
+- Provides clear feedback and next steps after migration
+
 ## Resource Types
 
 AGPM manages six types of resources with optimized parallel installation:

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1,17 +1,17 @@
-# CCPM Command Reference
+# AGPM Command Reference
 
-This document provides detailed information about all CCPM commands and their options.
+This document provides detailed information about all AGPM commands and their options.
 
 ## Global Options
 
 ```
-ccpm [OPTIONS] <COMMAND>
+agpm [OPTIONS] <COMMAND>
 
 Options:
   -v, --verbose              Enable verbose output
   -q, --quiet                Suppress non-error output
       --config <PATH>        Path to custom global configuration file
-      --manifest-path <PATH> Path to the manifest file (ccpm.toml)
+      --manifest-path <PATH> Path to the manifest file (agpm.toml)
       --no-progress          Disable progress bars and spinners
   -h, --help                 Print help information
   -V, --version              Print version information
@@ -19,74 +19,74 @@ Options:
 
 ## Commands
 
-### `ccpm init`
+### `agpm init`
 
-Initialize a new CCPM project by creating a `ccpm.toml` manifest file.
+Initialize a new AGPM project by creating a `agpm.toml` manifest file.
 
 ```bash
-ccpm init [OPTIONS]
+agpm init [OPTIONS]
 
 Options:
       --path <PATH>    Initialize in specific directory (default: current directory)
-      --force          Overwrite existing ccpm.toml file
+      --force          Overwrite existing agpm.toml file
   -h, --help           Print help information
 ```
 
 **Example:**
 ```bash
 # Initialize in current directory
-ccpm init
+agpm init
 
 # Initialize in specific directory
-ccpm init --path ./my-project
+agpm init --path ./my-project
 
 # Force overwrite existing manifest
-ccpm init --force
+agpm init --force
 ```
 
-### `ccpm install`
+### `agpm install`
 
-Install dependencies from `ccpm.toml` and generate/update `ccpm.lock`. Automatically updates the lockfile when manifest changes (similar to `cargo build`). Uses centralized version resolution and SHA-based worktree optimization for maximum performance.
+Install dependencies from `agpm.toml` and generate/update `agpm.lock`. Automatically updates the lockfile when manifest changes (similar to `cargo build`). Uses centralized version resolution and SHA-based worktree optimization for maximum performance.
 
 ```bash
-ccpm install [OPTIONS]
+agpm install [OPTIONS]
 
 Options:
       --no-lock                  Don't write lockfile after installation
       --frozen                   Require exact lockfile match (like cargo build --locked)
       --no-cache                 Bypass cache and fetch directly from sources
       --max-parallel <NUMBER>    Maximum parallel operations (default: max(10, 2 × CPU cores))
-      --manifest-path <PATH>     Path to ccpm.toml (default: ./ccpm.toml)
+      --manifest-path <PATH>     Path to agpm.toml (default: ./agpm.toml)
   -h, --help                     Print help information
 ```
 
 **Examples:**
 ```bash
 # Standard installation (auto-updates lockfile)
-ccpm install
+agpm install
 
 # CI/production mode - fail if lockfile out of sync (like cargo build --locked)
-ccpm install --frozen
+agpm install --frozen
 
 # Install without creating lockfile
-ccpm install --no-lock
+agpm install --no-lock
 
 # Bypass cache for fresh fetch
-ccpm install --no-cache
+agpm install --no-cache
 
 # Control parallelism (default: max(10, 2 × CPU cores))
-ccpm install --max-parallel 8
+agpm install --max-parallel 8
 
 # Use custom manifest path
-ccpm install --manifest-path ./configs/ccpm.toml
+agpm install --manifest-path ./configs/agpm.toml
 ```
 
-### `ccpm update`
+### `agpm update`
 
 Update dependencies to latest versions within version constraints. Always regenerates the lockfile with resolved versions.
 
 ```bash
-ccpm update [OPTIONS] [DEPENDENCY]
+agpm update [OPTIONS] [DEPENDENCY]
 
 Arguments:
   [DEPENDENCY]    Update specific dependency (default: update all)
@@ -94,31 +94,31 @@ Arguments:
 Options:
       --dry-run               Preview changes without applying
       --max-parallel <NUMBER> Maximum parallel operations (default: max(10, 2 × CPU cores))
-      --manifest-path <PATH>  Path to ccpm.toml (default: ./ccpm.toml)
+      --manifest-path <PATH>  Path to agpm.toml (default: ./agpm.toml)
   -h, --help                  Print help information
 ```
 
 **Examples:**
 ```bash
 # Update all dependencies
-ccpm update
+agpm update
 
 # Update specific dependency
-ccpm update rust-expert
+agpm update rust-expert
 
 # Preview changes
-ccpm update --dry-run
+agpm update --dry-run
 
 # Update with custom parallelism
-ccpm update --max-parallel 6
+agpm update --max-parallel 6
 ```
 
-### `ccpm outdated`
+### `agpm outdated`
 
 Check for available updates to installed dependencies. Analyzes the lockfile against available versions in Git repositories to identify dependencies with newer versions available.
 
 ```bash
-ccpm outdated [OPTIONS] [DEPENDENCIES]...
+agpm outdated [OPTIONS] [DEPENDENCIES]...
 
 Arguments:
   [DEPENDENCIES]...    Check specific dependencies (default: check all)
@@ -128,7 +128,7 @@ Options:
       --check                 Exit with error code 1 if updates are available
       --no-fetch             Use cached repository data without fetching updates
       --max-parallel <NUMBER> Maximum parallel operations (default: max(10, 2 × CPU cores))
-      --manifest-path <PATH>  Path to ccpm.toml (default: ./ccpm.toml)
+      --manifest-path <PATH>  Path to agpm.toml (default: ./agpm.toml)
       --no-progress          Disable progress bars and spinners
   -h, --help                  Print help information
 ```
@@ -136,22 +136,22 @@ Options:
 **Examples:**
 ```bash
 # Check all dependencies for updates
-ccpm outdated
+agpm outdated
 
 # Check specific dependencies
-ccpm outdated rust-expert my-agent
+agpm outdated rust-expert my-agent
 
 # Use in CI - exit with error if outdated
-ccpm outdated --check
+agpm outdated --check
 
 # Use cached data without fetching
-ccpm outdated --no-fetch
+agpm outdated --no-fetch
 
 # JSON output for scripting
-ccpm outdated --format json
+agpm outdated --format json
 
 # Control parallelism
-ccpm outdated --max-parallel 5
+agpm outdated --max-parallel 5
 ```
 
 **Output Information:**
@@ -165,7 +165,7 @@ The command displays:
 **Version Analysis:**
 
 The outdated command performs sophisticated version comparison:
-1. **Compatible Updates**: Versions that satisfy the current version constraint in ccpm.toml
+1. **Compatible Updates**: Versions that satisfy the current version constraint in agpm.toml
 2. **Major Updates**: Newer versions that exceed the constraint (require manual manifest update)
 3. **Up-to-date**: Dependencies already on the latest compatible version
 
@@ -197,41 +197,41 @@ When using `--format json`, the output includes:
 }
 ```
 
-### `ccpm list`
+### `agpm list`
 
-List installed resources from `ccpm.lock`.
+List installed resources from `agpm.lock`.
 
 ```bash
-ccpm list [OPTIONS]
+agpm list [OPTIONS]
 
 Options:
       --format <FORMAT>       Output format: table, json (default: table)
       --type <TYPE>           Filter by resource type: agents, snippets, commands, scripts, hooks, mcp-servers
-      --manifest-path <PATH>  Path to ccpm.toml (default: ./ccpm.toml)
+      --manifest-path <PATH>  Path to agpm.toml (default: ./agpm.toml)
   -h, --help                  Print help information
 ```
 
 **Examples:**
 ```bash
 # List all resources in table format
-ccpm list
+agpm list
 
 # List only agents
-ccpm list --type agents
+agpm list --type agents
 
 # Output as JSON
-ccpm list --format json
+agpm list --format json
 
 # Use custom manifest path
-ccpm list --manifest-path ./configs/ccpm.toml
+agpm list --manifest-path ./configs/agpm.toml
 ```
 
-### `ccpm tree`
+### `agpm tree`
 
 Display dependency trees for installed resources with transitive dependencies. Visualizes the complete dependency graph similar to `cargo tree`, helping identify duplicate or redundant dependencies.
 
 ```bash
-ccpm tree [OPTIONS]
+agpm tree [OPTIONS]
 
 Options:
   -d, --depth <NUMBER>        Maximum depth to display (unlimited if not specified)
@@ -246,35 +246,35 @@ Options:
       --hooks                 Show only hooks
       --mcp-servers           Show only MCP servers
   -i, --invert                Invert tree to show what depends on each package
-      --manifest-path <PATH>  Path to ccpm.toml (default: ./ccpm.toml)
+      --manifest-path <PATH>  Path to agpm.toml (default: ./agpm.toml)
   -h, --help                  Print help information
 ```
 
 **Examples:**
 ```bash
 # Display full dependency tree
-ccpm tree
+agpm tree
 
 # Limit tree depth to 2 levels
-ccpm tree --depth 2
+agpm tree --depth 2
 
 # Show tree for specific package
-ccpm tree --package my-agent
+agpm tree --package my-agent
 
 # Show only duplicate dependencies
-ccpm tree --duplicates
+agpm tree --duplicates
 
 # JSON output for scripting
-ccpm tree --format json
+agpm tree --format json
 
 # Show only agents and their dependencies
-ccpm tree --agents
+agpm tree --agents
 
 # Invert tree to see what depends on each package
-ccpm tree --invert
+agpm tree --invert
 
 # Show tree without deduplication
-ccpm tree --no-dedupe
+agpm tree --no-dedupe
 ```
 
 **Output Format:**
@@ -303,57 +303,57 @@ my-project
 
 Use `--format json` for programmatic access to dependency information, which includes complete metadata about each dependency and its relationships.
 
-### `ccpm validate`
+### `agpm validate`
 
-Validate `ccpm.toml` syntax and dependency resolution.
+Validate `agpm.toml` syntax and dependency resolution.
 
 ```bash
-ccpm validate [OPTIONS]
+agpm validate [OPTIONS]
 
 Options:
       --check-lock            Also validate lockfile consistency
       --resolve               Perform full dependency resolution
-      --manifest-path <PATH>  Path to ccpm.toml (default: ./ccpm.toml)
+      --manifest-path <PATH>  Path to agpm.toml (default: ./agpm.toml)
   -h, --help                  Print help information
 ```
 
 **Examples:**
 ```bash
 # Basic syntax validation
-ccpm validate
+agpm validate
 
 # Validate with lockfile consistency check
-ccpm validate --check-lock
+agpm validate --check-lock
 
 # Full validation with dependency resolution
-ccpm validate --resolve
+agpm validate --resolve
 
 # Validate custom manifest
-ccpm validate --manifest-path ./configs/ccpm.toml
+agpm validate --manifest-path ./configs/agpm.toml
 ```
 
-### `ccpm add`
+### `agpm add`
 
-Add sources or dependencies to `ccpm.toml`.
+Add sources or dependencies to `agpm.toml`.
 
 #### Add Source
 
 ```bash
-ccpm add source <NAME> <URL> [OPTIONS]
+agpm add source <NAME> <URL> [OPTIONS]
 
 Arguments:
   <NAME>    Source name
   <URL>     Git repository URL or local path
 
 Options:
-      --manifest-path <PATH>  Path to ccpm.toml (default: ./ccpm.toml)
+      --manifest-path <PATH>  Path to agpm.toml (default: ./agpm.toml)
   -h, --help                  Print help information
 ```
 
 #### Add Dependency
 
 ```bash
-ccpm add dep <RESOURCE_TYPE> <SPEC> [OPTIONS]
+agpm add dep <RESOURCE_TYPE> <SPEC> [OPTIONS]
 
 Arguments:
   <RESOURCE_TYPE>  Resource type: agent, snippet, command, script, hook, mcp-server
@@ -362,7 +362,7 @@ Arguments:
 Options:
       --name <NAME>           Dependency name (default: derived from path)
   -f, --force                 Force overwrite if dependency exists
-      --manifest-path <PATH>  Path to ccpm.toml (default: ./ccpm.toml)
+      --manifest-path <PATH>  Path to agpm.toml (default: ./agpm.toml)
   -h, --help                  Print help information
 ```
 
@@ -388,33 +388,33 @@ The `<SPEC>` argument supports multiple formats for different source types:
 **Examples:**
 ```bash
 # Add a source repository first
-ccpm add source community https://github.com/aig787/ccpm-community.git
+agpm add source community https://github.com/aig787/agpm-community.git
 
 # Git repository dependencies
-ccpm add dep agent community:agents/rust-expert.md@v1.0.0
-ccpm add dep agent community:agents/rust-expert.md  # Uses "main" branch
-ccpm add dep snippet community:snippets/react.md@feature-branch
+agpm add dep agent community:agents/rust-expert.md@v1.0.0
+agpm add dep agent community:agents/rust-expert.md  # Uses "main" branch
+agpm add dep snippet community:snippets/react.md@feature-branch
 
 # Local file dependencies
-ccpm add dep agent ./local-agents/helper.md --name my-helper
-ccpm add dep script /usr/local/scripts/build.sh
-ccpm add dep hook ../shared/hooks/pre-commit.json
+agpm add dep agent ./local-agents/helper.md --name my-helper
+agpm add dep script /usr/local/scripts/build.sh
+agpm add dep hook ../shared/hooks/pre-commit.json
 
 # Pattern dependencies (bulk installation)
-ccpm add dep agent "community:agents/ai/*.md@v1.0.0" --name ai-agents
-ccpm add dep snippet "community:snippets/**/*.md" --name all-snippets
-ccpm add dep script "./scripts/*.sh" --name local-scripts
+agpm add dep agent "community:agents/ai/*.md@v1.0.0" --name ai-agents
+agpm add dep snippet "community:snippets/**/*.md" --name all-snippets
+agpm add dep script "./scripts/*.sh" --name local-scripts
 
 # Windows paths
-ccpm add dep agent C:\Resources\agents\windows.md
-ccpm add dep script "file://C:/Users/name/scripts/build.ps1"
+agpm add dep agent C:\Resources\agents\windows.md
+agpm add dep script "file://C:/Users/name/scripts/build.ps1"
 
 # Custom names (recommended for patterns)
-ccpm add dep agent community:agents/reviewer.md --name code-reviewer
-ccpm add dep snippet "community:snippets/python/*.md" --name python-utils
+agpm add dep agent community:agents/reviewer.md --name code-reviewer
+agpm add dep snippet "community:snippets/python/*.md" --name python-utils
 
 # Force overwrite existing dependency
-ccpm add dep agent community:agents/new-version.md --name existing-agent --force
+agpm add dep agent community:agents/new-version.md --name existing-agent --force
 ```
 
 **Name Derivation:**
@@ -428,57 +428,57 @@ For pattern dependencies, you should typically provide a custom name since multi
 
 See the [Manifest Reference](manifest-reference.md) for inline table fields (`branch`, `rev`, `target`, `filename`, MCP settings) and advanced configuration after the dependency is added.
 
-### `ccpm remove`
+### `agpm remove`
 
-Remove sources or dependencies from `ccpm.toml`.
+Remove sources or dependencies from `agpm.toml`.
 
 #### Remove Source
 
 ```bash
-ccpm remove source <NAME> [OPTIONS]
+agpm remove source <NAME> [OPTIONS]
 
 Arguments:
   <NAME>    Source name to remove
 
 Options:
-      --manifest-path <PATH>  Path to ccpm.toml (default: ./ccpm.toml)
+      --manifest-path <PATH>  Path to agpm.toml (default: ./agpm.toml)
   -h, --help                  Print help information
 ```
 
 #### Remove Dependency
 
 ```bash
-ccpm remove dep <RESOURCE_TYPE> <NAME> [OPTIONS]
+agpm remove dep <RESOURCE_TYPE> <NAME> [OPTIONS]
 
 Arguments:
   <RESOURCE_TYPE>  Resource type: agent, snippet, command, script, hook, mcp-server
   <NAME>           Dependency name to remove
 
 Options:
-      --manifest-path <PATH>  Path to ccpm.toml (default: ./ccpm.toml)
+      --manifest-path <PATH>  Path to agpm.toml (default: ./agpm.toml)
   -h, --help                  Print help information
 ```
 
 **Examples:**
 ```bash
 # Remove a source
-ccpm remove source old-repo
+agpm remove source old-repo
 
 # Remove an agent
-ccpm remove dep agent old-agent
+agpm remove dep agent old-agent
 
 # Remove a snippet
-ccpm remove dep snippet unused-snippet
+agpm remove dep snippet unused-snippet
 ```
 
-### `ccpm config`
+### `agpm config`
 
-Manage global configuration in `~/.ccpm/config.toml`.
+Manage global configuration in `~/.agpm/config.toml`.
 
 #### Show Configuration
 
 ```bash
-ccpm config show [OPTIONS]
+agpm config show [OPTIONS]
 
 Options:
       --no-mask    Show actual token values (use with caution)
@@ -488,7 +488,7 @@ Options:
 #### Initialize Configuration
 
 ```bash
-ccpm config init [OPTIONS]
+agpm config init [OPTIONS]
 
 Options:
       --force      Overwrite existing configuration
@@ -498,7 +498,7 @@ Options:
 #### Edit Configuration
 
 ```bash
-ccpm config edit [OPTIONS]
+agpm config edit [OPTIONS]
 
 Options:
   -h, --help    Print help information
@@ -508,42 +508,42 @@ Options:
 
 ```bash
 # Add source with authentication
-ccpm config add-source <NAME> <URL>
+agpm config add-source <NAME> <URL>
 
 # List all global sources (tokens masked)
-ccpm config list-sources
+agpm config list-sources
 
 # Remove source
-ccpm config remove-source <NAME>
+agpm config remove-source <NAME>
 ```
 
 **Examples:**
 ```bash
 # Show current configuration (tokens masked)
-ccpm config show
+agpm config show
 
 # Initialize config with examples
-ccpm config init
+agpm config init
 
 # Edit config in default editor
-ccpm config edit
+agpm config edit
 
 # Add private source with token
-ccpm config add-source private "https://oauth2:ghp_xxxx@github.com/org/private.git"
+agpm config add-source private "https://oauth2:ghp_xxxx@github.com/org/private.git"
 
 # List all sources
-ccpm config list-sources
+agpm config list-sources
 
 # Remove a source
-ccpm config remove-source old-private
+agpm config remove-source old-private
 ```
 
-### `ccpm upgrade`
+### `agpm upgrade`
 
-Self-update CCPM to the latest version or a specific version. Includes automatic backup and rollback capabilities with built-in security features.
+Self-update AGPM to the latest version or a specific version. Includes automatic backup and rollback capabilities with built-in security features.
 
 ```bash
-ccpm upgrade [OPTIONS] [VERSION]
+agpm upgrade [OPTIONS] [VERSION]
 
 Arguments:
   [VERSION]    Target version to upgrade to (e.g., "0.3.18" or "v0.3.18")
@@ -560,46 +560,46 @@ Options:
 **Examples:**
 ```bash
 # Upgrade to latest version
-ccpm upgrade
+agpm upgrade
 
 # Check for available updates
-ccpm upgrade --check
+agpm upgrade --check
 
 # Show current and latest version
-ccpm upgrade --status
+agpm upgrade --status
 
 # Upgrade to specific version
-ccpm upgrade 0.3.18
+agpm upgrade 0.3.18
 
 # Force reinstall latest version
-ccpm upgrade --force
+agpm upgrade --force
 
 # Rollback to previous version
-ccpm upgrade --rollback
+agpm upgrade --rollback
 
 # Upgrade without creating backup
-ccpm upgrade --no-backup
+agpm upgrade --no-backup
 ```
 
 #### Security Features
 
 The upgrade command implements multiple security measures to ensure safe updates:
 
-- **GitHub Integration**: Only downloads binaries from official CCPM GitHub releases
+- **GitHub Integration**: Only downloads binaries from official AGPM GitHub releases
 - **HTTPS Downloads**: Uses secure HTTPS connections for all network operations
 - **Platform-Specific Archives**: Downloads appropriate archive format for your platform (.tar.xz for Unix, .zip for Windows)
 - **Atomic Operations**: Minimizes vulnerability windows during binary replacement
 - **Permission Preservation**: Maintains original file permissions and ownership
 - **Backup Protection**: Creates backups with appropriate permissions before any modifications
 
-### `ccpm cache`
+### `agpm cache`
 
-Manage the global Git repository cache in `~/.ccpm/cache/`. The cache uses SHA-based worktrees for optimal deduplication and performance.
+Manage the global Git repository cache in `~/.agpm/cache/`. The cache uses SHA-based worktrees for optimal deduplication and performance.
 
 #### Cache Information
 
 ```bash
-ccpm cache info [OPTIONS]
+agpm cache info [OPTIONS]
 
 Options:
   -h, --help    Print help information
@@ -608,7 +608,7 @@ Options:
 #### Clean Cache
 
 ```bash
-ccpm cache clean [OPTIONS]
+agpm cache clean [OPTIONS]
 
 Options:
       --all       Remove all cached repositories
@@ -619,7 +619,7 @@ Options:
 #### List Cache
 
 ```bash
-ccpm cache list [OPTIONS]
+agpm cache list [OPTIONS]
 
 Options:
   -h, --help    Print help information
@@ -628,33 +628,33 @@ Options:
 **Examples:**
 ```bash
 # Show cache statistics
-ccpm cache info
+agpm cache info
 
 # Clean unused repositories
-ccpm cache clean
+agpm cache clean
 
 # Remove all cached repositories
-ccpm cache clean --all
+agpm cache clean --all
 
 # List cached repositories
-ccpm cache list
+agpm cache list
 ```
 
 ## Resource Types
 
-CCPM manages six types of resources with optimized parallel installation:
+AGPM manages six types of resources with optimized parallel installation:
 
 ### Direct Installation Resources
 
 - **Agents**: AI assistant configurations (installed to `.claude/agents/`)
-- **Snippets**: Reusable code templates (installed to `.claude/ccpm/snippets/`)
+- **Snippets**: Reusable code templates (installed to `.claude/agpm/snippets/`)
 - **Commands**: Claude Code slash commands (installed to `.claude/commands/`)
-- **Scripts**: Executable automation files (installed to `.claude/ccpm/scripts/`)
+- **Scripts**: Executable automation files (installed to `.claude/agpm/scripts/`)
 
 ### Configuration-Merged Resources
 
-- **Hooks**: Event-based automation (installed to `.claude/ccpm/hooks/`, merged into `.claude/settings.local.json`)
-- **MCP Servers**: Model Context Protocol servers (installed to `.claude/ccpm/mcp-servers/`, merged into `.mcp.json`)
+- **Hooks**: Event-based automation (installed to `.claude/agpm/hooks/`, merged into `.claude/settings.local.json`)
+- **MCP Servers**: Model Context Protocol servers (installed to `.claude/agpm/mcp-servers/`, merged into `.mcp.json`)
 
 ### Parallel Installation Features
 
@@ -665,7 +665,7 @@ CCPM manages six types of resources with optimized parallel installation:
 
 ## Version Constraints
 
-CCPM supports semantic version constraints:
+AGPM supports semantic version constraints:
 
 | Syntax | Description | Example |
 |--------|-------------|---------|
@@ -699,7 +699,7 @@ review-tools = { source = "community", path = "agents/**/review*.md", version = 
 
 ## Parallelism Control
 
-CCPM v0.3.0 introduces advanced parallelism control for optimal performance:
+AGPM v0.3.0 introduces advanced parallelism control for optimal performance:
 
 ### --max-parallel Flag
 
@@ -715,16 +715,16 @@ Available on `install` and `update` commands to control concurrent operations:
 **Examples:**
 ```bash
 # Use default parallelism (recommended)
-ccpm install
+agpm install
 
 # High-performance system with fast network
-ccpm install --max-parallel 20
+agpm install --max-parallel 20
 
 # Limited bandwidth or shared resources
-ccpm install --max-parallel 3
+agpm install --max-parallel 3
 
 # Single-threaded operation (debugging)
-ccpm install --max-parallel 1
+agpm install --max-parallel 1
 ```
 
 ### Performance Characteristics
@@ -736,17 +736,17 @@ ccpm install --max-parallel 1
 
 ## Environment Variables
 
-CCPM respects these environment variables:
+AGPM respects these environment variables:
 
-- `CCPM_CONFIG` - Path to custom global config file
-- `CCPM_CACHE_DIR` - Override cache directory
-- `CCPM_NO_PROGRESS` - Disable progress bars
-- `CCPM_MAX_PARALLEL` - Default parallelism level (overridden by --max-parallel flag)
+- `AGPM_CONFIG` - Path to custom global config file
+- `AGPM_CACHE_DIR` - Override cache directory
+- `AGPM_NO_PROGRESS` - Disable progress bars
+- `AGPM_MAX_PARALLEL` - Default parallelism level (overridden by --max-parallel flag)
 - `RUST_LOG` - Set logging level (debug, info, warn, error)
 
 ## Exit Codes
 
-CCPM uses these exit codes:
+AGPM uses these exit codes:
 
 - `0` - Success
 - `1` - General error
@@ -762,9 +762,9 @@ CCPM uses these exit codes:
 ### Basic Project
 
 ```toml
-# ccpm.toml
+# agpm.toml
 [sources]
-community = "https://github.com/aig787/ccpm-community.git"
+community = "https://github.com/aig787/agpm-community.git"
 
 [agents]
 rust-expert = { source = "community", path = "agents/rust-expert.md", version = "v1.0.0" }
@@ -776,9 +776,9 @@ react-hooks = { source = "community", path = "snippets/react-hooks.md", version 
 ### Advanced Project
 
 ```toml
-# ccpm.toml
+# agpm.toml
 [sources]
-community = "https://github.com/aig787/ccpm-community.git"
+community = "https://github.com/aig787/agpm-community.git"
 tools = "https://github.com/myorg/ccpm-tools.git"
 local = "./local-resources"
 
@@ -813,7 +813,7 @@ gitignore = false
 
 ## Getting Help
 
-- Run `ccpm --help` for general help
-- Run `ccpm <command> --help` for command-specific help
+- Run `agpm --help` for general help
+- Run `agpm <command> --help` for command-specific help
 - Check the [FAQ](docs/faq.md) for common questions
-- Visit [GitHub Issues](https://github.com/aig787/ccpm/issues) for support
+- Visit [GitHub Issues](https://github.com/aig787/agpm/issues) for support

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,10 +1,10 @@
 # Configuration Guide
 
-CCPM uses a two-tier configuration system to separate sensitive data from project settings.
+AGPM uses a two-tier configuration system to separate sensitive data from project settings.
 
 ## Configuration Files
 
-### Project Manifest (ccpm.toml)
+### Project Manifest (agpm.toml)
 
 The project manifest defines dependencies and is committed to version control.
 
@@ -12,11 +12,11 @@ The project manifest defines dependencies and is committed to version control.
 **Purpose**: Define sources and dependencies
 **Version Control**: ✅ Commit to Git
 
-### Global Configuration (~/.ccpm/config.toml)
+### Global Configuration (~/.agpm/config.toml)
 
 The global configuration stores sensitive data like authentication tokens.
 
-**Location**: `~/.ccpm/config.toml` (Unix/macOS) or `%USERPROFILE%\.ccpm\config.toml` (Windows)
+**Location**: `~/.agpm/config.toml` (Unix/macOS) or `%USERPROFILE%\.agpm\config.toml` (Windows)
 **Purpose**: Store authentication tokens and private sources
 **Version Control**: ❌ Never commit to Git
 
@@ -26,35 +26,35 @@ The global configuration stores sensitive data like authentication tokens.
 
 ```bash
 # Initialize with example configuration
-ccpm config init
+agpm config init
 
 # Edit the config file
-ccpm config edit
+agpm config edit
 
 # Show current configuration (tokens masked)
-ccpm config show
+agpm config show
 ```
 
 ### Managing Sources
 
 ```bash
 # Add a private source with authentication
-ccpm config add-source private "https://oauth2:TOKEN@github.com/yourcompany/private-ccpm.git"
+agpm config add-source private "https://oauth2:TOKEN@github.com/yourcompany/private-agpm.git"
 
 # List all global sources (tokens are masked)
-ccpm config list-sources
+agpm config list-sources
 
 # Remove a source
-ccpm config remove-source private
+agpm config remove-source private
 ```
 
 ### Global Config Format
 
 ```toml
-# ~/.ccpm/config.toml
+# ~/.agpm/config.toml
 [sources]
 # Private sources with authentication
-private = "https://oauth2:ghp_xxxx@github.com/yourcompany/private-ccpm.git"
+private = "https://oauth2:ghp_xxxx@github.com/yourcompany/private-agpm.git"
 internal = "https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.company.com/resources.git"
 
 [settings]
@@ -72,8 +72,8 @@ enhanced_progress = true
 
 Sources are resolved in this order:
 
-1. **Global sources** from `~/.ccpm/config.toml` (loaded first, contain secrets)
-2. **Local sources** from `ccpm.toml` (override global, committed to Git)
+1. **Global sources** from `~/.agpm/config.toml` (loaded first, contain secrets)
+2. **Local sources** from `agpm.toml` (override global, committed to Git)
 
 This separation keeps authentication tokens out of version control while allowing teams to share project configurations.
 
@@ -84,7 +84,7 @@ This separation keeps authentication tokens out of version control while allowin
 For repositories accessible via SSH:
 
 ```toml
-# In ccpm.toml (safe to commit)
+# In agpm.toml (safe to commit)
 [sources]
 private = "git@github.com:mycompany/private-agents.git"
 ```
@@ -94,8 +94,8 @@ private = "git@github.com:mycompany/private-agents.git"
 For repositories requiring authentication tokens:
 
 ```bash
-# In global config only (never in ccpm.toml)
-ccpm config add-source private "https://oauth2:ghp_xxxx@github.com/yourcompany/private-ccpm.git"
+# In global config only (never in agpm.toml)
+agpm config add-source private "https://oauth2:ghp_xxxx@github.com/yourcompany/private-agpm.git"
 ```
 
 ### Environment Variables
@@ -103,7 +103,7 @@ ccpm config add-source private "https://oauth2:ghp_xxxx@github.com/yourcompany/p
 Use environment variables for CI/CD:
 
 ```toml
-# In ~/.ccpm/config.toml
+# In ~/.agpm/config.toml
 [sources]
 ci-source = "https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.company.com/resources.git"
 ```
@@ -112,18 +112,18 @@ ci-source = "https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.company.com/resource
 
 ### DO ✅
 
-- Store authentication tokens in `~/.ccpm/config.toml`
-- Use SSH URLs for repositories in `ccpm.toml`
-- Commit `ccpm.toml` to version control
+- Store authentication tokens in `~/.agpm/config.toml`
+- Use SSH URLs for repositories in `agpm.toml`
+- Commit `agpm.toml` to version control
 - Use environment variables for CI/CD tokens
 - Rotate tokens regularly
 - Use read-only tokens when possible
 
 ### DON'T ❌
 
-- Put tokens, passwords, or secrets in `ccpm.toml`
-- Use HTTPS URLs with embedded credentials in `ccpm.toml`
-- Commit `~/.ccpm/config.toml` to version control
+- Put tokens, passwords, or secrets in `agpm.toml`
+- Use HTTPS URLs with embedded credentials in `agpm.toml`
+- Commit `~/.agpm/config.toml` to version control
 - Share your global config file
 - Use personal tokens in CI/CD
 - Store tokens in plain text files
@@ -133,7 +133,7 @@ ci-source = "https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.company.com/resource
 ### Using SSH (Recommended)
 
 ```toml
-# ccpm.toml - safe to commit
+# agpm.toml - safe to commit
 [sources]
 private = "git@github.com:mycompany/private-agents.git"
 
@@ -145,11 +145,11 @@ internal-tool = { source = "private", path = "agents/tool.md", version = "v1.0.0
 
 ```bash
 # Add to global config
-ccpm config add-source private "https://oauth2:TOKEN@github.com/yourcompany/private-ccpm.git"
+agpm config add-source private "https://oauth2:TOKEN@github.com/yourcompany/private-agpm.git"
 ```
 
 ```toml
-# ccpm.toml - reference the source name
+# agpm.toml - reference the source name
 [agents]
 internal-tool = { source = "private", path = "agents/tool.md", version = "v1.0.0" }
 ```
@@ -159,27 +159,27 @@ internal-tool = { source = "private", path = "agents/tool.md", version = "v1.0.0
 ### GitHub Actions
 
 ```yaml
-- name: Configure CCPM
+- name: Configure AGPM
   run: |
-    mkdir -p ~/.ccpm
-    echo '[sources]' > ~/.ccpm/config.toml
-    echo 'private = "https://oauth2:${{ secrets.GITHUB_TOKEN }}@github.com/org/private.git"' >> ~/.ccpm/config.toml
+    mkdir -p ~/.agpm
+    echo '[sources]' > ~/.agpm/config.toml
+    echo 'private = "https://oauth2:${{ secrets.GITHUB_TOKEN }}@github.com/org/private.git"' >> ~/.agpm/config.toml
 
 - name: Install dependencies
-  run: ccpm install --frozen
+  run: agpm install --frozen
 ```
 
 ### GitLab CI
 
 ```yaml
 before_script:
-  - mkdir -p ~/.ccpm
+  - mkdir -p ~/.agpm
   - |
-    cat > ~/.ccpm/config.toml << EOF
+    cat > ~/.agpm/config.toml << EOF
     [sources]
     private = "https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.com/org/private.git"
     EOF
-  - ccpm install --frozen
+  - agpm install --frozen
 ```
 
 ## Cache Configuration
@@ -187,7 +187,7 @@ before_script:
 ### Custom Cache Directory
 
 ```toml
-# ~/.ccpm/config.toml
+# ~/.agpm/config.toml
 [settings]
 cache_dir = "/custom/cache/path"
 ```
@@ -196,26 +196,26 @@ cache_dir = "/custom/cache/path"
 
 ```bash
 # View cache information
-ccpm cache info
+agpm cache info
 
 # Clean unused cache entries
-ccpm cache clean
+agpm cache clean
 
 # Clear entire cache
-ccpm cache clean --all
+agpm cache clean --all
 
 # Bypass cache for fresh clone
-ccpm install --no-cache
+agpm install --no-cache
 ```
 
 ## Performance Settings
 
 ### Parallelism Control
 
-CCPM provides flexible parallelism control at multiple levels:
+AGPM provides flexible parallelism control at multiple levels:
 
 ```toml
-# ~/.ccpm/config.toml
+# ~/.agpm/config.toml
 [settings]
 # Default parallelism for all operations (default: max(10, 2 × CPU cores))
 max_parallel = 8
@@ -225,21 +225,21 @@ Per-command override:
 
 ```bash
 # Override global setting for specific commands
-ccpm install --max-parallel 12
-ccpm update --max-parallel 6
+agpm install --max-parallel 12
+agpm update --max-parallel 6
 ```
 
 Environment variable override:
 
 ```bash
 # Set default for current session
-export CCPM_MAX_PARALLEL=16
-ccpm install  # Uses 16 parallel operations
+export AGPM_MAX_PARALLEL=16
+agpm install  # Uses 16 parallel operations
 ```
 
 #### Parallelism Guidelines
 
-- **Default behavior**: CCPM automatically sets reasonable limits based on your system
+- **Default behavior**: AGPM automatically sets reasonable limits based on your system
 - **High-end systems**: Can safely use 16-32 parallel operations
 - **Resource-constrained environments**: Consider lowering to 4-8 operations
 - **CI/CD environments**: May need lower limits depending on container resources
@@ -250,7 +250,7 @@ ccpm install  # Uses 16 parallel operations
 Override default installation paths:
 
 ```toml
-# ccpm.toml
+# agpm.toml
 [target]
 agents = "custom/agents"
 snippets = "resources/snippets"
@@ -265,18 +265,18 @@ gitignore = false  # Don't create .gitignore (default: true)
 
 ## Environment Variables
 
-CCPM respects these environment variables for configuration and debugging:
+AGPM respects these environment variables for configuration and debugging:
 
 ### Configuration Variables
 
-- `CCPM_CONFIG` - Path to custom global config file
-- `CCPM_CACHE_DIR` - Override cache directory location
-- `CCPM_MAX_PARALLEL` - Default parallelism level (overridden by --max-parallel flag)
+- `AGPM_CONFIG` - Path to custom global config file
+- `AGPM_CACHE_DIR` - Override cache directory location
+- `AGPM_MAX_PARALLEL` - Default parallelism level (overridden by --max-parallel flag)
 
 ### User Interface Variables
 
-- `CCPM_NO_PROGRESS` - Disable progress bars (useful for CI/CD)
-- `CCPM_ENHANCED_PROGRESS` - Enable enhanced progress reporting with phase details
+- `AGPM_NO_PROGRESS` - Disable progress bars (useful for CI/CD)
+- `AGPM_ENHANCED_PROGRESS` - Enable enhanced progress reporting with phase details
 
 ### Debugging Variables
 
@@ -292,19 +292,19 @@ CCPM respects these environment variables for configuration and debugging:
 
 ```bash
 # Debug mode with detailed Git operation logging
-RUST_LOG=debug ccpm install
+RUST_LOG=debug agpm install
 
 # CI/CD mode: no progress bars, custom parallelism
-CCPM_NO_PROGRESS=1 CCPM_MAX_PARALLEL=4 ccpm install --frozen
+AGPM_NO_PROGRESS=1 AGPM_MAX_PARALLEL=4 agpm install --frozen
 
 # Enhanced progress with custom config location
-CCPM_ENHANCED_PROGRESS=1 CCPM_CONFIG=/custom/config.toml ccpm install
+AGPM_ENHANCED_PROGRESS=1 AGPM_CONFIG=/custom/config.toml agpm install
 
 # High-performance mode for powerful systems
-CCPM_MAX_PARALLEL=20 ccpm install --max-parallel 32
+AGPM_MAX_PARALLEL=20 agpm install --max-parallel 32
 
 # Debugging Git worktree operations
-RUST_LOG=debug GIT_TRACE=1 ccpm install
+RUST_LOG=debug GIT_TRACE=1 agpm install
 ```
 
 ## Troubleshooting Configuration
@@ -313,17 +313,17 @@ RUST_LOG=debug GIT_TRACE=1 ccpm install
 
 ```bash
 # Check config location
-ccpm config show
+agpm config show
 
 # Initialize if missing
-ccpm config init
+agpm config init
 ```
 
 ### Authentication Failures
 
 ```bash
 # Verify source URL
-ccpm config list-sources
+agpm config list-sources
 
 # Test git access directly
 git ls-remote https://token@github.com/org/repo.git
@@ -333,33 +333,33 @@ git ls-remote https://token@github.com/org/repo.git
 
 ```bash
 # Check which source is being used (with worktree context)
-RUST_LOG=debug ccpm install
+RUST_LOG=debug agpm install
 
 # Trace Git operations to see repository access patterns
-GIT_TRACE=1 RUST_LOG=debug ccpm install
+GIT_TRACE=1 RUST_LOG=debug agpm install
 
 # Override with local source
-# In ccpm.toml, redefine the source name
+# In agpm.toml, redefine the source name
 ```
 
 ### Parallel Operation Issues
 
 ```bash
 # Reduce parallelism if experiencing resource contention
-ccpm install --max-parallel 2
+agpm install --max-parallel 2
 
 # Debug worktree creation issues
-RUST_LOG=debug ccpm install --no-cache
+RUST_LOG=debug agpm install --no-cache
 
 # Monitor system resources during installation
-top -p $(pgrep ccpm) &
-ccpm install --max-parallel 16
+top -p $(pgrep agpm) &
+agpm install --max-parallel 16
 ```
 
 ### Token Rotation
 
 When rotating tokens:
 
-1. Update global config: `ccpm config edit`
-2. Clear cache: `ccpm cache clean --all`
-3. Test installation: `ccpm install --no-cache`
+1. Update global config: `agpm config edit`
+2. Clear cache: `agpm cache clean --all`
+3. Test installation: `agpm install --no-cache`

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -333,7 +333,7 @@ AGPM is tested and supported on:
 
 ### Where can I find example resources?
 Check out community repositories:
-- [ccpm-community](https://github.com/aig787/agpm-community) - Official community resources
+- [agpm-community](https://github.com/aig787/agpm-community) - Official community resources
 - Search GitHub for repositories with "agpm" topics
 
 ## Still Have Questions?

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,4 +1,4 @@
-# CCPM Frequently Asked Questions
+# AGPM Frequently Asked Questions
 
 ## Table of Contents
 
@@ -13,66 +13,66 @@
 
 ## General Questions
 
-### What is CCPM?
-CCPM (Claude Code Package Manager) is a Git-based package manager for Claude Code resources. It enables reproducible installations of AI agents, snippets, commands, scripts, hooks, and MCP servers from Git repositories using a lockfile-based approach similar to Cargo or npm.
+### What is AGPM?
+AGPM (Claude Code Package Manager) is a Git-based package manager for Claude Code resources. It enables reproducible installations of AI agents, snippets, commands, scripts, hooks, and MCP servers from Git repositories using a lockfile-based approach similar to Cargo or npm.
 
-### How does CCPM differ from other package managers?
-Unlike traditional package managers with central registries, CCPM is fully decentralized and Git-based. Resources are distributed directly from Git repositories, and versioning is tied to Git tags, branches, or commits. This makes it perfect for managing AI-related resources that may be proprietary or experimental.
+### How does AGPM differ from other package managers?
+Unlike traditional package managers with central registries, AGPM is fully decentralized and Git-based. Resources are distributed directly from Git repositories, and versioning is tied to Git tags, branches, or commits. This makes it perfect for managing AI-related resources that may be proprietary or experimental.
 
-### What types of resources can CCPM manage?
-CCPM manages six resource types:
+### What types of resources can AGPM manage?
+AGPM manages six resource types:
 - **Direct Installation**: Agents, Snippets, Commands, Scripts (copied directly to target directories)
 - **Configuration-Merged**: Hooks, MCP Servers (installed then merged into Claude Code config files)
 
-### Do I need Git installed to use CCPM?
-Yes, CCPM uses your system's Git command for all repository operations. This ensures maximum compatibility and respects your existing Git configuration (SSH keys, credentials, etc.).
+### Do I need Git installed to use AGPM?
+Yes, AGPM uses your system's Git command for all repository operations. This ensures maximum compatibility and respects your existing Git configuration (SSH keys, credentials, etc.).
 
 ## Installation & Setup
 
-### How do I install CCPM?
+### How do I install AGPM?
 
-CCPM is published to crates.io with automated releases. You can install via:
+AGPM is published to crates.io with automated releases. You can install via:
 
 **All Platforms (via Cargo):**
 ```bash
 # Requires Rust toolchain
-cargo install ccpm  # Published to crates.io
+cargo install agpm  # Published to crates.io
 # Or from GitHub for latest development
-cargo install --git https://github.com/aig787/ccpm.git
+cargo install --git https://github.com/aig787/agpm.git
 ```
 
 **Unix/macOS (Pre-built Binary):**
 ```bash
 # Download pre-built binary (automatically detects architecture)
-curl -L https://github.com/aig787/ccpm/releases/latest/download/ccpm-$(uname -m)-$(uname -s | tr '[:upper:]' '[:lower:]').tar.gz | tar xz
-chmod +x ccpm
-sudo mv ccpm /usr/local/bin/
+curl -L https://github.com/aig787/agpm/releases/latest/download/agpm-$(uname -m)-$(uname -s | tr '[:upper:]' '[:lower:]').tar.gz | tar xz
+chmod +x agpm
+sudo mv agpm /usr/local/bin/
 ```
 
 **Windows (Pre-built Binary):**
 ```powershell
 # PowerShell
-Invoke-WebRequest -Uri "https://github.com/aig787/ccpm/releases/latest/download/ccpm-x86_64-windows.zip" -OutFile ccpm.zip
-Expand-Archive -Path ccpm.zip -DestinationPath .
+Invoke-WebRequest -Uri "https://github.com/aig787/agpm/releases/latest/download/agpm-x86_64-windows.zip" -OutFile agpm.zip
+Expand-Archive -Path agpm.zip -DestinationPath .
 # Move to a directory in PATH or add to PATH manually
-Move-Item ccpm.exe "$env:LOCALAPPDATA\ccpm\bin\"
+Move-Item agpm.exe "$env:LOCALAPPDATA\agpm\bin\"
 ```
 
-### How do I start a new CCPM project?
+### How do I start a new AGPM project?
 ```bash
-ccpm init  # Creates ccpm.toml
+agpm init  # Creates agpm.toml
 # or
-ccpm init --path ./my-project  # Creates in specific directory
+agpm init --path ./my-project  # Creates in specific directory
 ```
 
-### What's the difference between ccpm.toml and ccpm.lock?
-- **ccpm.toml**: Your project manifest that declares dependencies and their version constraints (you edit this)
-- **ccpm.lock**: Auto-generated file with exact resolved versions for reproducible builds (don't edit manually)
+### What's the difference between agpm.toml and agpm.lock?
+- **agpm.toml**: Your project manifest that declares dependencies and their version constraints (you edit this)
+- **agpm.lock**: Auto-generated file with exact resolved versions for reproducible builds (don't edit manually)
 
 ## Dependencies & Versions
 
 ### Can I use specific versions of resources?
-Yes! CCPM supports multiple versioning strategies:
+Yes! AGPM supports multiple versioning strategies:
 ```toml
 exact = { source = "repo", path = "file.md", version = "v1.0.0" }      # Exact tag
 range = { source = "repo", path = "file.md", version = "^1.0.0" }      # Compatible versions
@@ -81,7 +81,7 @@ commit = { source = "repo", path = "file.md", rev = "abc123" }         # Specifi
 ```
 
 ### What version constraints are supported?
-CCPM uses semantic versioning constraints like Cargo:
+AGPM uses semantic versioning constraints like Cargo:
 - `^1.2.3` - Compatible updates (>=1.2.3, <2.0.0)
 - `~1.2.3` - Patch updates only (>=1.2.3, <1.3.0)
 - `>=1.0.0, <2.0.0` - Custom ranges
@@ -90,19 +90,19 @@ CCPM uses semantic versioning constraints like Cargo:
 
 ### How do I check for available updates?
 ```bash
-ccpm outdated            # Check all dependencies for updates
-ccpm outdated agent-name # Check specific dependency
-ccpm outdated --check    # Exit with error code if updates available (for CI)
-ccpm outdated --format json # JSON output for scripting
+agpm outdated            # Check all dependencies for updates
+agpm outdated agent-name # Check specific dependency
+agpm outdated --check    # Exit with error code if updates available (for CI)
+agpm outdated --format json # JSON output for scripting
 ```
 
 The `outdated` command shows current versions, latest available, and whether updates are compatible with your version constraints.
 
 ### How do I update dependencies?
 ```bash
-ccpm update              # Update all to latest compatible versions
-ccpm update agent-name   # Update specific dependency
-ccpm update --dry-run    # Preview changes without applying
+agpm update              # Update all to latest compatible versions
+agpm update agent-name   # Update specific dependency
+agpm update --dry-run    # Preview changes without applying
 ```
 
 ### Can I use local files without Git?
@@ -121,16 +121,16 @@ direct = { path = "../agents/my-agent.md" }                 # Direct file path
 ### Where are resources installed?
 Default installation directories:
 - Agents: `.claude/agents/`
-- Snippets: `.claude/ccpm/snippets/`
+- Snippets: `.claude/agpm/snippets/`
 - Commands: `.claude/commands/`
-- Scripts: `.claude/ccpm/scripts/`
-- Hooks: `.claude/ccpm/hooks/` (then merged into `.claude/settings.local.json`)
-- MCP Servers: `.claude/ccpm/mcp-servers/` (then merged into `.mcp.json`)
+- Scripts: `.claude/agpm/scripts/`
+- Hooks: `.claude/agpm/hooks/` (then merged into `.claude/settings.local.json`)
+- MCP Servers: `.claude/agpm/mcp-servers/` (then merged into `.mcp.json`)
 
 ### Can I customize installation directories?
 Yes, there are two ways to customize where resources are installed:
 
-**1. Global defaults** - Use the `[target]` section in ccpm.toml:
+**1. Global defaults** - Use the `[target]` section in agpm.toml:
 ```toml
 [target]
 agents = "custom/agents/path"
@@ -151,7 +151,7 @@ special-agent = { source = "repo", path = "agents/special.md", target = "special
 The per-dependency `target` takes precedence over global `[target]` settings.
 
 ### How are installed files named?
-Files are named based on the dependency key in ccpm.toml, not their source filename:
+Files are named based on the dependency key in agpm.toml, not their source filename:
 ```toml
 [agents]
 my-helper = { source = "repo", path = "agents/assistant.md" }
@@ -164,7 +164,7 @@ my-helper = { source = "repo", path = "agents/assistant.md" }
 
 ### How do hooks and MCP servers get configured?
 These are "configuration-merged" resources:
-1. JSON files are installed to `.claude/ccpm/`
+1. JSON files are installed to `.claude/agpm/`
 2. Configurations are automatically merged into Claude Code's settings
 3. User-configured entries are preserved
 
@@ -172,105 +172,105 @@ These are "configuration-merged" resources:
 
 ### What should I commit to Git?
 Commit these files:
-- `ccpm.toml` - Your dependency manifest
-- `ccpm.lock` - Locked versions for reproducible builds
+- `agpm.toml` - Your dependency manifest
+- `agpm.lock` - Locked versions for reproducible builds
 
 Don't commit:
 - `.claude/` directory (auto-generated, gitignored by default)
-- `~/.ccpm/config.toml` (contains secrets)
+- `~/.agpm/config.toml` (contains secrets)
 
 ### Why are my installed files gitignored?
-By default, CCPM creates `.gitignore` entries to prevent installed dependencies from being committed. This follows the pattern of other package managers where you commit the manifest but not the installed packages.
+By default, AGPM creates `.gitignore` entries to prevent installed dependencies from being committed. This follows the pattern of other package managers where you commit the manifest but not the installed packages.
 
 ### Can I commit installed resources to Git?
-Yes, set `gitignore = false` in ccpm.toml:
+Yes, set `gitignore = false` in agpm.toml:
 ```toml
 [target]
 gitignore = false  # Don't create .gitignore
 ```
 
-### How does CCPM handle the .gitignore file?
-CCPM manages a section in `.gitignore` marked with "CCPM managed entries". It preserves any user entries outside this section while updating its own entries based on installed resources.
+### How does AGPM handle the .gitignore file?
+AGPM manages a section in `.gitignore` marked with "AGPM managed entries". It preserves any user entries outside this section while updating its own entries based on installed resources.
 
 ## Team Collaboration
 
 ### How do team members get the same versions?
-1. Commit both `ccpm.toml` and `ccpm.lock` to your repository
-2. Team members run `ccpm install --frozen` to install exact lockfile versions
+1. Commit both `agpm.toml` and `agpm.lock` to your repository
+2. Team members run `agpm install --frozen` to install exact lockfile versions
 3. This ensures everyone has identical resource versions
 
 ### How do I handle private repositories?
 For repositories requiring authentication:
 ```bash
 # Add to global config (not committed)
-ccpm config add-source private "https://oauth2:TOKEN@github.com/org/private.git"
+agpm config add-source private "https://oauth2:TOKEN@github.com/org/private.git"
 
-# Or use SSH in ccpm.toml (safe to commit)
+# Or use SSH in agpm.toml (safe to commit)
 [sources]
 private = "git@github.com:org/private.git"
 ```
 
 ### What's the difference between global and local sources?
-- **Global sources** (`~/.ccpm/config.toml`): For credentials and private repos, not committed
-- **Local sources** (`ccpm.toml`): Project-specific sources, safe to commit
+- **Global sources** (`~/.agpm/config.toml`): For credentials and private repos, not committed
+- **Local sources** (`agpm.toml`): Project-specific sources, safe to commit
 
 Sources are resolved with global sources first, then local sources can override.
 
 ### What's the --frozen flag for?
-`ccpm install --frozen` uses exact versions from ccpm.lock without checking for updates. Use this in CI/CD and production environments for deterministic builds.
+`agpm install --frozen` uses exact versions from agpm.lock without checking for updates. Use this in CI/CD and production environments for deterministic builds.
 
 ## Troubleshooting
 
 ### Installation fails with "No manifest found"
-Create a ccpm.toml file:
+Create a agpm.toml file:
 ```bash
-ccpm init  # Creates ccpm.toml
+agpm init  # Creates agpm.toml
 ```
 
 ### How do I debug installation issues?
 ```bash
 # Run with debug logging
-RUST_LOG=debug ccpm install
+RUST_LOG=debug agpm install
 
 # Validate manifest and sources
-ccpm validate --resolve
+agpm validate --resolve
 
 # Check cache status
-ccpm cache info
+agpm cache info
 ```
 
 ### Resources aren't being installed
-1. Check ccpm.toml syntax: `ccpm validate`
+1. Check agpm.toml syntax: `agpm validate`
 2. Verify source repositories are accessible
 3. Check Git authentication for private repos
-4. Clear cache if corrupted: `ccpm cache clean --all`
+4. Clear cache if corrupted: `agpm cache clean --all`
 
 ### How do I handle version conflicts?
 ```bash
 # Check for conflicts
-ccpm validate --resolve
+agpm validate --resolve
 
 # Optional: inspect the graph
-ccpm validate --resolve --format json
+agpm validate --resolve --format json
 
 # Auto-update the lockfile after adjusting constraints
-ccpm install
+agpm install
 ```
 
-If the error reports incompatible constraints, update `ccpm.toml` (or the resource metadata) so all dependents agree on a version. Prefer explicitly pinning the parent entry; CCPM will propagate that version to transitive dependencies. For duplicate install paths reported during resolution, add a `filename` or `target` override so each dependency gets a unique destination.
+If the error reports incompatible constraints, update `agpm.toml` (or the resource metadata) so all dependents agree on a version. Prefer explicitly pinning the parent entry; AGPM will propagate that version to transitive dependencies. For duplicate install paths reported during resolution, add a `filename` or `target` override so each dependency gets a unique destination.
 
 ### Can I uninstall resources?
-CCPM doesn't have an uninstall command. To remove resources:
-1. Remove the dependency from ccpm.toml
-2. Run `ccpm install` to update
+AGPM doesn't have an uninstall command. To remove resources:
+1. Remove the dependency from agpm.toml
+2. Run `agpm install` to update
 3. Manually delete the installed files if needed
 
 ### What if my existing Claude Code settings conflict?
-CCPM preserves user-configured settings in:
+AGPM preserves user-configured settings in:
 - `.claude/settings.local.json` (for hooks)
 - `.mcp.json` (for MCP servers)
 
-Only CCPM-managed entries (marked with metadata) are updated.
+Only AGPM-managed entries (marked with metadata) are updated.
 
 ## Advanced Usage
 
@@ -285,19 +285,19 @@ local = "./local-resources"
 
 ### How do I bypass the cache?
 ```bash
-ccpm install --no-cache  # Fetch directly from sources
+agpm install --no-cache  # Fetch directly from sources
 ```
 
 ### Can I control parallel downloads?
 ```bash
-ccpm install --max-parallel 4  # Limit concurrent operations
+agpm install --max-parallel 4  # Limit concurrent operations
 ```
 
 ### How do I clean up the cache?
 ```bash
-ccpm cache clean       # Remove unused repositories
-ccpm cache clean --all # Clear entire cache
-ccpm cache info        # View cache statistics
+agpm cache clean       # Remove unused repositories
+agpm cache clean --all # Clear entire cache
+agpm cache info        # View cache statistics
 ```
 
 ### Can I reference resources from subdirectories?
@@ -318,28 +318,28 @@ MCP server and hook configurations support `${VAR}` expansion:
 }
 ```
 
-### Can I use CCPM in CI/CD pipelines?
+### Can I use AGPM in CI/CD pipelines?
 Yes! Best practices for CI/CD:
-1. Commit ccpm.lock to your repository
-2. Use `ccpm install --frozen` in CI
+1. Commit agpm.lock to your repository
+2. Use `agpm install --frozen` in CI
 3. Set authentication in environment or global config
 4. Use `--max-parallel` to control resource usage
 
-### What platforms does CCPM support?
-CCPM is tested and supported on:
+### What platforms does AGPM support?
+AGPM is tested and supported on:
 - macOS (x86_64, aarch64)
 - Linux (x86_64, aarch64)
 - Windows (x86_64)
 
 ### Where can I find example resources?
 Check out community repositories:
-- [ccpm-community](https://github.com/aig787/ccpm-community) - Official community resources
-- Search GitHub for repositories with "ccpm" topics
+- [ccpm-community](https://github.com/aig787/agpm-community) - Official community resources
+- Search GitHub for repositories with "agpm" topics
 
 ## Still Have Questions?
 
 If your question isn't answered here:
 1. Check the [full documentation](README.md)
-2. Search [existing issues](https://github.com/aig787/ccpm/issues)
-3. Ask in [GitHub Discussions](https://github.com/aig787/ccpm/discussions)
-4. Report bugs via [GitHub Issues](https://github.com/aig787/ccpm/issues/new)
+2. Search [existing issues](https://github.com/aig787/agpm/issues)
+3. Ask in [GitHub Discussions](https://github.com/aig787/agpm/discussions)
+4. Report bugs via [GitHub Issues](https://github.com/aig787/agpm/issues/new)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Installation Guide
 
-This guide covers all installation methods for CCPM across different platforms.
+This guide covers all installation methods for AGPM across different platforms.
 
 ## Requirements
 
@@ -19,27 +19,27 @@ If you have Rust installed, this is the easiest method:
 
 ```bash
 # Install latest stable version from crates.io
-cargo install ccpm
+cargo install agpm
 
 # Install latest development version from GitHub
-cargo install --git https://github.com/aig787/ccpm.git
+cargo install --git https://github.com/aig787/agpm.git
 
 # Install specific version
-cargo install ccpm --version 0.3.0
+cargo install agpm --version 0.3.0
 ```
 
 ### Installer Scripts (Recommended)
 
-The easiest way to install CCPM is using the automated installer scripts:
+The easiest way to install AGPM is using the automated installer scripts:
 
 **Unix/Linux/macOS:**
 ```bash
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/aig787/ccpm/releases/latest/download/ccpm-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/aig787/agpm/releases/latest/download/agpm-installer.sh | sh
 ```
 
 **Windows (PowerShell):**
 ```powershell
-irm https://github.com/aig787/ccpm/releases/latest/download/ccpm-installer.ps1 | iex
+irm https://github.com/aig787/agpm/releases/latest/download/agpm-installer.ps1 | iex
 ```
 
 ### Manual Download
@@ -48,44 +48,44 @@ Download and install pre-built binaries directly from GitHub releases:
 
 #### macOS (Apple Silicon)
 ```bash
-mkdir -p ~/.ccpm/bin
-curl -L https://github.com/aig787/ccpm/releases/latest/download/ccpm-aarch64-apple-darwin.tar.xz | tar xJ -C ~/.ccpm/bin
-echo 'export PATH="$HOME/.ccpm/bin:$PATH"' >> ~/.zshrc
+mkdir -p ~/.agpm/bin
+curl -L https://github.com/aig787/agpm/releases/latest/download/agpm-aarch64-apple-darwin.tar.xz | tar xJ -C ~/.agpm/bin
+echo 'export PATH="$HOME/.agpm/bin:$PATH"' >> ~/.zshrc
 source ~/.zshrc
 ```
 
 #### macOS (Intel)
 ```bash
-mkdir -p ~/.ccpm/bin
-curl -L https://github.com/aig787/ccpm/releases/latest/download/ccpm-x86_64-apple-darwin.tar.xz | tar xJ -C ~/.ccpm/bin
-echo 'export PATH="$HOME/.ccpm/bin:$PATH"' >> ~/.zshrc
+mkdir -p ~/.agpm/bin
+curl -L https://github.com/aig787/agpm/releases/latest/download/agpm-x86_64-apple-darwin.tar.xz | tar xJ -C ~/.agpm/bin
+echo 'export PATH="$HOME/.agpm/bin:$PATH"' >> ~/.zshrc
 source ~/.zshrc
 ```
 
 #### Linux (x86_64)
 ```bash
-mkdir -p ~/.ccpm/bin
-curl -L https://github.com/aig787/ccpm/releases/latest/download/ccpm-x86_64-unknown-linux-gnu.tar.xz | tar xJ -C ~/.ccpm/bin
-echo 'export PATH="$HOME/.ccpm/bin:$PATH"' >> ~/.bashrc
+mkdir -p ~/.agpm/bin
+curl -L https://github.com/aig787/agpm/releases/latest/download/agpm-x86_64-unknown-linux-gnu.tar.xz | tar xJ -C ~/.agpm/bin
+echo 'export PATH="$HOME/.agpm/bin:$PATH"' >> ~/.bashrc
 source ~/.bashrc
 ```
 
 #### Linux (ARM64/aarch64)
 ```bash
-mkdir -p ~/.ccpm/bin
-curl -L https://github.com/aig787/ccpm/releases/latest/download/ccpm-aarch64-unknown-linux-gnu.tar.xz | tar xJ -C ~/.ccpm/bin
-echo 'export PATH="$HOME/.ccpm/bin:$PATH"' >> ~/.bashrc
+mkdir -p ~/.agpm/bin
+curl -L https://github.com/aig787/agpm/releases/latest/download/agpm-aarch64-unknown-linux-gnu.tar.xz | tar xJ -C ~/.agpm/bin
+echo 'export PATH="$HOME/.agpm/bin:$PATH"' >> ~/.bashrc
 source ~/.bashrc
 ```
 
 #### Windows (PowerShell)
 ```powershell
 # Download and extract to a user directory
-$installPath = "$env:USERPROFILE\.ccpm\bin"
+$installPath = "$env:USERPROFILE\.agpm\bin"
 New-Item -ItemType Directory -Force -Path $installPath
-Invoke-WebRequest https://github.com/aig787/ccpm/releases/latest/download/ccpm-x86_64-pc-windows-msvc.zip -OutFile ccpm.zip
-Expand-Archive ccpm.zip -DestinationPath $installPath -Force
-Remove-Item ccpm.zip
+Invoke-WebRequest https://github.com/aig787/agpm/releases/latest/download/agpm-x86_64-pc-windows-msvc.zip -OutFile agpm.zip
+Expand-Archive agpm.zip -DestinationPath $installPath -Force
+Remove-Item agpm.zip
 
 # Add to PATH for current session
 $env:PATH += ";$installPath"
@@ -101,8 +101,8 @@ $env:PATH += ";$installPath"
 #### Manual Installation
 ```bash
 # Download and install (automatically detects architecture)
-curl -L https://github.com/aig787/ccpm/releases/latest/download/ccpm-$(uname -m)-macos.tar.gz | tar xz
-sudo mv ccpm /usr/local/bin/
+curl -L https://github.com/aig787/agpm/releases/latest/download/agpm-$(uname -m)-macos.tar.gz | tar xz
+sudo mv agpm /usr/local/bin/
 ```
 
 ### Linux
@@ -110,8 +110,8 @@ sudo mv ccpm /usr/local/bin/
 #### Manual Installation
 ```bash
 # Download and install (automatically detects architecture)
-curl -L https://github.com/aig787/ccpm/releases/latest/download/ccpm-$(uname -m)-linux.tar.gz | tar xz
-sudo mv ccpm /usr/local/bin/
+curl -L https://github.com/aig787/agpm/releases/latest/download/agpm-$(uname -m)-linux.tar.gz | tar xz
+sudo mv agpm /usr/local/bin/
 ```
 
 ### Windows
@@ -120,18 +120,18 @@ sudo mv ccpm /usr/local/bin/
 
 ```powershell
 # Download and extract
-Invoke-WebRequest -Uri "https://github.com/aig787/ccpm/releases/latest/download/ccpm-x86_64-windows.zip" -OutFile ccpm.zip
-Expand-Archive -Path ccpm.zip -DestinationPath .
+Invoke-WebRequest -Uri "https://github.com/aig787/agpm/releases/latest/download/agpm-x86_64-windows.zip" -OutFile agpm.zip
+Expand-Archive -Path agpm.zip -DestinationPath .
 
 # Option 1: Install to System32 (requires admin)
-Copy-Item ccpm.exe -Destination C:\Windows\System32\
+Copy-Item agpm.exe -Destination C:\Windows\System32\
 
 # Option 2: Install to user directory (recommended)
-New-Item -ItemType Directory -Force -Path "$env:LOCALAPPDATA\ccpm\bin"
-Copy-Item ccpm.exe -Destination "$env:LOCALAPPDATA\ccpm\bin\"
+New-Item -ItemType Directory -Force -Path "$env:LOCALAPPDATA\agpm\bin"
+Copy-Item agpm.exe -Destination "$env:LOCALAPPDATA\agpm\bin\"
 
 # Add to PATH (user-level)
-[Environment]::SetEnvironmentVariable("Path", $env:Path + ";$env:LOCALAPPDATA\ccpm\bin", [EnvironmentVariableTarget]::User)
+[Environment]::SetEnvironmentVariable("Path", $env:Path + ";$env:LOCALAPPDATA\agpm\bin", [EnvironmentVariableTarget]::User)
 
 # Restart PowerShell or refresh PATH
 $env:Path = [System.Environment]::GetEnvironmentVariable("Path","User")
@@ -152,8 +152,8 @@ $env:Path = [System.Environment]::GetEnvironmentVariable("Path","User")
 
 ```bash
 # Clone the repository
-git clone https://github.com/aig787/ccpm.git
-cd ccpm
+git clone https://github.com/aig787/agpm.git
+cd agpm
 
 # Build in release mode with optimizations
 cargo build --release
@@ -174,21 +174,21 @@ cargo install --path .
 
 #### Unix/macOS
 ```bash
-git clone https://github.com/aig787/ccpm.git
-cd ccpm
+git clone https://github.com/aig787/agpm.git
+cd agpm
 cargo build --release
-sudo cp target/release/ccpm /usr/local/bin/
+sudo cp target/release/agpm /usr/local/bin/
 ```
 
 #### Windows (PowerShell)
 ```powershell
-git clone https://github.com/aig787/ccpm.git
-cd ccpm
+git clone https://github.com/aig787/agpm.git
+cd agpm
 cargo build --release
 
 # Install to user directory
-New-Item -ItemType Directory -Force -Path "$env:LOCALAPPDATA\ccpm\bin"
-Copy-Item target\release\ccpm.exe -Destination "$env:LOCALAPPDATA\ccpm\bin\"
+New-Item -ItemType Directory -Force -Path "$env:LOCALAPPDATA\agpm\bin"
+Copy-Item target\release\agpm.exe -Destination "$env:LOCALAPPDATA\agpm\bin\"
 ```
 
 ### Cross-Compilation
@@ -211,34 +211,34 @@ cargo build --target aarch64-unknown-linux-gnu --release
 
 ## Verifying Installation
 
-After installation, verify CCPM is working:
+After installation, verify AGPM is working:
 
 ```bash
 # Check version and verify installation
-ccpm --version
+agpm --version
 
 # Show help and available commands
-ccpm --help
+agpm --help
 
 # Test Git worktree support (requires Git 2.5+)
 git --version
 
 # Initialize a test project
-ccpm init
+agpm init
 
 # Test parallel installation capabilities
-ccpm install --help | grep max-parallel
+agpm install --help | grep max-parallel
 ```
 
-## Updating CCPM
+## Updating AGPM
 
 ### Via Cargo
 ```bash
 # Update to latest stable version
-cargo install ccpm --force
+cargo install agpm --force
 
 # Update to latest development version
-cargo install --git https://github.com/aig787/ccpm.git --force
+cargo install --git https://github.com/aig787/agpm.git --force
 ```
 
 ### Manual Update
@@ -248,16 +248,16 @@ Download the latest release and replace the existing binary.
 
 ### Via Cargo
 ```bash
-cargo uninstall ccpm
+cargo uninstall agpm
 ```
 
 ### Manual Uninstall
 ```bash
 # Unix/macOS
-sudo rm /usr/local/bin/ccpm
+sudo rm /usr/local/bin/agpm
 
 # Windows
-Remove-Item "$env:LOCALAPPDATA\ccpm\bin\ccpm.exe"
+Remove-Item "$env:LOCALAPPDATA\agpm\bin\agpm.exe"
 ```
 
 ## Troubleshooting Installation
@@ -268,17 +268,17 @@ Remove-Item "$env:LOCALAPPDATA\ccpm\bin\ccpm.exe"
 
 **Unix/macOS:**
 ```bash
-# Check if ccpm is in PATH
-which ccpm
+# Check if agpm is in PATH
+which agpm
 
 # Add to PATH in ~/.bashrc or ~/.zshrc
-export PATH="$PATH:/path/to/ccpm"
+export PATH="$PATH:/path/to/agpm"
 ```
 
 **Windows:**
 ```powershell
-# Check if ccpm is in PATH
-where.exe ccpm
+# Check if agpm is in PATH
+where.exe agpm
 
 # View current PATH
 $env:Path -split ';'
@@ -291,10 +291,10 @@ $env:Path -split ';'
 **Unix/macOS:**
 ```bash
 # Make executable
-chmod +x ccpm
+chmod +x agpm
 
 # Use sudo for system directories
-sudo cp ccpm /usr/local/bin/
+sudo cp agpm /usr/local/bin/
 ```
 
 **Windows:**
@@ -338,7 +338,7 @@ sudo yum install git
 
 ### Long Path Support
 
-CCPM handles long paths automatically, but you may need to enable system support:
+AGPM handles long paths automatically, but you may need to enable system support:
 
 ```powershell
 # Enable long paths (requires admin)
@@ -348,9 +348,9 @@ New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" `
 
 ### Antivirus Software
 
-Some antivirus software may flag or slow down CCPM operations. Consider:
-- Adding CCPM to your antivirus exclusion list
-- Excluding `~/.ccpm/cache/` directory from real-time scanning
+Some antivirus software may flag or slow down AGPM operations. Consider:
+- Adding AGPM to your antivirus exclusion list
+- Excluding `~/.agpm/cache/` directory from real-time scanning
 
 ## Next Steps
 

--- a/docs/manifest-reference.md
+++ b/docs/manifest-reference.md
@@ -1,6 +1,6 @@
 # Manifest Reference
 
-This guide summarizes every field that appears in `ccpm.toml` and how CLI inputs map to the manifest schema. Use it alongside the command reference when editing manifests manually or generating them with `ccpm add`.
+This guide summarizes every field that appears in `agpm.toml` and how CLI inputs map to the manifest schema. Use it alongside the command reference when editing manifests manually or generating them with `agpm add`.
 
 ## Manifest Layout
 
@@ -30,7 +30,7 @@ Each resource table maps a dependency name (key) to either a simple string path 
 | --- | --- | --- | --- | --- |
 | `source` | Only for Git resources | agents/snippets/commands/scripts/hooks/mcp-servers | Name from `[sources]`; omit for local filesystem paths. | Parsed from the `source:` prefix (e.g., `community:...`). |
 | `path` | Yes | All | File path inside the repo (Git) or filesystem path/glob (local). Patterns are detected by `*`, `?`, or `[]`. | Parsed from the middle portion of the spec. |
-| `version` | Default `"main"` for Git | Git resources | Tag, semantic range, `latest`, or branch alias. Used when no explicit `branch`/`rev` are provided. | Parsed from `@value` when using `ccpm add dep`. Defaults to `main` if omitted. |
+| `version` | Default `"main"` for Git | Git resources | Tag, semantic range, `latest`, or branch alias. Used when no explicit `branch`/`rev` are provided. | Parsed from `@value` when using `agpm add dep`. Defaults to `main` if omitted. |
 | `branch` | No | Git resources | Track a branch tip. Overrides `version` when present. Requires manual manifest edit today. | Add manually: `{ branch = "develop" }`. |
 | `rev` | No | Git resources | Exact commit SHA (short or full). Highest precedence when set. | Add manually; not provided by current CLI shorthand. |
 | `command` | MCP servers | MCP | Launch command (e.g., `npx`, `uvx`). | Use inline table or edit manifest. |
@@ -39,7 +39,7 @@ Each resource table maps a dependency name (key) to either a simple string path 
 | `filename` | Optional | All | Force output filename (with extension). | Manual edit. |
 | `dependencies` | Auto-generated | All | Extracted transitive dependencies from resource metadata. Do not edit by hand. | Populated during install. |
 
-> **Priority rules**: `rev` (commit) overrides `branch`, which overrides `version`. If you set multiple selectors, CCPM picks the most specific one.
+> **Priority rules**: `rev` (commit) overrides `branch`, which overrides `version`. If you set multiple selectors, AGPM picks the most specific one.
 
 ### CLI Spec → Manifest Examples
 
@@ -61,7 +61,7 @@ pinned  = { source = "community", path = "agents/dev.md", rev = "abc123def" }
 
 - Specify glob characters (`*`, `?`, `[]`, `**`) in `path` to install multiple files.
 - Provide a descriptive dependency name (`ai-agents`, `all-snippets`) so lockfile entries are easy to read.
-- CCPM expands the pattern during install and records every concrete match in `ccpm.lock` under the resolved dependency, using `resource_type/name@resolved_version` entries.
+- AGPM expands the pattern during install and records every concrete match in `agpm.lock` under the resolved dependency, using `resource_type/name@resolved_version` entries.
 - Conflicts are detected after expansion—if two patterns resolve to the same install location, the install fails with a duplicate-path error (see the conflicts section for remediation guidance).
 
 ## Targets and Naming Overrides
@@ -74,6 +74,6 @@ pinned  = { source = "community", path = "agents/dev.md", rev = "abc123def" }
 
 ## Recommended Workflow
 
-1. Use `ccpm add dep` for initial entries—this ensures naming and defaults are correct.
+1. Use `agpm add dep` for initial entries—this ensures naming and defaults are correct.
 2. Edit the generated inline table when you need advanced selectors (`branch`, `rev`), custom install paths, or MCP launch commands.
-3. Re-run `ccpm install` (or `ccpm validate --resolve`) after manual edits to confirm the manifest parses and resolves correctly.
+3. Re-run `agpm install` (or `agpm validate --resolve`) after manual edits to confirm the manifest parses and resolves correctly.

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -187,7 +187,7 @@ After installation, `.mcp.json` contains both user and AGPM-managed servers:
         "--root",
         "./data"
       ],
-      "_ccpm": {
+      "_agpm": {
         "managed": true,
         "config_file": ".claude/agpm/mcp-servers/filesystem.json",
         "installed_at": "2024-01-15T10:30:00Z"

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -1,6 +1,6 @@
 # Resources Guide
 
-CCPM manages six types of resources for Claude Code, divided into two categories based on how they're integrated.
+AGPM manages six types of resources for Claude Code, divided into two categories based on how they're integrated.
 
 ## Resource Categories
 
@@ -15,7 +15,7 @@ These resources are copied directly to their target directories and used as stan
 
 ### Configuration-Merged Resources
 
-These resources are installed to `.claude/ccpm/` and then their configurations are merged into Claude Code's settings:
+These resources are installed to `.claude/agpm/` and then their configurations are merged into Claude Code's settings:
 
 - **Hooks** - Event-based automation
 - **MCP Servers** - Model Context Protocol servers
@@ -28,7 +28,7 @@ AI assistant configurations with prompts and behavioral definitions.
 
 **Default Location**: `.claude/agents/`
 
-**Path Preservation**: CCPM preserves the source directory structure during installation.
+**Path Preservation**: AGPM preserves the source directory structure during installation.
 
 **Examples**:
 ```toml
@@ -50,7 +50,7 @@ local-agent = { path = "../local-agents/ai/helper.md" }  # → .claude/agents/ai
 
 Reusable code templates and documentation fragments.
 
-**Default Location**: `.claude/ccpm/snippets/`
+**Default Location**: `.claude/agpm/snippets/`
 
 **Example**:
 ```toml
@@ -76,7 +76,7 @@ lint = { source = "tools", path = "commands/lint.md", branch = "main" }
 
 Executable files (.sh, .js, .py, etc.) that can be run by hooks or independently.
 
-**Default Location**: `.claude/ccpm/scripts/`
+**Default Location**: `.claude/agpm/scripts/`
 
 **Example**:
 ```toml
@@ -92,7 +92,7 @@ Scripts must be executable and can be written in any language supported by your 
 
 Event-based automation configurations for Claude Code. JSON files that define when to run scripts.
 
-**Default Location**: `.claude/ccpm/hooks/`
+**Default Location**: `.claude/agpm/hooks/`
 **Configuration**: Automatically merged into `.claude/settings.local.json`
 
 #### Hook Structure
@@ -102,7 +102,7 @@ Event-based automation configurations for Claude Code. JSON files that define wh
   "events": ["PreToolUse"],
   "matcher": "Bash|Write|Edit",
   "type": "command",
-  "command": ".claude/ccpm/scripts/security-check.sh",
+  "command": ".claude/agpm/scripts/security-check.sh",
   "timeout": 5000,
   "description": "Security validation before file operations"
 }
@@ -128,7 +128,7 @@ file-guard = { source = "security-tools", path = "hooks/file-guard.json", versio
 
 Model Context Protocol servers that extend Claude Code's capabilities with external tools and APIs.
 
-**Default Location**: `.claude/ccpm/mcp-servers/`
+**Default Location**: `.claude/agpm/mcp-servers/`
 **Configuration**: Automatically merged into `.mcp.json`
 
 #### MCP Server Structure
@@ -163,14 +163,14 @@ postgres = { source = "local-deps", path = "mcp-servers/postgres.json" }
 
 Configuration-merged resources (Hooks and MCP Servers) follow a two-step process:
 
-1. **File Installation**: JSON configuration files are installed to `.claude/ccpm/`
+1. **File Installation**: JSON configuration files are installed to `.claude/agpm/`
 2. **Configuration Merging**: Settings are automatically merged into Claude Code's configuration files
-3. **Non-destructive Updates**: CCPM preserves user-configured entries while managing its own
-4. **Tracking**: CCPM adds metadata to track which entries it manages
+3. **Non-destructive Updates**: AGPM preserves user-configured entries while managing its own
+4. **Tracking**: AGPM adds metadata to track which entries it manages
 
 ### Example: Merged .mcp.json
 
-After installation, `.mcp.json` contains both user and CCPM-managed servers:
+After installation, `.mcp.json` contains both user and AGPM-managed servers:
 
 ```json
 {
@@ -189,7 +189,7 @@ After installation, `.mcp.json` contains both user and CCPM-managed servers:
       ],
       "_ccpm": {
         "managed": true,
-        "config_file": ".claude/ccpm/mcp-servers/filesystem.json",
+        "config_file": ".claude/agpm/mcp-servers/filesystem.json",
         "installed_at": "2024-01-15T10:30:00Z"
       }
     }
@@ -201,7 +201,7 @@ After installation, `.mcp.json` contains both user and CCPM-managed servers:
 
 ### Path Preservation
 
-CCPM preserves the source directory structure during installation. Files are named based on their source path, maintaining the original organization:
+AGPM preserves the source directory structure during installation. Files are named based on their source path, maintaining the original organization:
 
 ```toml
 [agents]
@@ -241,11 +241,11 @@ Override default installation directories for all resources of a type:
 ```toml
 [target]
 agents = ".claude/agents"           # Default
-snippets = ".claude/ccpm/snippets"  # Default
+snippets = ".claude/agpm/snippets"  # Default
 commands = ".claude/commands"        # Default
-scripts = ".claude/ccpm/scripts"    # Default
-hooks = ".claude/ccpm/hooks"        # Default
-mcp-servers = ".claude/ccpm/mcp-servers"  # Default
+scripts = ".claude/agpm/scripts"    # Default
+hooks = ".claude/agpm/hooks"        # Default
+mcp-servers = ".claude/agpm/mcp-servers"  # Default
 
 # Or use custom paths
 agents = "custom/agents"
@@ -295,11 +295,11 @@ reviewer = {
 
 ## Version Control Strategy
 
-By default, CCPM creates `.gitignore` entries to exclude installed files from Git:
+By default, AGPM creates `.gitignore` entries to exclude installed files from Git:
 
-- The `ccpm.toml` manifest and `ccpm.lock` lockfile are committed
+- The `agpm.toml` manifest and `agpm.lock` lockfile are committed
 - Installed resource files are automatically gitignored
-- Team members run `ccpm install` to get their own copies
+- Team members run `agpm install` to get their own copies
 
 To commit resources to Git instead:
 
@@ -326,13 +326,13 @@ review-tools = { source = "community", path = "agents/**/review*.md", version = 
 
 [snippets]
 # All Python snippets - directory structure preserved
-# snippets/python/utils.md → .claude/ccpm/snippets/python/utils.md
-# snippets/python/helpers.md → .claude/ccpm/snippets/python/helpers.md
+# snippets/python/utils.md → .claude/agpm/snippets/python/utils.md
+# snippets/python/helpers.md → .claude/agpm/snippets/python/helpers.md
 python-snippets = { source = "community", path = "snippets/python/*.md", version = "v1.0.0" }
 
 # Multiple nested directories
-# snippets/web/react/hooks.md → .claude/ccpm/snippets/web/react/hooks.md
-# snippets/web/vue/composables.md → .claude/ccpm/snippets/web/vue/composables.md
+# snippets/web/react/hooks.md → .claude/agpm/snippets/web/react/hooks.md
+# snippets/web/vue/composables.md → .claude/agpm/snippets/web/vue/composables.md
 web-snippets = { source = "community", path = "snippets/web/**/*.md", version = "v1.0.0" }
 ```
 
@@ -372,6 +372,6 @@ web-snippets = { source = "community", path = "snippets/web/**/*.md", version = 
 
 ### Configuration Not Merging
 
-- Run `ccpm install` again to re-merge configurations
+- Run `agpm install` again to re-merge configurations
 - Check for syntax errors in JSON files
-- Ensure CCPM has write permissions to config files
+- Ensure AGPM has write permissions to config files

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,26 +8,26 @@ This guide covers common issues and their solutions.
 
 **Unix/macOS:**
 ```bash
-# Check if ccpm is in PATH
-which ccpm
+# Check if agpm is in PATH
+which agpm
 
 # Add to PATH in ~/.bashrc or ~/.zshrc
-export PATH="$PATH:/path/to/ccpm"
+export PATH="$PATH:/path/to/agpm"
 ```
 
 **Windows:**
 ```powershell
-# Check if ccpm is in PATH
-where.exe ccpm
+# Check if agpm is in PATH
+where.exe agpm
 
 # View current PATH
 $env:Path -split ';'
 
 # Add to PATH for current session
-$env:Path += ";$env:LOCALAPPDATA\ccpm\bin"
+$env:Path += ";$env:LOCALAPPDATA\agpm\bin"
 
 # Add to PATH permanently
-[Environment]::SetEnvironmentVariable("Path", $env:Path + ";$env:LOCALAPPDATA\ccpm\bin", [EnvironmentVariableTarget]::User)
+[Environment]::SetEnvironmentVariable("Path", $env:Path + ";$env:LOCALAPPDATA\agpm\bin", [EnvironmentVariableTarget]::User)
 ```
 
 ### Permission Denied
@@ -35,10 +35,10 @@ $env:Path += ";$env:LOCALAPPDATA\ccpm\bin"
 **Unix/macOS:**
 ```bash
 # Make executable
-chmod +x ccpm
+chmod +x agpm
 
 # Use sudo for system directories
-sudo cp ccpm /usr/local/bin/
+sudo cp agpm /usr/local/bin/
 ```
 
 **Windows:**
@@ -80,10 +80,10 @@ xcode-select --install
 
 ```bash
 # Initialize a new project
-ccpm init
+agpm init
 
 # Or specify manifest path
-ccpm install --manifest-path ./path/to/ccpm.toml
+agpm install --manifest-path ./path/to/agpm.toml
 ```
 
 ## Dependency Issues
@@ -92,30 +92,30 @@ ccpm install --manifest-path ./path/to/ccpm.toml
 
 ```bash
 # Check for conflicts
-ccpm validate --resolve
+agpm validate --resolve
 
 # View detailed resolution
-RUST_LOG=debug ccpm validate --resolve
+RUST_LOG=debug agpm validate --resolve
 ```
 
 **Common solutions:**
-- Widen version constraints in ccpm.toml
+- Widen version constraints in agpm.toml
 - Use exact versions to pin dependencies
 - Check if sources have compatible versions
 
 ### Lockfile Out of Sync
 
-- Check the exact staleness reason with `ccpm validate --check-lock`.
-- Rerun `ccpm install` to regenerate the lockfile; the resolver keeps existing versions unless the manifest or upstream reference changed.
-- Remove `ccpm.lock` only when you intentionally want a clean rebuild (e.g., recovering from manual edits or corruption).
+- Check the exact staleness reason with `agpm validate --check-lock`.
+- Rerun `agpm install` to regenerate the lockfile; the resolver keeps existing versions unless the manifest or upstream reference changed.
+- Remove `agpm.lock` only when you intentionally want a clean rebuild (e.g., recovering from manual edits or corruption).
 
 ```bash
 # Regenerate lockfile in place
-ccpm install
+agpm install
 
 # Last resort: rebuild from scratch
-rm ccpm.lock
-ccpm install
+rm agpm.lock
+agpm install
 ```
 
 ### Dependency Not Found
@@ -150,7 +150,7 @@ ssh-add ~/.ssh/id_rsa
 **HTTPS Token Issues:**
 ```bash
 # Verify token in global config
-ccpm config show
+agpm config show
 
 # Test git access directly
 git ls-remote https://token@github.com/org/repo.git
@@ -160,14 +160,14 @@ git ls-remote https://token@github.com/org/repo.git
 
 ```bash
 # Update token
-ccpm config edit
+agpm config edit
 
 # Or use command
-ccpm config add-source private "https://oauth2:NEW_TOKEN@github.com/org/repo.git"
+agpm config add-source private "https://oauth2:NEW_TOKEN@github.com/org/repo.git"
 
 # Clear cache and retry
-ccpm cache clean --all
-ccpm install --no-cache
+agpm cache clean --all
+agpm install --no-cache
 ```
 
 ## Cache Issues
@@ -176,29 +176,29 @@ ccpm install --no-cache
 
 ```bash
 # Clean specific source
-ccpm cache clean
+agpm cache clean
 
 # Clear entire cache (including worktrees)
-ccpm cache clean --all
+agpm cache clean --all
 
 # Bypass cache
-ccpm install --no-cache
+agpm install --no-cache
 
 # Clean only worktrees (keep bare repositories)
-ccpm cache clean --worktrees
+agpm cache clean --worktrees
 ```
 
 ### Disk Space
 
 ```bash
 # Check cache size
-ccpm cache info
+agpm cache info
 
 # Clean unused entries
-ccpm cache clean
+agpm cache clean
 
 # Change cache location
-# Edit ~/.ccpm/config.toml
+# Edit ~/.agpm/config.toml
 [settings]
 cache_dir = "/larger/disk/cache"
 ```
@@ -209,14 +209,14 @@ cache_dir = "/larger/disk/cache"
 
 **Check permissions:**
 ```bash
-ls -la .claude/ccpm/scripts/
-chmod +x .claude/ccpm/scripts/*.sh
+ls -la .claude/agpm/scripts/
+chmod +x .claude/agpm/scripts/*.sh
 ```
 
 **Check interpreter:**
 ```bash
 # Verify shebang line
-head -1 .claude/ccpm/scripts/script.sh
+head -1 .claude/agpm/scripts/script.sh
 
 # Check if interpreter exists
 which bash
@@ -231,7 +231,7 @@ which python3
 cat .claude/settings.local.json | grep "hook-name"
 
 # Check hook file exists
-ls .claude/ccpm/hooks/
+ls .claude/agpm/hooks/
 ```
 
 **Debug hooks:**
@@ -284,7 +284,7 @@ New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" `
 git config --global core.autocrlf true
 
 # Convert existing files
-dos2unix .claude/ccpm/scripts/*.sh
+dos2unix .claude/agpm/scripts/*.sh
 ```
 
 ### macOS Gatekeeper
@@ -293,7 +293,7 @@ If macOS blocks the binary:
 
 ```bash
 # Remove quarantine attribute
-xattr -d com.apple.quarantine ccpm
+xattr -d com.apple.quarantine agpm
 
 # Or allow in System Preferences > Security & Privacy
 ```
@@ -302,11 +302,11 @@ xattr -d com.apple.quarantine ccpm
 
 ```bash
 # Fix ownership
-sudo chown -R $USER:$USER ~/.ccpm
+sudo chown -R $USER:$USER ~/.agpm
 
 # Fix permissions
-chmod -R u+rw ~/.ccpm
-find ~/.ccpm -type d -exec chmod u+x {} \;
+chmod -R u+rw ~/.agpm
+find ~/.agpm -type d -exec chmod u+x {} \;
 ```
 
 ## Worktree Issues
@@ -316,26 +316,26 @@ find ~/.ccpm -type d -exec chmod u+x {} \;
 **Concurrent access conflicts:**
 ```bash
 # Check for existing worktrees
-ls ~/.ccpm/cache/worktrees/
+ls ~/.agpm/cache/worktrees/
 
 # Clean stale worktrees
-ccpm cache clean --worktrees
+agpm cache clean --worktrees
 
 # Retry with fresh worktrees
-ccpm install --no-cache
+agpm install --no-cache
 ```
 
 **Bare repository issues:**
 ```bash
 # Verify bare repository exists
-ls ~/.ccpm/cache/sources/
+ls ~/.agpm/cache/sources/
 
 # Check if bare repo has refs
-git --git-dir ~/.ccpm/cache/sources/repo.git show-ref
+git --git-dir ~/.agpm/cache/sources/repo.git show-ref
 
 # Re-clone if corrupted
-ccpm cache clean --source repo-name
-ccpm install
+agpm cache clean --source repo-name
+agpm install
 ```
 
 ### Parallel Installation Problems
@@ -346,10 +346,10 @@ ccpm install
 top -n1 | grep "load average"
 
 # Reduce parallelism
-ccpm install --max-parallel 2
+agpm install --max-parallel 2
 
 # Monitor Git operations
-RUST_LOG="ccpm::git=debug" ccpm install
+RUST_LOG="agpm::git=debug" agpm install
 ```
 
 **Git semaphore exhaustion:**
@@ -360,21 +360,21 @@ sysctl -n hw.ncpu  # macOS
 echo $NUMBER_OF_PROCESSORS  # Windows
 
 # Force sequential operations
-ccpm install --max-parallel 1
+agpm install --max-parallel 1
 ```
 
 ## SHA-Based Optimization Issues
 
-CCPM v0.3.2+ uses centralized version resolution and SHA-based worktrees for optimal performance. Here are common issues:
+AGPM v0.3.2+ uses centralized version resolution and SHA-based worktrees for optimal performance. Here are common issues:
 
 ### Version Resolution Failures
 
 ```bash
 # Check if version constraint is valid
-ccpm validate --resolve
+agpm validate --resolve
 
 # Debug version resolution
-RUST_LOG="ccpm::resolver::version_resolver=debug" ccpm install
+RUST_LOG="agpm::resolver::version_resolver=debug" agpm install
 
 # Check available tags in repository
 git ls-remote --tags https://github.com/org/repo.git
@@ -384,33 +384,33 @@ git ls-remote --tags https://github.com/org/repo.git
 
 ```bash
 # Clean resolved SHA cache
-ccpm cache clean --all
+agpm cache clean --all
 
 # Force fresh resolution
-ccpm install --no-cache
+agpm install --no-cache
 
 # Verify repository integrity
-ccpm cache list
+agpm cache list
 ```
 
 ### Worktree Deduplication Issues
 
 ```bash
 # Check if worktrees are being reused properly
-ls ~/.ccpm/cache/worktrees/
+ls ~/.agpm/cache/worktrees/
 
 # View worktree reuse in logs
-RUST_LOG="ccpm::cache=debug" ccpm install
+RUST_LOG="agpm::cache=debug" agpm install
 
 # Clean stale SHA-based worktrees
-ccpm cache clean --worktrees
+agpm cache clean --worktrees
 ```
 
 ### Constraint Resolution Problems
 
 ```bash
 # Test constraint manually
-ccpm validate --resolve
+agpm validate --resolve
 
 # Check for complex constraints that might fail
 # Example: version = ">=1.0.0, <2.0.0, !=1.5.0"
@@ -428,27 +428,27 @@ ccpm validate --resolve
 ping github.com
 
 # Use parallel operations with worktrees
-ccpm install --max-parallel 8
+agpm install --max-parallel 8
 
 # Use cache (worktrees reuse bare repos)
-ccpm install  # Second run uses cache
+agpm install  # Second run uses cache
 
 # Check worktree overhead
-RUST_LOG="ccpm::cache=debug" ccpm install
+RUST_LOG="agpm::cache=debug" agpm install
 ```
 
 ### High Memory Usage
 
 ```bash
 # Limit parallelism (reduces concurrent worktrees)
-ccpm install --max-parallel 2
+agpm install --max-parallel 2
 
 # Clean cache and worktrees regularly
-ccpm cache clean
-ccpm cache clean --worktrees
+agpm cache clean
+agpm cache clean --worktrees
 
 # Monitor worktree count
-find ~/.ccpm/cache/worktrees/ -maxdepth 1 -type d | wc -l
+find ~/.agpm/cache/worktrees/ -maxdepth 1 -type d | wc -l
 ```
 
 ## Debugging
@@ -457,19 +457,19 @@ find ~/.ccpm/cache/worktrees/ -maxdepth 1 -type d | wc -l
 
 ```bash
 # Verbose output
-RUST_LOG=debug ccpm install
+RUST_LOG=debug agpm install
 
 # Focus on Git operations
-RUST_LOG="ccpm::git=debug" ccpm install
+RUST_LOG="agpm::git=debug" agpm install
 
 # Focus on cache operations
-RUST_LOG="ccpm::cache=debug" ccpm install
+RUST_LOG="agpm::cache=debug" agpm install
 
 # Trace-level logging
-RUST_LOG=trace ccpm install
+RUST_LOG=trace agpm install
 
 # Log to file
-RUST_LOG=debug ccpm install 2> debug.log
+RUST_LOG=debug agpm install 2> debug.log
 ```
 
 ### Check Git Operations
@@ -478,7 +478,7 @@ RUST_LOG=debug ccpm install 2> debug.log
 # Test git commands directly
 GIT_TRACE=1 git clone https://github.com/org/repo.git
 
-# Test bare clone (CCPM method)
+# Test bare clone (AGPM method)
 GIT_TRACE=1 git clone --bare https://github.com/org/repo.git /tmp/test.git
 
 # Test worktree creation
@@ -496,13 +496,13 @@ git --version  # Should be >= 2.5
 
 ```bash
 # Check manifest syntax
-ccpm validate
+agpm validate
 
 # Check with resolution
-ccpm validate --resolve
+agpm validate --resolve
 
 # Check lockfile consistency
-ccpm validate --check-lock
+agpm validate --check-lock
 ```
 
 ## Getting Help
@@ -510,10 +510,10 @@ ccpm validate --check-lock
 If you're still having issues:
 
 1. Check the [FAQ](faq.md)
-2. Search [existing issues](https://github.com/aig787/ccpm/issues)
-3. Create a [new issue](https://github.com/aig787/ccpm/issues/new) with:
-   - CCPM version: `ccpm --version`
+2. Search [existing issues](https://github.com/aig787/agpm/issues)
+3. Create a [new issue](https://github.com/aig787/agpm/issues/new) with:
+   - AGPM version: `agpm --version`
    - Platform: Windows/macOS/Linux
    - Error message
-   - Debug output: `RUST_LOG=debug ccpm [command]`
+   - Debug output: `RUST_LOG=debug agpm [command]`
    - Relevant config files (remove sensitive data)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,6 +1,6 @@
 # User Guide
 
-This guide will help you get started with CCPM and cover common workflows.
+This guide will help you get started with AGPM and cover common workflows.
 
 ## Getting Started
 
@@ -12,14 +12,14 @@ This guide will help you get started with CCPM and cover common workflows.
 
 ### Installation
 
-The quickest way to install CCPM:
+The quickest way to install AGPM:
 
 ```bash
 # If you have Rust installed
-cargo install ccpm
+cargo install agpm
 
 # For latest development version
-cargo install --git https://github.com/aig787/ccpm.git
+cargo install --git https://github.com/aig787/agpm.git
 
 # Or download pre-built binaries
 # See the Installation Guide for platform-specific instructions
@@ -30,38 +30,38 @@ cargo install --git https://github.com/aig787/ccpm.git
 1. **Initialize a new project:**
 
 ```bash
-ccpm init
+agpm init
 ```
 
-This creates a basic `ccpm.toml` file with example dependencies.
+This creates a basic `agpm.toml` file with example dependencies.
 
 2. **Install dependencies:**
 
 ```bash
-ccpm install
+agpm install
 ```
 
 This will:
-- Clone the required Git repositories to `~/.ccpm/cache/`
+- Clone the required Git repositories to `~/.agpm/cache/`
 - Copy resources to your project directories
-- Generate a `ccpm.lock` file with exact versions
+- Generate a `agpm.lock` file with exact versions
 
 3. **Verify installation:**
 
 ```bash
-ccpm list
+agpm list
 ```
 
 ## Basic Concepts
 
-### Manifest File (ccpm.toml)
+### Manifest File (agpm.toml)
 
 The manifest defines your project's dependencies:
 
 ```toml
 [sources]
 # Define Git repositories to pull resources from
-community = "https://github.com/aig787/ccpm-community.git"
+community = "https://github.com/aig787/agpm-community.git"
 
 [agents]
 # Install AI agents - path preservation maintains directory structure
@@ -74,28 +74,28 @@ nested = { source = "community", path = "agents/ai/helper.md", version = "v1.0.0
 
 See the [Manifest Reference](manifest-reference.md) for a complete field-by-field breakdown and CLI mapping guidance.
 
-### Lockfile (ccpm.lock)
+### Lockfile (agpm.lock)
 
 The lockfile records exact versions for reproducible installations:
-- Generated automatically by `ccpm install`
+- Generated automatically by `agpm install`
 - Should be committed to version control
 - Ensures team members get identical versions
 
 #### Lifecycle and Guarantees
 
-- `ccpm install` always re-runs dependency resolution using the current manifest and lockfile. If nothing has changed, it writes the same resolved versions and SHAs back to disk—versions do **not** automatically advance just because you reinstalled.
+- `agpm install` always re-runs dependency resolution using the current manifest and lockfile. If nothing has changed, it writes the same resolved versions and SHAs back to disk—versions do **not** automatically advance just because you reinstalled.
 - Resolution only diverges when the manifest changed, a tag/branch now points somewhere else, or a dependency was missing from the previous lockfile.
-- Use `ccpm install --no-lock` when you want to verify installs without touching `ccpm.lock` (e.g., local experiments).
-- Use `ccpm install --frozen` in CI or release pipelines to assert that the existing lockfile matches the manifest exactly. The command fails instead of regenerating when staleness is detected.
+- Use `agpm install --no-lock` when you want to verify installs without touching `agpm.lock` (e.g., local experiments).
+- Use `agpm install --frozen` in CI or release pipelines to assert that the existing lockfile matches the manifest exactly. The command fails instead of regenerating when staleness is detected.
 
 #### Detecting Staleness
 
-CCPM automatically checks for stale lockfiles during install and via `ccpm validate --check-lock`:
+AGPM automatically checks for stale lockfiles during install and via `agpm validate --check-lock`:
 - Duplicate entries or source URL drift (security-critical issues)
 - Manifest entries missing from the lockfile
 - Version/path changes that have not been resolved yet
 
-If any of these occur, rerun `ccpm install` (without `--frozen`) to regenerate the lockfile so teammates stay in sync.
+If any of these occur, rerun `agpm install` (without `--frozen`) to regenerate the lockfile so teammates stay in sync.
 
 ### Sources
 
@@ -108,7 +108,7 @@ Sources are Git repositories containing resources:
 
 ### Adding Dependencies
 
-#### Method 1: Edit ccpm.toml directly
+#### Method 1: Edit agpm.toml directly
 
 ```toml
 [agents]
@@ -117,17 +117,17 @@ my-agent = { source = "community", path = "agents/helper.md", version = "v1.0.0"
 
 Then run:
 ```bash
-ccpm install
+agpm install
 ```
 
 #### Method 2: Use CLI commands
 
 ```bash
 # Add a source
-ccpm add source community https://github.com/aig787/ccpm-community.git
+agpm add source community https://github.com/aig787/agpm-community.git
 
 # Add a dependency
-ccpm add dep agent community:agents/helper.md --name my-agent
+agpm add dep agent community:agents/helper.md --name my-agent
 ```
 
 ### Checking for Updates
@@ -136,16 +136,16 @@ Before updating, check what updates are available:
 
 ```bash
 # Check all dependencies for available updates
-ccpm outdated
+agpm outdated
 
 # Check specific dependencies
-ccpm outdated my-agent other-agent
+agpm outdated my-agent other-agent
 
 # Use in CI to fail if updates are available
-ccpm outdated --check
+agpm outdated --check
 
 # Get JSON output for automation
-ccpm outdated --format json
+agpm outdated --format json
 ```
 
 The `outdated` command shows:
@@ -159,19 +159,19 @@ The `outdated` command shows:
 Update all dependencies within version constraints:
 
 ```bash
-ccpm update
+agpm update
 ```
 
 Update specific dependency:
 
 ```bash
-ccpm update my-agent
+agpm update my-agent
 ```
 
 Preview updates without making changes:
 
 ```bash
-ccpm update --dry-run
+agpm update --dry-run
 ```
 
 ### Working with Local Resources
@@ -199,7 +199,7 @@ For private repositories, configure authentication globally:
 
 ```bash
 # Add private source with token
-ccpm config add-source private "https://oauth2:TOKEN@github.com/org/private.git"
+agpm config add-source private "https://oauth2:TOKEN@github.com/org/private.git"
 ```
 
 Then reference in your manifest:
@@ -213,7 +213,7 @@ internal = { source = "private", path = "agents/internal.md", version = "v1.0.0"
 
 ### Version Constraints
 
-CCPM supports flexible version constraints:
+AGPM supports flexible version constraints:
 
 ```toml
 # Exact version
@@ -238,19 +238,19 @@ For development, track branches:
 dev-agent = { source = "community", path = "agents/dev.md", branch = "main" }
 ```
 
-⚠️ **Note**: Branches update on each `ccpm update`. Use tags for stability.
+⚠️ **Note**: Branches update on each `agpm update`. Use tags for stability.
 
 ## Team Collaboration
 
 ### Setting Up
 
-1. Create and configure `ccpm.toml`
-2. Run `ccpm install` to generate `ccpm.lock`
+1. Create and configure `agpm.toml`
+2. Run `agpm install` to generate `agpm.lock`
 3. Commit both files to Git:
 
 ```bash
-git add ccpm.toml ccpm.lock
-git commit -m "Add CCPM dependencies"
+git add agpm.toml agpm.lock
+git commit -m "Add AGPM dependencies"
 ```
 
 ### Team Member Setup
@@ -259,41 +259,41 @@ Team members clone the repository and run:
 
 ```bash
 # Install exact versions from lockfile
-ccpm install --frozen
+agpm install --frozen
 ```
 
 ### Updating Dependencies
 
 When updating dependencies:
 
-1. Update version constraints in `ccpm.toml`
-2. Run `ccpm update`
+1. Update version constraints in `agpm.toml`
+2. Run `agpm update`
 3. Test the changes
-4. Commit the updated `ccpm.lock`
+4. Commit the updated `agpm.lock`
 
 ## CI/CD Integration
 
 ### GitHub Actions
 
 ```yaml
-- name: Install CCPM
-  run: cargo install --git https://github.com/aig787/ccpm.git
+- name: Install AGPM
+  run: cargo install --git https://github.com/aig787/agpm.git
 
 - name: Install dependencies
-  run: ccpm install --frozen
+  run: agpm install --frozen
 ```
 
 ### With Authentication
 
 ```yaml
-- name: Configure CCPM
+- name: Configure AGPM
   run: |
-    mkdir -p ~/.ccpm
-    echo '[sources]' > ~/.ccpm/config.toml
-    echo 'private = "https://oauth2:${{ secrets.GITHUB_TOKEN }}@github.com/org/private.git"' >> ~/.ccpm/config.toml
+    mkdir -p ~/.agpm
+    echo '[sources]' > ~/.agpm/config.toml
+    echo 'private = "https://oauth2:${{ secrets.GITHUB_TOKEN }}@github.com/org/private.git"' >> ~/.agpm/config.toml
 
 - name: Install dependencies
-  run: ccpm install --frozen
+  run: agpm install --frozen
 ```
 
 ## Pattern Matching
@@ -314,18 +314,18 @@ review-agents = { source = "community", path = "agents/**/review*.md", version =
 
 [snippets]
 # All Python snippets - directory structure preserved
-# snippets/python/utils.md → .claude/ccpm/snippets/python/utils.md
-# snippets/python/django/models.md → .claude/ccpm/snippets/python/django/models.md
+# snippets/python/utils.md → .claude/agpm/snippets/python/utils.md
+# snippets/python/django/models.md → .claude/agpm/snippets/python/django/models.md
 python = { source = "community", path = "snippets/python/**/*.md", version = "v1.0.0" }
 ```
 
-During `ccpm install`, CCPM expands each glob, installs every concrete match, and records them individually in `ccpm.lock` under the pattern dependency. Lockfile entries use the `resource_type/name@resolved_version` format so you can track the exact files that were installed.
+During `agpm install`, AGPM expands each glob, installs every concrete match, and records them individually in `agpm.lock` under the pattern dependency. Lockfile entries use the `resource_type/name@resolved_version` format so you can track the exact files that were installed.
 
-> **Tip**: Pair pattern entries with descriptive keys (like `ai-agents`) and review the resolved output with `ccpm list` or by inspecting `ccpm.lock` to confirm the matches.
+> **Tip**: Pair pattern entries with descriptive keys (like `ai-agents`) and review the resolved output with `agpm list` or by inspecting `agpm.lock` to confirm the matches.
 
 ## Transitive Dependencies
 
-Resources can declare their own dependencies, and CCPM will automatically resolve the entire dependency tree.
+Resources can declare their own dependencies, and AGPM will automatically resolve the entire dependency tree.
 
 ### Declaring Dependencies
 
@@ -361,7 +361,7 @@ dependencies:
 
 ### How It Works
 
-1. **Automatic Discovery**: When installing resources, CCPM scans their contents for dependency declarations
+1. **Automatic Discovery**: When installing resources, AGPM scans their contents for dependency declarations
 2. **Graph Building**: All dependencies (direct and transitive) are collected into a dependency graph
 3. **Cycle Detection**: Circular dependencies are detected and reported as errors
 4. **Topological Ordering**: Dependencies are installed before their dependents
@@ -376,9 +376,9 @@ Transitive dependencies inherit properties from their parent:
 ### Example
 
 ```toml
-# ccpm.toml
+# agpm.toml
 [sources]
-community = "https://github.com/aig787/ccpm-community.git"
+community = "https://github.com/aig787/agpm-community.git"
 
 [commands]
 deploy = { source = "community", path = "commands/deploy.md", version = "v1.0.0" }
@@ -396,7 +396,7 @@ dependencies:
 ---
 ```
 
-Running `ccpm install` will automatically install:
+Running `agpm install` will automatically install:
 1. `deploy.md` (direct dependency)
 2. `agents/deploy-helper.md` (transitive, inherits v1.0.0)
 3. `snippets/aws-utils.md` (transitive, uses v2.0.0)
@@ -405,11 +405,11 @@ Running `ccpm install` will automatically install:
 
 - **Scripts & hooks**: Transitive scripts inherit the parent's source but still require executable permissions. Hooks declared in metadata merge into `.claude/settings.local.json`; use `target` or `filename` overrides in the manifest if two hooks would collide.
 - **MCP servers**: Transitive MCP definitions inherit `command`/`args` from the file itself. Edit the manifest entry if you need to override runtime arguments.
-- **Version overrides**: If a downstream resource needs a different version than its parent, specify `version:` in the resource metadata. CCPM will prioritize the explicit value over inheritance.
+- **Version overrides**: If a downstream resource needs a different version than its parent, specify `version:` in the resource metadata. AGPM will prioritize the explicit value over inheritance.
 
 ### Lockfile Tracking
 
-Transitive dependencies are tracked in `ccpm.lock`:
+Transitive dependencies are tracked in `agpm.lock`:
 ```toml
 [[commands]]
 name = "deploy"
@@ -423,7 +423,7 @@ dependencies = [
 
 ### Conflict Resolution
 
-When multiple resources depend on the same resource, CCPM attempts to converge on a single version:
+When multiple resources depend on the same resource, AGPM attempts to converge on a single version:
 - Compatible constraints resolve to the highest satisfying tag and the decision is logged in the CLI output.
 - Incompatible constraints (`v1` vs `v2` with no overlap) make the install fail with a detailed error.
 - Duplicate install paths (for example, two patterns resolving to `.claude/agents/reviewer.md`) also trigger a hard error.
@@ -438,12 +438,12 @@ Error: Version conflict for agents/helper.md
 ```
 
 **Troubleshooting steps:**
-1. Run `ccpm validate --resolve --format json` to see the dependency graph CCPM built.
+1. Run `agpm validate --resolve --format json` to see the dependency graph AGPM built.
 2. If the conflict is transitive, update the declaring resource's metadata to pin a specific `version` or fork the dependency.
-3. If it is direct, align your manifest constraints (e.g., bump both to `v2.0.0`) and run `ccpm install` to auto-update the lockfile.
+3. If it is direct, align your manifest constraints (e.g., bump both to `v2.0.0`) and run `agpm install` to auto-update the lockfile.
 4. For duplicate install paths, add `filename` or `target` overrides so the files land in distinct locations.
 
-After making changes, re-run `ccpm install` to refresh `ccpm.lock`. Use `RUST_LOG=debug` when you need the full resolver trace.
+After making changes, re-run `agpm install` to refresh `agpm.lock`. Use `RUST_LOG=debug` when you need the full resolver trace.
 
 ## Resource Organization
 
@@ -452,11 +452,11 @@ After making changes, re-run `ccpm install` to refresh `ccpm.lock`. Use `RUST_LO
 Resources are installed to these default locations, with source directory structure preserved:
 
 - Agents: `.claude/agents/` (e.g., `agents/ai/helper.md` → `.claude/agents/ai/helper.md`)
-- Snippets: `.claude/ccpm/snippets/` (e.g., `snippets/react/hooks.md` → `.claude/ccpm/snippets/react/hooks.md`)
+- Snippets: `.claude/agpm/snippets/` (e.g., `snippets/react/hooks.md` → `.claude/agpm/snippets/react/hooks.md`)
 - Commands: `.claude/commands/` (e.g., `commands/build/deploy.md` → `.claude/commands/build/deploy.md`)
-- Scripts: `.claude/ccpm/scripts/` (e.g., `scripts/ci/test.sh` → `.claude/ccpm/scripts/ci/test.sh`)
-- Hooks: `.claude/ccpm/hooks/`
-- MCP Servers: `.claude/ccpm/mcp-servers/`
+- Scripts: `.claude/agpm/scripts/` (e.g., `scripts/ci/test.sh` → `.claude/agpm/scripts/ci/test.sh`)
+- Hooks: `.claude/agpm/hooks/`
+- MCP Servers: `.claude/agpm/mcp-servers/`
 
 **Path Preservation**: The relative directory structure from the source repository is maintained during installation. This means:
 - `agents/example.md` → `.claude/agents/example.md`
@@ -465,7 +465,7 @@ Resources are installed to these default locations, with source directory struct
 
 ### Custom Locations
 
-Override defaults in `ccpm.toml`:
+Override defaults in `agpm.toml`:
 
 ```toml
 [target]
@@ -485,7 +485,7 @@ gitignore = false  # Don't create .gitignore
 
 ## Performance Features
 
-CCPM v0.3.2+ includes significant performance optimizations:
+AGPM v0.3.2+ includes significant performance optimizations:
 
 ### Centralized Version Resolution
 - **Batch processing**: All version constraints resolved in a single operation per repository
@@ -500,37 +500,37 @@ CCPM v0.3.2+ includes significant performance optimizations:
 ### Controlling Parallelism
 ```bash
 # Control number of parallel operations (default: max(10, 2 × CPU cores))
-ccpm install --max-parallel 8
+agpm install --max-parallel 8
 
 # Use all available cores
-ccpm install --max-parallel 0
+agpm install --max-parallel 0
 
 # Single-threaded execution for debugging
-ccpm install --max-parallel 1
+agpm install --max-parallel 1
 ```
 
 ### Cache Management
 ```bash
 # View cache statistics
-ccpm cache list
+agpm cache list
 
 # Clean old cache entries
-ccpm cache clean
+agpm cache clean
 
 # Bypass cache for fresh installation
-ccpm install --no-cache
+agpm install --no-cache
 ```
 
 ### Automatic Artifact Cleanup
 
-CCPM automatically removes old resource files when:
+AGPM automatically removes old resource files when:
 - A dependency is removed from the manifest
 - A resource's path changes in the manifest
 - A resource is renamed
 
 **Example:**
 ```toml
-# Initial ccpm.toml
+# Initial agpm.toml
 [agents]
 helper = { source = "community", path = "agents/helper.md", version = "v1.0.0" }
 # Installed as: .claude/agents/helper.md
@@ -538,13 +538,13 @@ helper = { source = "community", path = "agents/helper.md", version = "v1.0.0" }
 
 After updating the path:
 ```toml
-# Updated ccpm.toml
+# Updated agpm.toml
 [agents]
 helper = { source = "community", path = "agents/ai/helper.md", version = "v1.0.0" }
 # Now installed as: .claude/agents/ai/helper.md
 ```
 
-When you run `ccpm install`:
+When you run `agpm install`:
 1. The old file at `.claude/agents/helper.md` is automatically removed
 2. The new file is installed at `.claude/agents/ai/helper.md`
 3. Empty parent directories are cleaned up (`.claude/agents/` only if empty)
@@ -556,13 +556,13 @@ When you run `ccpm install`:
 
 ## Best Practices
 
-1. **Always commit ccpm.lock** for reproducible builds
+1. **Always commit agpm.lock** for reproducible builds
 2. **Use semantic versioning** (`v1.0.0`) instead of branches
-3. **Validate before committing**: Run `ccpm validate`
-4. **Use --frozen in production**: `ccpm install --frozen`
-5. **Keep secrets in global config**, never in `ccpm.toml`
+3. **Validate before committing**: Run `agpm validate`
+4. **Use --frozen in production**: `agpm install --frozen`
+5. **Keep secrets in global config**, never in `agpm.toml`
 6. **Document custom sources** with comments
-7. **Check for outdated dependencies** regularly: `ccpm outdated`
+7. **Check for outdated dependencies** regularly: `agpm outdated`
 8. **Test updates locally** before committing
 
 ## Troubleshooting
@@ -571,30 +571,30 @@ When you run `ccpm install`:
 
 **Manifest not found:**
 ```bash
-ccpm init  # Create a new manifest
+agpm init  # Create a new manifest
 ```
 
 **Version conflicts:**
 ```bash
-ccpm validate --resolve  # Check for conflicts
+agpm validate --resolve  # Check for conflicts
 ```
 
 **Authentication issues:**
 ```bash
-ccpm config list-sources  # Verify source configuration
+agpm config list-sources  # Verify source configuration
 ```
 
 **Lockfile out of sync:**
 ```bash
-ccpm install  # Regenerate lockfile
+agpm install  # Regenerate lockfile
 ```
 
 ### Getting Help
 
-- Run `ccpm --help` for command help
+- Run `agpm --help` for command help
 - Check the [FAQ](faq.md) for common questions
 - See [Troubleshooting Guide](troubleshooting.md) for detailed solutions
-- Visit [GitHub Issues](https://github.com/aig787/ccpm/issues) for support
+- Visit [GitHub Issues](https://github.com/aig787/agpm/issues) for support
 
 ## Next Steps
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,6 +1,6 @@
 # Versioning Guide
 
-CCPM uses Git-based versioning where version constraints apply at the repository level, not individual files. This guide explains how versioning works and best practices for managing dependencies.
+AGPM uses Git-based versioning where version constraints apply at the repository level, not individual files. This guide explains how versioning works and best practices for managing dependencies.
 
 ## Core Concepts
 
@@ -10,7 +10,7 @@ When you specify a version (e.g., `version = "v1.0.0"`), you're referencing a Gi
 
 ### Supported Version References
 
-CCPM supports multiple ways to reference specific points in a repository's history:
+AGPM supports multiple ways to reference specific points in a repository's history:
 
 - **Git Tags** (recommended): Semantic versions like `v1.0.0`, `v2.1.3`
 - **Git Branches**: Branch names like `main`, `develop`, `feature/xyz`
@@ -29,7 +29,7 @@ agent2 = { source = "community", path = "agents/agent2.md", version = "v1.0.0" }
 
 ### Semantic Version Ranges
 
-CCPM follows standard semver conventions used by Cargo and npm:
+AGPM follows standard semver conventions used by Cargo and npm:
 
 | Syntax              | Example                       | Matches              | Description           |
 |---------------------|-------------------------------|----------------------|-----------------------|
@@ -64,7 +64,7 @@ any-agent = { source = "community", path = "agents/any.md", version = "*" }
 
 ### Enhanced Constraint Support
 
-CCPM v0.3.2+ includes improved constraint parsing and resolution:
+AGPM v0.3.2+ includes improved constraint parsing and resolution:
 
 - **Complex ranges**: Support for multiple constraints with AND logic
 - **Intelligent tag matching**: Better handling of tag prefixes (v1.0.0 vs 1.0.0)
@@ -87,7 +87,7 @@ compatible-agent = { source = "community", path = "agents/helper.md", version = 
 patch-only-agent = { source = "community", path = "agents/util.md", version = "~1.2.3" }    # 1.2.3 to <1.3.0
 ```
 
-**How it works**: When CCPM resolves `version = "v1.0.0"`, it:
+**How it works**: When AGPM resolves `version = "v1.0.0"`, it:
 1. Looks for a Git tag named `v1.0.0` in the repository
 2. Checks out the repository at that tag
 3. Retrieves the specified file from that tagged state
@@ -105,7 +105,7 @@ dev-agent = { source = "community", path = "agents/dev.md", branch = "main" }
 feature-agent = { source = "community", path = "agents/new.md", branch = "feature/new-capability" }
 ```
 
-⚠️ **Important**: Branch references are mutable - they update to the latest commit each time you run `ccpm update`. Use tags for stable, reproducible builds.
+⚠️ **Important**: Branch references are mutable - they update to the latest commit each time you run `agpm update`. Use tags for stable, reproducible builds.
 
 ### Git Commit Hashes
 
@@ -144,7 +144,7 @@ direct-agent = { path = "../agents/my-agent.md" }
 
 ## Version Resolution
 
-CCPM v0.3.2+ uses a centralized, high-performance version resolution system with the VersionResolver module:
+AGPM v0.3.2+ uses a centralized, high-performance version resolution system with the VersionResolver module:
 
 ### Centralized Resolution Process
 
@@ -154,7 +154,7 @@ CCPM v0.3.2+ uses a centralized, high-performance version resolution system with
 4. **Constraint Matching**: Enhanced semver engine finds best matching tags for complex constraints
 5. **SHA Validation**: All resolved SHAs are validated as 40-character hexadecimal strings
 6. **Worktree Optimization**: SHA-based worktree creation maximizes reuse for identical commits
-7. **Lock Generation**: Record exact commit SHAs and resolved references in `ccpm.lock`
+7. **Lock Generation**: Record exact commit SHAs and resolved references in `agpm.lock`
 
 ### Enhanced Performance Benefits
 
@@ -177,14 +177,14 @@ Given available tags: `v1.0.0`, `v1.1.0`, `v1.2.0`, `v2.0.0`
 
 ## Lockfile and Reproducibility
 
-The `ccpm.lock` file ensures reproducible installations by recording exact resolution results from the VersionResolver:
+The `agpm.lock` file ensures reproducible installations by recording exact resolution results from the VersionResolver:
 
 ```toml
 [[agents]]
 name = "example-agent"
 source = "community"
 path = "agents/example.md"
-version = "^1.0.0"                    # Original constraint from ccpm.toml
+version = "^1.0.0"                    # Original constraint from agpm.toml
 resolved_commit = "abc123def456..."   # Exact commit SHA (40 characters)
 resolved_version = "v1.2.3"          # Actual tag that satisfied constraint
 ```
@@ -193,7 +193,7 @@ resolved_version = "v1.2.3"          # Actual tag that satisfied constraint
 
 With the centralized VersionResolver, the lockfile provides:
 
-- **Original constraint** (`version`): What was requested in `ccpm.toml` (e.g., `^1.0.0`)
+- **Original constraint** (`version`): What was requested in `agpm.toml` (e.g., `^1.0.0`)
 - **Resolved commit** (`resolved_commit`): Exact Git commit SHA determined by VersionResolver
 - **Resolved version** (`resolved_version`): The specific tag/branch that satisfied the constraint
 - **SHA-based reproducibility**: Same SHA always produces identical installations
@@ -201,13 +201,13 @@ With the centralized VersionResolver, the lockfile provides:
 
 ### Lockfile Staleness Checks
 
-CCPM tracks whether `ccpm.lock` still matches the manifest and the resolution rules that produced it. Both `ccpm install` and `ccpm validate --check-lock` run the same validation logic:
+AGPM tracks whether `agpm.lock` still matches the manifest and the resolution rules that produced it. Both `agpm install` and `agpm validate --check-lock` run the same validation logic:
 
 - **Always checked**: duplicate lockfile entries (corruption) and changed source URLs (security risk).
-- **Strict-mode checks** (`ccpm install`, `ccpm validate --check-lock`): missing dependencies that now exist in the manifest, version constraint changes, or path changes compared to what the lockfile previously captured.
-- **Lenient mode** (`ccpm install --frozen`): only the always-checked issues; anything else causes the command to exit instead of regenerating.
+- **Strict-mode checks** (`agpm install`, `agpm validate --check-lock`): missing dependencies that now exist in the manifest, version constraint changes, or path changes compared to what the lockfile previously captured.
+- **Lenient mode** (`agpm install --frozen`): only the always-checked issues; anything else causes the command to exit instead of regenerating.
 
-When validation reports a staleness reason, run `ccpm install` (without `--frozen`) to regenerate the lockfile. The resolver reuses prior resolutions whenever possible, so versions stay unchanged unless the manifest or upstream reference moved.
+When validation reports a staleness reason, run `agpm install` (without `--frozen`) to regenerate the lockfile. The resolver reuses prior resolutions whenever possible, so versions stay unchanged unless the manifest or upstream reference moved.
 
 ## Common Scenarios
 
@@ -261,7 +261,7 @@ Use local directories as sources without requiring Git:
 # Local directory as a source - no Git required
 local-deps = "./dependencies"
 shared-resources = "../shared-resources"
-absolute-local = "/home/user/ccpm-resources"
+absolute-local = "/home/user/agpm-resources"
 
 [agents]
 # Dependencies from local directory sources don't need versions
@@ -271,7 +271,7 @@ shared-agent = { source = "shared-resources", path = "agents/common.md" }
 
 **Security Note**: For security, local paths are restricted to:
 - Within the current project directory
-- Within the CCPM cache directory (`~/.ccpm/cache`)
+- Within the AGPM cache directory (`~/.agpm/cache`)
 - Within `/tmp` for testing
 
 ### Direct File Paths
@@ -307,13 +307,13 @@ local-branch-agent = { source = "local-repo", path = "agents/dev.md", branch = "
 1. **Use Semantic Version Tags**: Tag releases with semantic versions (`v1.0.0`, `v2.1.3`)
 2. **Prefer Tags Over Branches**: Tags are immutable; branches change over time
 3. **Use Caret Ranges**: `^1.0.0` allows compatible updates while preventing breaking changes
-4. **Lock for Production**: Commit `ccpm.lock` and use `--frozen` flag in CI/CD
+4. **Lock for Production**: Commit `agpm.lock` and use `--frozen` flag in CI/CD
 5. **Document Breaking Changes**: Use major version bumps (v1.x.x → v2.x.x) for breaking changes
-6. **Test Before Updating**: Use `ccpm update --dry-run` to preview changes
+6. **Test Before Updating**: Use `agpm update --dry-run` to preview changes
 
 ## Automated Releases
 
-CCPM itself uses [semantic-release](https://semantic-release.gitbook.io/) for automated versioning. Every push to `main` triggers:
+AGPM itself uses [semantic-release](https://semantic-release.gitbook.io/) for automated versioning. Every push to `main` triggers:
 
 1. **Commit analysis** to determine version bump based on [Conventional Commits](https://www.conventionalcommits.org/):
    - `fix:` → Patch release (0.0.X)
@@ -329,11 +329,11 @@ CCPM itself uses [semantic-release](https://semantic-release.gitbook.io/) for au
    - Pre-release support on `alpha` and `beta` branches
 
 3. **Binary Assets** available for each release:
-   - `ccpm-x86_64-linux.tar.gz` - Linux x86_64
-   - `ccpm-aarch64-linux.tar.gz` - Linux ARM64
-   - `ccpm-x86_64-macos.tar.gz` - macOS Intel
-   - `ccpm-aarch64-macos.tar.gz` - macOS Apple Silicon
-   - `ccpm-x86_64-windows.zip` - Windows x86_64
+   - `agpm-x86_64-linux.tar.gz` - Linux x86_64
+   - `agpm-aarch64-linux.tar.gz` - Linux ARM64
+   - `agpm-x86_64-macos.tar.gz` - macOS Intel
+   - `agpm-aarch64-macos.tar.gz` - macOS Apple Silicon
+   - `agpm-x86_64-windows.zip` - Windows x86_64
 
 ## Troubleshooting
 
@@ -341,21 +341,21 @@ CCPM itself uses [semantic-release](https://semantic-release.gitbook.io/) for au
 
 ```bash
 # Check for conflicts
-ccpm validate --resolve
+agpm validate --resolve
 
-# Update version constraints in ccpm.toml to resolve
+# Update version constraints in agpm.toml to resolve
 ```
 
-If no shared version exists, synchronize the manifest constraints (for example, bump every dependent to the same tag) or pin the dependency to a specific commit with `rev = "<sha>"`. You can inspect the resolver output with `ccpm validate --resolve --format json` to see which dependency introduced the incompatible requirement.
+If no shared version exists, synchronize the manifest constraints (for example, bump every dependent to the same tag) or pin the dependency to a specific commit with `rev = "<sha>"`. You can inspect the resolver output with `agpm validate --resolve --format json` to see which dependency introduced the incompatible requirement.
 
 ### Lockfile Out of Sync
 
 ```bash
 # Regenerate lockfile
-ccpm install
+agpm install
 
 # Use exact lockfile versions (no updates)
-ccpm install --frozen
+agpm install --frozen
 ```
 
 ### Finding Available Versions

--- a/examples/cleanup_project.sh
+++ b/examples/cleanup_project.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Cleanup script for CCPM example project
+# Cleanup script for AGPM example project
 # This script removes all dependencies added by setup_project.sh and cleans up the project directory
 
 set -e  # Exit on error
@@ -12,7 +12,7 @@ YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
 echo -e "${RED}╔════════════════════════════════════════════╗${NC}"
-echo -e "${RED}║     CCPM Project Cleanup Script            ║${NC}"
+echo -e "${RED}║     AGPM Project Cleanup Script            ║${NC}"
 echo -e "${RED}╚════════════════════════════════════════════╝${NC}"
 echo ""
 
@@ -30,33 +30,33 @@ if [ ! -d "$PROJECT_DIR" ]; then
     exit 0
 fi
 
-# Ensure ccpm is available
+# Ensure agpm is available
 cd "$(dirname "$SCRIPT_DIR")"
-if [ ! -f "target/release/ccpm" ]; then
-    echo "→ Building ccpm for cleanup operations"
+if [ ! -f "target/release/agpm" ]; then
+    echo "→ Building agpm for cleanup operations"
     cargo build --release
 fi
 
 # Add to PATH for this script
 export PATH="$PWD/target/release:$PATH"
 
-echo -e "${GREEN}✓ Using ccpm from: $(which ccpm)${NC}"
+echo -e "${GREEN}✓ Using agpm from: $(which agpm)${NC}"
 echo ""
 
 # Change to project directory
 cd "$PROJECT_DIR"
 
-# Check if ccpm.toml exists
-if [ ! -f "ccpm.toml" ]; then
-    echo -e "${YELLOW}→ No ccpm.toml found in project${NC}"
+# Check if agpm.toml exists
+if [ ! -f "agpm.toml" ]; then
+    echo -e "${YELLOW}→ No agpm.toml found in project${NC}"
     echo "→ Skipping dependency removal, proceeding to directory cleanup"
 else
-    echo "→ Starting cleanup of CCPM project '$PROJECT_NAME'"
+    echo "→ Starting cleanup of AGPM project '$PROJECT_NAME'"
     echo ""
     
     # List current resources before removal
     echo "→ Current installed resources:"
-    ccpm list || true
+    agpm list || true
     echo ""
     
     echo -e "${YELLOW}═══ Removing All Dependencies ═══${NC}"
@@ -64,57 +64,57 @@ else
     
     # Remove MCP servers
     echo "→ Removing MCP servers..."
-    ccpm remove dep mcp-server filesystem 2>/dev/null && echo "  ✓ Removed filesystem" || true
-    ccpm remove dep mcp-server fetch 2>/dev/null && echo "  ✓ Removed fetch" || true
+    agpm remove dep mcp-server filesystem 2>/dev/null && echo "  ✓ Removed filesystem" || true
+    agpm remove dep mcp-server fetch 2>/dev/null && echo "  ✓ Removed fetch" || true
     
     # Remove hooks
     echo ""
     echo "→ Removing hooks..."
-    ccpm remove dep hook pre-tool-use 2>/dev/null && echo "  ✓ Removed pre-tool-use" || true
-    ccpm remove dep hook user-prompt-submit 2>/dev/null && echo "  ✓ Removed user-prompt-submit" || true
+    agpm remove dep hook pre-tool-use 2>/dev/null && echo "  ✓ Removed pre-tool-use" || true
+    agpm remove dep hook user-prompt-submit 2>/dev/null && echo "  ✓ Removed user-prompt-submit" || true
     
     # Remove scripts
     echo ""
     echo "→ Removing scripts..."
-    ccpm remove dep script build 2>/dev/null && echo "  ✓ Removed build" || true
-    ccpm remove dep script test 2>/dev/null && echo "  ✓ Removed test" || true
+    agpm remove dep script build 2>/dev/null && echo "  ✓ Removed build" || true
+    agpm remove dep script test 2>/dev/null && echo "  ✓ Removed test" || true
     
     # Remove commands
     echo ""
     echo "→ Removing commands..."
-    ccpm remove dep command git-auto-commit 2>/dev/null && echo "  ✓ Removed git-auto-commit" || true
-    ccpm remove dep command format-json 2>/dev/null && echo "  ✓ Removed format-json" || true
+    agpm remove dep command git-auto-commit 2>/dev/null && echo "  ✓ Removed git-auto-commit" || true
+    agpm remove dep command format-json 2>/dev/null && echo "  ✓ Removed format-json" || true
     
     # Remove snippets
     echo ""
     echo "→ Removing snippets..."
-    ccpm remove dep snippet error-analysis 2>/dev/null && echo "  ✓ Removed error-analysis" || true
-    ccpm remove dep snippet unit-tests 2>/dev/null && echo "  ✓ Removed unit-tests" || true
-    ccpm remove dep snippet security-review 2>/dev/null && echo "  ✓ Removed security-review" || true
-    ccpm remove dep snippet rest-api 2>/dev/null && echo "  ✓ Removed rest-api" || true
-    ccpm remove dep snippet test-coverage 2>/dev/null && echo "  ✓ Removed test-coverage" || true
+    agpm remove dep snippet error-analysis 2>/dev/null && echo "  ✓ Removed error-analysis" || true
+    agpm remove dep snippet unit-tests 2>/dev/null && echo "  ✓ Removed unit-tests" || true
+    agpm remove dep snippet security-review 2>/dev/null && echo "  ✓ Removed security-review" || true
+    agpm remove dep snippet rest-api 2>/dev/null && echo "  ✓ Removed rest-api" || true
+    agpm remove dep snippet test-coverage 2>/dev/null && echo "  ✓ Removed test-coverage" || true
     
     # Remove agents
     echo ""
     echo "→ Removing agents..."
-    ccpm remove dep agent rust-haiku 2>/dev/null && echo "  ✓ Removed rust-haiku" || true
-    ccpm remove dep agent javascript-haiku 2>/dev/null && echo "  ✓ Removed javascript-haiku" || true
+    agpm remove dep agent rust-haiku 2>/dev/null && echo "  ✓ Removed rust-haiku" || true
+    agpm remove dep agent javascript-haiku 2>/dev/null && echo "  ✓ Removed javascript-haiku" || true
     
     # Remove sources (should be empty now, so this should succeed)
     echo ""
     echo "→ Removing sources..."
-    ccpm remove source local-deps 2>/dev/null && echo "  ✓ Removed local-deps source" || echo "  ⚠ Could not remove local-deps (may still be in use)"
+    agpm remove source local-deps 2>/dev/null && echo "  ✓ Removed local-deps source" || echo "  ⚠ Could not remove local-deps (may still be in use)"
     
     # Show what's left (should be empty)
     echo ""
     echo "→ Remaining resources after cleanup:"
-    ccpm list || true
+    agpm list || true
     
     # Show the cleaned manifest
     echo ""
     echo "→ Manifest after cleanup:"
     echo "----------------------------------------"
-    cat ccpm.toml
+    cat agpm.toml
     echo "----------------------------------------"
 fi
 

--- a/examples/deps/commands/format-json.md
+++ b/examples/deps/commands/format-json.md
@@ -1,7 +1,7 @@
 ---
 title: Format JSON
 description: Pretty-print and validate JSON files
-author: CCPM Team
+author: AGPM Team
 version: 1.0.0
 tags:
   - json

--- a/examples/deps/commands/git-auto-commit.md
+++ b/examples/deps/commands/git-auto-commit.md
@@ -1,7 +1,7 @@
 ---
 title: Git Auto Commit
 description: Automated git commit with semantic commit messages
-author: CCPM Team
+author: AGPM Team
 version: 1.0.0
 tags:
   - git

--- a/examples/deps/hooks/pre-tool-use.json
+++ b/examples/deps/hooks/pre-tool-use.json
@@ -4,7 +4,7 @@
   ],
   "matcher": "Bash|Write",
   "type": "command",
-  "command": ".claude/ccpm/scripts/build.sh",
+  "command": ".claude/agpm/scripts/build.sh",
   "timeout": 5000,
   "description": "Validate dangerous operations before execution",
   "dependencies": {

--- a/examples/deps/hooks/user-prompt-submit.json
+++ b/examples/deps/hooks/user-prompt-submit.json
@@ -1,7 +1,7 @@
 {
   "events": ["UserPromptSubmit"],
   "type": "command",
-  "command": ".claude/ccpm/scripts/test.js",
+  "command": ".claude/agpm/scripts/test.js",
   "timeout": 10000,
   "description": "Run tests before processing user prompt"
 }

--- a/examples/deps/scripts/build.sh
+++ b/examples/deps/scripts/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Example build script for CCPM
+# Example build script for AGPM
 # This script demonstrates how to use scripts as dependencies
 
 set -e

--- a/examples/deps/scripts/test.js
+++ b/examples/deps/scripts/test.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Example test runner script for CCPM
+// Example test runner script for AGPM
 // This script demonstrates how to use JavaScript scripts as dependencies
 
 console.log('🧪 Running tests...');

--- a/examples/setup_project.sh
+++ b/examples/setup_project.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Example setup script demonstrating CCPM with a local Git repository
+# Example setup script demonstrating AGPM with a local Git repository
 # This script sets up a complete Claude Code project with agents, snippets,
 # commands, and MCP servers from a local repository
 
@@ -12,7 +12,7 @@ YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
 echo -e "${BLUE}╔════════════════════════════════════════════════════════════════════╗${NC}"
-echo -e "${BLUE}║          CCPM Example Project Setup Script                         ║${NC}"
+echo -e "${BLUE}║          AGPM Example Project Setup Script                         ║${NC}"
 echo -e "${BLUE}║        Demonstrating Transitive Dependency Resolution              ║${NC}"
 echo -e "${BLUE}╚════════════════════════════════════════════════════════════════════╝${NC}"
 echo ""
@@ -30,8 +30,8 @@ echo "→ Cleaning up previous example (if exists)"
 rm -rf "$PROJECT_DIR"
 
 
-# Ensure ccpm is built
-echo "→ Building ccpm"
+# Ensure agpm is built
+echo "→ Building agpm"
 cd "$(dirname "$SCRIPT_DIR")"
 cargo build --release
 
@@ -39,7 +39,7 @@ cargo build --release
 export PATH="$PWD/target/release:$PATH"
 
 echo ""
-echo -e "${GREEN}✓ Using ccpm from: $(which ccpm)${NC}"
+echo -e "${GREEN}✓ Using agpm from: $(which agpm)${NC}"
 echo ""
 
 # Create project directory
@@ -47,9 +47,9 @@ echo "→ Creating directory: $PROJECT_DIR"
 mkdir -p "$PROJECT_DIR"
 cd "$PROJECT_DIR"
 
-# Initialize CCPM manifest
-echo "→ Initializing CCPM manifest"
-ccpm init
+# Initialize AGPM manifest
+echo "→ Initializing AGPM manifest"
+agpm init
 
 # Show initial project structure
 echo ""
@@ -59,54 +59,54 @@ tree -a -L 4
 # Add the local-deps source (local directory)
 echo ""
 echo "→ Adding local-deps source (local directory)"
-ccpm add source local-deps "$DEPS_DIR"
+agpm add source local-deps "$DEPS_DIR"
 
 # Add the ccpm-community GitHub repository
 echo ""
 echo "→ Adding ccpm-community GitHub repository"
-ccpm add source community "https://github.com/aig787/ccpm-community.git"
+agpm add source community "https://github.com/aig787/ccpm-community.git"
 
 # Add resources with transitive dependencies via commands (using local source)
 echo ""
 echo -e "${YELLOW}→ Adding commands (which have transitive dependencies)${NC}"
 echo "  - git-auto-commit depends on: rust-haiku agent, commit-message snippet"
 echo "  - format-json depends on: javascript-haiku agent, data-validation snippet"
-ccpm add dep command local-deps:commands/git-auto-commit.md --name git-auto-commit
-ccpm add dep command local-deps:commands/format-json.md --name format-json
+agpm add dep command local-deps:commands/git-auto-commit.md --name git-auto-commit
+agpm add dep command local-deps:commands/format-json.md --name format-json
 
 echo ""
 echo -e "${YELLOW}→ Adding agents (which also have dependencies)${NC}"
 echo "  - rust-haiku depends on: error-analysis, unit-test-creation snippets"
 echo "  - javascript-haiku depends on: test-automation, data-validation snippets"
-ccpm add dep agent local-deps:agents/rust-haiku.md --name rust-haiku
-ccpm add dep agent local-deps:agents/javascript-haiku.md --name javascript-haiku
+agpm add dep agent local-deps:agents/rust-haiku.md --name rust-haiku
+agpm add dep agent local-deps:agents/javascript-haiku.md --name javascript-haiku
 
 echo ""
 echo -e "${YELLOW}→ Adding base snippets (dependencies of other resources)${NC}"
-ccpm add dep snippet local-deps:snippets/error-analysis.md --name error-analysis
-ccpm add dep snippet local-deps:snippets/unit-test-creation.md --name unit-tests
-ccpm add dep snippet local-deps:snippets/commit-message.md --name commit-message
-ccpm add dep snippet local-deps:snippets/data-validation.md --name data-validation
-ccpm add dep snippet local-deps:snippets/test-automation.md --name test-automation
+agpm add dep snippet local-deps:snippets/error-analysis.md --name error-analysis
+agpm add dep snippet local-deps:snippets/unit-test-creation.md --name unit-tests
+agpm add dep snippet local-deps:snippets/commit-message.md --name commit-message
+agpm add dep snippet local-deps:snippets/data-validation.md --name data-validation
+agpm add dep snippet local-deps:snippets/test-automation.md --name test-automation
 
 echo ""
 echo "→ Adding 2 scripts via command"
-ccpm add dep script local-deps:scripts/build.sh --name build
-ccpm add dep script local-deps:scripts/test.js --name test
+agpm add dep script local-deps:scripts/build.sh --name build
+agpm add dep script local-deps:scripts/test.js --name test
 
 echo ""
 echo "→ Adding 2 hooks via command"
-ccpm add dep hook local-deps:hooks/pre-tool-use.json --name pre-tool-use
-ccpm add dep hook local-deps:hooks/user-prompt-submit.json --name user-prompt-submit
+agpm add dep hook local-deps:hooks/pre-tool-use.json --name pre-tool-use
+agpm add dep hook local-deps:hooks/user-prompt-submit.json --name user-prompt-submit
 
 echo ""
 echo "→ Adding 2 MCP servers via command"
-ccpm add dep mcp-server local-deps:mcp-servers/filesystem.json --name filesystem
-ccpm add dep mcp-server local-deps:mcp-servers/fetch.json --name fetch
+agpm add dep mcp-server local-deps:mcp-servers/filesystem.json --name filesystem
+agpm add dep mcp-server local-deps:mcp-servers/fetch.json --name fetch
 
 echo ""
-echo "→ Adding remaining resources directly to ccpm.toml"
-cat >> ccpm.toml << 'EOF'
+echo "→ Adding remaining resources directly to agpm.toml"
+cat >> agpm.toml << 'EOF'
 
 [agents]
 # Additional agents from ccpm-community
@@ -136,30 +136,30 @@ EOF
 
 # Show the generated manifest
 echo ""
-echo "→ Generated ccpm.toml:"
-cat ccpm.toml
+echo "→ Generated agpm.toml:"
+cat agpm.toml
 
 # Validate the manifest
 echo ""
 echo "→ Validating manifest"
-ccpm validate
+agpm validate
 
 # Install dependencies
 echo ""
-echo "→ Installing dependencies with CCPM"
+echo "→ Installing dependencies with AGPM"
 # Remove lockfile since we appended to the manifest
-rm -f ccpm.lock
-ccpm install
+rm -f agpm.lock
+agpm install
 
 # List installed resources
 echo ""
 echo "→ Listing installed resources"
-ccpm list
+agpm list
 
 # Update dependencies
 echo ""
-echo "→ Updating dependathies with CCPM"
-ccpm update
+echo "→ Updating dependathies with AGPM"
+agpm update
 
 
 echo ""
@@ -169,7 +169,7 @@ echo -e "${GREEN}╚════════════════════
 echo ""
 echo "Your Claude Code project '$PROJECT_NAME' is ready:"
 echo ""
-ccpm tree
+agpm tree
 
 # Show final structure
 echo ""

--- a/examples/setup_project.sh
+++ b/examples/setup_project.sh
@@ -61,10 +61,10 @@ echo ""
 echo "→ Adding local-deps source (local directory)"
 agpm add source local-deps "$DEPS_DIR"
 
-# Add the ccpm-community GitHub repository
+# Add the agpm-community GitHub repository
 echo ""
-echo "→ Adding ccpm-community GitHub repository"
-agpm add source community "https://github.com/aig787/ccpm-community.git"
+echo "→ Adding agpm-community GitHub repository"
+agpm add source community "https://github.com/aig787/agpm-community.git"
 
 # Add resources with transitive dependencies via commands (using local source)
 echo ""
@@ -109,7 +109,7 @@ echo "→ Adding remaining resources directly to agpm.toml"
 cat >> agpm.toml << 'EOF'
 
 [agents]
-# Additional agents from ccpm-community
+# Additional agents from agpm-community
 api-designer = { source = "community", path = "agents/awesome-claude-code-subagents/categories/01-core-development/api-designer.md", version = "v0.0.1" }
 backend-developer = { source = "community", path = "agents/awesome-claude-code-subagents/categories/01-core-development/backend-developer.md", version = "^v0.0.1" }
 frontend-developer = { source = "community", path = "agents/awesome-claude-code-subagents/categories/01-core-development/frontend-developer.md", version = "=v0.0.1" }

--- a/src/cache/lock.rs
+++ b/src/cache/lock.rs
@@ -47,9 +47,9 @@ impl CacheLock {
     /// ```
     ///
     /// Examples:
-    /// - `~/.ccpm/cache/.locks/community.lock`
-    /// - `~/.ccpm/cache/.locks/work-tools.lock`
-    /// - `~/.ccpm/cache/.locks/my-project.lock`
+    /// - `~/.agpm/cache/.locks/community.lock`
+    /// - `~/.agpm/cache/.locks/work-tools.lock`
+    /// - `~/.agpm/cache/.locks/my-project.lock`
     ///
     /// # Parameters
     ///
@@ -92,11 +92,11 @@ impl CacheLock {
     /// Simple lock acquisition:
     ///
     /// ```rust,no_run
-    /// use ccpm::cache::lock::CacheLock;
+    /// use agpm::cache::lock::CacheLock;
     /// use std::path::PathBuf;
     ///
     /// # async fn example() -> anyhow::Result<()> {
-    /// let cache_dir = PathBuf::from("/home/user/.ccpm/cache");
+    /// let cache_dir = PathBuf::from("/home/user/.agpm/cache");
     ///
     /// // This will block if another process has the lock
     /// let lock = CacheLock::acquire(&cache_dir, "my-source").await?;
@@ -113,7 +113,7 @@ impl CacheLock {
     /// Error handling for lock acquisition:
     ///
     /// ```rust,no_run
-    /// use ccpm::cache::lock::CacheLock;
+    /// use agpm::cache::lock::CacheLock;
     /// use std::path::PathBuf;
     ///
     /// # async fn example() -> anyhow::Result<()> {
@@ -134,7 +134,7 @@ impl CacheLock {
     /// # }
     /// ```
     pub async fn acquire(cache_dir: &Path, source_name: &str) -> Result<Self> {
-        // Create lock file path: ~/.ccpm/cache/.locks/source_name.lock
+        // Create lock file path: ~/.agpm/cache/.locks/source_name.lock
         let locks_dir = cache_dir.join(".locks");
         tokio::fs::create_dir_all(&locks_dir).await.map_err(|e| {
             if e.kind() == std::io::ErrorKind::NotADirectory {
@@ -217,11 +217,11 @@ impl Drop for CacheLock {
 /// # Example
 ///
 /// ```rust,no_run
-/// use ccpm::cache::lock::cleanup_stale_locks;
+/// use agpm::cache::lock::cleanup_stale_locks;
 /// use std::path::PathBuf;
 ///
 /// # async fn example() -> anyhow::Result<()> {
-/// let cache_dir = PathBuf::from("/home/user/.ccpm/cache");
+/// let cache_dir = PathBuf::from("/home/user/.agpm/cache");
 /// // Clean up lock files older than 1 hour
 /// let removed = cleanup_stale_locks(&cache_dir, 3600).await?;
 /// println!("Removed {} stale lock files", removed);

--- a/src/cache/lock.rs
+++ b/src/cache/lock.rs
@@ -174,14 +174,14 @@ impl CacheLock {
 
             // Try to acquire exclusive lock (blocking)
             file.lock_exclusive()
-                .with_context(|| format!("Failed to acquire lock for: {}", source_name))?;
+                .with_context(|| format!("Failed to acquire lock for: {source_name}"))?;
 
             Ok(file)
         })
         .await
         .context("Failed to spawn blocking task for lock acquisition")??;
 
-        Ok(CacheLock {
+        Ok(Self {
             _file: file,
             path: lock_path,
         })

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -1,7 +1,7 @@
-//! Add command implementation for CCPM
+//! Add command implementation for AGPM
 //!
 //! This module provides functionality to add sources and dependencies
-//! to a CCPM project manifest. It supports both Git repository sources
+//! to a AGPM project manifest. It supports both Git repository sources
 //! and various types of resource dependencies (agents, snippets, commands, MCP servers).
 
 use anyhow::{Result, anyhow};
@@ -19,7 +19,7 @@ use crate::models::{
 };
 use crate::utils::fs::atomic_write;
 
-/// Command to add sources and dependencies to a CCPM project.
+/// Command to add sources and dependencies to a AGPM project.
 #[derive(Args)]
 pub struct AddCommand {
     /// The specific add operation to perform
@@ -68,13 +68,13 @@ enum DependencySubcommand {
 impl AddCommand {
     /// Execute the add command with an optional manifest path.
     ///
-    /// This method allows specifying a custom path to the ccpm.toml manifest file.
-    /// If no path is provided, it will search for ccpm.toml in the current directory
+    /// This method allows specifying a custom path to the agpm.toml manifest file.
+    /// If no path is provided, it will search for agpm.toml in the current directory
     /// and parent directories.
     ///
     /// # Arguments
     ///
-    /// * `manifest_path` - Optional path to the ccpm.toml file
+    /// * `manifest_path` - Optional path to the agpm.toml file
     ///
     /// # Returns
     ///
@@ -84,7 +84,7 @@ impl AddCommand {
     /// # Examples
     ///
     /// ```ignore
-    /// use ccpm::cli::add::{AddCommand, AddSubcommand};
+    /// use agpm::cli::add::{AddCommand, AddSubcommand};
     /// use std::path::PathBuf;
     ///
     /// let cmd = AddCommand {
@@ -98,7 +98,7 @@ impl AddCommand {
     /// cmd.execute_with_manifest_path(None).await?;
     ///
     /// // Or specify custom manifest path
-    /// cmd.execute_with_manifest_path(Some(PathBuf::from("/path/to/ccpm.toml"))).await?;
+    /// cmd.execute_with_manifest_path(Some(PathBuf::from("/path/to/agpm.toml"))).await?;
     /// ```
     pub async fn execute_with_manifest_path(
         self,
@@ -273,7 +273,7 @@ async fn add_dependency_with_manifest_path(
 /// ```text
 /// # Unix/Linux/macOS
 /// /home/user/resources/agent.md
-/// /usr/local/share/ccpm/snippets/helper.md
+/// /usr/local/share/agpm/snippets/helper.md
 ///
 /// # Windows
 /// C:\Users\name\resources\agent.md
@@ -325,7 +325,7 @@ async fn add_dependency_with_manifest_path(
 ///
 /// For pattern dependencies, you should typically provide a custom name:
 /// ```bash
-/// ccpm add dep agent "community:agents/ai/*.md@v1.0.0" --name ai-agents
+/// agpm add dep agent "community:agents/ai/*.md@v1.0.0" --name ai-agents
 /// ```
 ///
 /// ## Version Handling
@@ -374,7 +374,7 @@ async fn add_dependency_with_manifest_path(
 /// assert_eq!(name, "my-agent");
 ///
 /// // Parse with manifest context for better source detection
-/// let manifest = Manifest::load(Path::new("ccpm.toml")).unwrap();
+/// let manifest = Manifest::load(Path::new("agpm.toml")).unwrap();
 /// let (name, dep) = parse_dependency_spec(
 ///     "community:snippets/helper.md",
 ///     &None,
@@ -570,7 +570,7 @@ mod tests {
 
 [target]
 agents = ".claude/agents"
-snippets = ".claude/ccpm/snippets"
+snippets = ".claude/agpm/snippets"
 commands = ".claude/commands"
 
 [agents]
@@ -595,7 +595,7 @@ existing = "https://github.com/existing/repo.git"
 
 [target]
 agents = ".claude/agents"
-snippets = ".claude/ccpm/snippets"
+snippets = ".claude/agpm/snippets"
 commands = ".claude/commands"
 
 [agents]
@@ -714,20 +714,20 @@ existing-mcp = "../local/mcp-servers/existing.json"
 
     /// Helper function to convert a manifest path to its corresponding lockfile path
     fn manifest_path_to_lockfile(manifest_path: &std::path::Path) -> std::path::PathBuf {
-        manifest_path.with_file_name("ccpm.lock")
+        manifest_path.with_file_name("agpm.lock")
     }
 
     #[test]
     fn test_manifest_path_to_lockfile() {
         use std::path::PathBuf;
 
-        let manifest = PathBuf::from("/project/ccpm.toml");
+        let manifest = PathBuf::from("/project/agpm.toml");
         let lockfile = manifest_path_to_lockfile(&manifest);
-        assert_eq!(lockfile, PathBuf::from("/project/ccpm.lock"));
+        assert_eq!(lockfile, PathBuf::from("/project/agpm.lock"));
 
-        let manifest2 = PathBuf::from("./ccpm.toml");
+        let manifest2 = PathBuf::from("./agpm.toml");
         let lockfile2 = manifest_path_to_lockfile(&manifest2);
-        assert_eq!(lockfile2, PathBuf::from("./ccpm.lock"));
+        assert_eq!(lockfile2, PathBuf::from("./agpm.lock"));
     }
 
     // NEW COMPREHENSIVE TESTS
@@ -735,7 +735,7 @@ existing-mcp = "../local/mcp-servers/existing.json"
     #[tokio::test]
     async fn test_execute_add_source() {
         let temp_dir = TempDir::new().unwrap();
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
         create_test_manifest(&manifest_path);
 
         // Change to temp directory
@@ -765,7 +765,7 @@ existing-mcp = "../local/mcp-servers/existing.json"
     #[tokio::test]
     async fn test_execute_add_agent_dependency() {
         let temp_dir = TempDir::new().unwrap();
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
         create_test_manifest(&manifest_path);
 
         // Create local agent file for testing
@@ -800,7 +800,7 @@ existing-mcp = "../local/mcp-servers/existing.json"
     #[tokio::test]
     async fn test_execute_add_snippet_dependency() {
         let temp_dir = TempDir::new().unwrap();
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
         create_test_manifest(&manifest_path);
 
         // Create local snippet file for testing
@@ -834,7 +834,7 @@ existing-mcp = "../local/mcp-servers/existing.json"
     #[tokio::test]
     async fn test_execute_add_command_dependency() {
         let temp_dir = TempDir::new().unwrap();
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
         create_test_manifest(&manifest_path);
 
         // Create local command file for testing
@@ -868,7 +868,7 @@ existing-mcp = "../local/mcp-servers/existing.json"
     #[tokio::test]
     async fn test_execute_add_mcp_server_dependency() {
         let temp_dir = TempDir::new().unwrap();
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
         create_test_manifest(&manifest_path);
 
         // Create a test MCP server JSON file
@@ -903,7 +903,7 @@ existing-mcp = "../local/mcp-servers/existing.json"
         // Check that the file was installed
         let installed_path = temp_dir
             .path()
-            .join(".claude/ccpm/mcp-servers/test-mcp.json");
+            .join(".claude/agpm/mcp-servers/test-mcp.json");
         assert!(
             installed_path.exists(),
             "MCP server config should be installed"
@@ -916,7 +916,7 @@ existing-mcp = "../local/mcp-servers/existing.json"
     #[tokio::test]
     async fn test_add_source_success() {
         let temp_dir = TempDir::new().unwrap();
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
         create_test_manifest(&manifest_path);
 
         // Change to temp directory
@@ -941,7 +941,7 @@ existing-mcp = "../local/mcp-servers/existing.json"
     #[tokio::test]
     async fn test_add_source_already_exists() {
         let temp_dir = TempDir::new().unwrap();
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
         create_test_manifest_with_content(&manifest_path);
 
         // Change to temp directory
@@ -1026,7 +1026,7 @@ existing-mcp = "../local/mcp-servers/existing.json"
     #[tokio::test]
     async fn test_install_single_dependency_mcp_server() {
         let temp_dir = TempDir::new().unwrap();
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
 
         // Create a test MCP server JSON file
         let mcp_config = serde_json::json!({
@@ -1045,9 +1045,9 @@ existing-mcp = "../local/mcp-servers/existing.json"
 
 [target]
 agents = ".claude/agents"
-snippets = ".claude/ccpm/snippets"
+snippets = ".claude/agpm/snippets"
 commands = ".claude/commands"
-mcp-servers = ".claude/ccpm/mcp-servers"
+mcp-servers = ".claude/agpm/mcp-servers"
 
 [agents]
 
@@ -1078,7 +1078,7 @@ test-mcp = "{}"
         // Check that the MCP server config was created
         let mcp_config_path = temp_dir
             .path()
-            .join(".claude/ccpm/mcp-servers/test-mcp.json");
+            .join(".claude/agpm/mcp-servers/test-mcp.json");
         assert!(
             mcp_config_path.exists(),
             "MCP server config file should be created"
@@ -1088,7 +1088,7 @@ test-mcp = "{}"
     #[tokio::test]
     async fn test_install_single_dependency_invalid_resource_type() {
         let temp_dir = TempDir::new().unwrap();
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
 
         // Create a test file
         let test_file = temp_dir.path().join("test.md");
@@ -1100,7 +1100,7 @@ test-mcp = "{}"
 
 [target]
 agents = ".claude/agents"
-snippets = ".claude/ccpm/snippets"
+snippets = ".claude/agpm/snippets"
 commands = ".claude/commands"
 
 [agents]
@@ -1136,14 +1136,14 @@ test = "{}"
     #[tokio::test]
     async fn test_install_single_dependency_source_not_found() {
         let temp_dir = TempDir::new().unwrap();
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
 
         // Create manifest with a dependency that references a non-existent source
         let manifest_content = r#"[sources]
 
 [target]
 agents = ".claude/agents"
-snippets = ".claude/ccpm/snippets"
+snippets = ".claude/agpm/snippets"
 commands = ".claude/commands"
 
 [agents]
@@ -1171,7 +1171,7 @@ test-agent = { source = "nonexistent-source", path = "agents/test.md", version =
     #[tokio::test]
     async fn test_add_dependency_agent_with_force() {
         let temp_dir = TempDir::new().unwrap();
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
 
         // Create local agent file for testing (this will be the original)
         let original_agent_file = temp_dir.path().join("original-agent.md");
@@ -1184,7 +1184,7 @@ existing = "https://github.com/existing/repo.git"
 
 [target]
 agents = ".claude/agents"
-snippets = ".claude/ccpm/snippets"
+snippets = ".claude/agpm/snippets"
 commands = ".claude/commands"
 
 [agents]
@@ -1234,7 +1234,7 @@ existing-agent = "{}"
     #[tokio::test]
     async fn test_add_dependency_mcp_server_without_force() {
         let temp_dir = TempDir::new().unwrap();
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
         create_test_manifest_with_content(&manifest_path);
 
         // Change to temp directory
@@ -1261,7 +1261,7 @@ existing-agent = "{}"
     #[tokio::test]
     async fn test_add_dependency_snippet_without_force() {
         let temp_dir = TempDir::new().unwrap();
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
         create_test_manifest_with_content(&manifest_path);
 
         // Create local snippet file for testing
@@ -1292,7 +1292,7 @@ existing-agent = "{}"
     #[tokio::test]
     async fn test_add_dependency_command_without_force() {
         let temp_dir = TempDir::new().unwrap();
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
         create_test_manifest_with_content(&manifest_path);
 
         // Create local command file for testing
@@ -1323,7 +1323,7 @@ existing-agent = "{}"
     #[tokio::test]
     async fn test_add_dependency_mcp_server_with_file() {
         let temp_dir = TempDir::new().unwrap();
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
         create_test_manifest(&manifest_path);
 
         // Create a test MCP server JSON file
@@ -1358,7 +1358,7 @@ existing-agent = "{}"
         // Check that the file was installed
         let installed_path = temp_dir
             .path()
-            .join(".claude/ccpm/mcp-servers/file-mcp.json");
+            .join(".claude/agpm/mcp-servers/file-mcp.json");
         assert!(
             installed_path.exists(),
             "MCP server config should be installed"

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -183,8 +183,7 @@ async fn add_dependency_with_manifest_path(
         // Check if dependency already exists
         if manifest.mcp_servers.contains_key(&name) && !common.force {
             return Err(anyhow!(
-                "MCP server '{}' already exists in manifest. Use --force to overwrite",
-                name
+                "MCP server '{name}' already exists in manifest. Use --force to overwrite"
             ));
         }
 
@@ -206,9 +205,7 @@ async fn add_dependency_with_manifest_path(
         // Check if dependency already exists
         if section.contains_key(&name) && !common.force {
             return Err(anyhow!(
-                "{} '{}' already exists in manifest. Use --force to overwrite",
-                resource_type,
-                name
+                "{resource_type} '{name}' already exists in manifest. Use --force to overwrite"
             ));
         }
 

--- a/src/cli/cache.rs
+++ b/src/cli/cache.rs
@@ -1,7 +1,7 @@
-//! Manage the global Git repository cache for CCPM.
+//! Manage the global Git repository cache for AGPM.
 //!
 //! This module provides the `cache` command which allows users to manage the
-//! global cache directory where CCPM stores cloned Git repositories. The cache
+//! global cache directory where AGPM stores cloned Git repositories. The cache
 //! improves performance by avoiding repeated clones of the same repositories.
 //!
 //! # Features
@@ -14,7 +14,7 @@
 //!
 //! # Cache Structure
 //!
-//! The cache directory (typically `~/.ccpm/cache/`) contains:
+//! The cache directory (typically `~/.agpm/cache/`) contains:
 //! - One subdirectory per source repository
 //! - Each subdirectory is a bare Git clone
 //! - Directory names match source names from manifests
@@ -23,18 +23,18 @@
 //!
 //! Show cache information:
 //! ```bash
-//! ccpm cache info
-//! ccpm cache  # defaults to info
+//! agpm cache info
+//! agpm cache  # defaults to info
 //! ```
 //!
 //! Clean unused cache entries:
 //! ```bash
-//! ccpm cache clean
+//! agpm cache clean
 //! ```
 //!
 //! Clear entire cache:
 //! ```bash
-//! ccpm cache clean --all
+//! agpm cache clean --all
 //! ```
 //!
 //! # Cache Management Strategy
@@ -76,7 +76,7 @@ use std::path::PathBuf;
 
 /// Command to manage the global Git repository cache.
 ///
-/// This command provides operations for managing CCPM's global cache directory
+/// This command provides operations for managing AGPM's global cache directory
 /// where Git repositories are stored. The cache improves performance by avoiding
 /// repeated clones of the same repositories across multiple projects.
 ///
@@ -87,7 +87,7 @@ use std::path::PathBuf;
 /// # Examples
 ///
 /// ```rust,ignore
-/// use ccpm::cli::cache::{CacheCommand, CacheSubcommands};
+/// use agpm::cli::cache::{CacheCommand, CacheSubcommands};
 ///
 /// // Show cache info (default behavior)
 /// let cmd = CacheCommand { command: None };
@@ -122,7 +122,7 @@ enum CacheSubcommands {
     /// repositories not referenced by the current project are removed.
     ///
     /// # Smart Cleanup Logic
-    /// 1. Loads the current project manifest (`ccpm.toml`)
+    /// 1. Loads the current project manifest (`agpm.toml`)
     /// 2. Extracts all source repository names
     /// 3. Compares with cached repository directories
     /// 4. Removes cache entries not referenced in the manifest
@@ -136,8 +136,8 @@ enum CacheSubcommands {
     ///
     /// # Examples
     /// ```bash
-    /// ccpm cache clean           # Remove unused entries
-    /// ccpm cache clean --all     # Remove entire cache
+    /// agpm cache clean           # Remove unused entries
+    /// agpm cache clean --all     # Remove entire cache
     /// ```
     Clean {
         /// Remove all cache, not just unused entries
@@ -166,8 +166,8 @@ enum CacheSubcommands {
     ///
     /// # Examples
     /// ```bash
-    /// ccpm cache info    # Explicit info command
-    /// ccpm cache         # Defaults to info
+    /// agpm cache info    # Explicit info command
+    /// agpm cache         # Defaults to info
     /// ```
     Info,
 }
@@ -186,7 +186,7 @@ impl CacheCommand {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// use ccpm::cli::cache::CacheCommand;
+    /// use agpm::cli::cache::CacheCommand;
     ///
     /// # tokio_test::block_on(async {
     /// let cmd = CacheCommand { command: None };
@@ -243,8 +243,8 @@ impl CacheCommand {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// use ccpm::cli::cache::{CacheCommand, CacheSubcommands};
-    /// use ccpm::cache::Cache;
+    /// use agpm::cli::cache::{CacheCommand, CacheSubcommands};
+    /// use agpm::cache::Cache;
     /// use tempfile::TempDir;
     ///
     /// # tokio_test::block_on(async {
@@ -339,7 +339,7 @@ impl CacheCommand {
     ///
     /// This method performs intelligent cache cleanup by:
     ///
-    /// 1. Loading the current project's manifest (`ccpm.toml`)
+    /// 1. Loading the current project's manifest (`agpm.toml`)
     /// 2. Extracting the list of source repository names
     /// 3. Comparing cached repositories with active sources
     /// 4. Removing only cache entries not referenced in the manifest
@@ -358,7 +358,7 @@ impl CacheCommand {
     ///
     /// # Behavior Without Manifest
     ///
-    /// If no `ccpm.toml` file is found:
+    /// If no `agpm.toml` file is found:
     /// - Issues a warning message
     /// - Performs no cleanup operations
     /// - Suggests using `--all` flag for complete cleanup
@@ -386,7 +386,7 @@ impl CacheCommand {
             }
             Err(_) => {
                 // No manifest found, can't determine what's in use
-                println!("⚠️  No ccpm.toml found. Use --all to clear entire cache.");
+                println!("⚠️  No agpm.toml found. Use --all to clear entire cache.");
                 return Ok(());
             }
         };
@@ -433,8 +433,8 @@ impl CacheCommand {
     ///
     /// ## Cache Location
     /// Shows the full path to the cache directory, typically:
-    /// - `~/.ccpm/cache/` on Unix-like systems
-    /// - `%APPDATA%/ccpm/cache/` on Windows
+    /// - `~/.agpm/cache/` on Unix-like systems
+    /// - `%APPDATA%/agpm/cache/` on Windows
     ///
     /// ## Cache Size
     /// Total disk space used by all cached repositories, automatically
@@ -489,8 +489,8 @@ impl CacheCommand {
         }
 
         println!("\n{}", "Tip:".yellow());
-        println!("  Use 'ccpm cache clean' to remove unused cache");
-        println!("  Use 'ccpm cache clean --all' to clear all cache");
+        println!("  Use 'agpm cache clean' to remove unused cache");
+        println!("  Use 'agpm cache clean --all' to clear all cache");
 
         Ok(())
     }
@@ -527,7 +527,7 @@ impl CacheCommand {
 /// # Examples
 ///
 /// ```rust,ignore
-/// # use ccpm::cli::cache::format_size;
+/// # use agpm::cli::cache::format_size;
 /// assert_eq!(format_size(0), "0 B");
 /// assert_eq!(format_size(512), "512 B");
 /// assert_eq!(format_size(1024), "1.00 KB");
@@ -660,7 +660,7 @@ mod tests {
         };
 
         // Pass a non-existent manifest path to ensure no manifest is found
-        let non_existent_manifest = work_dir.path().join("ccpm.toml");
+        let non_existent_manifest = work_dir.path().join("agpm.toml");
         assert!(!non_existent_manifest.exists());
 
         // Without a manifest, should warn and not clean
@@ -686,7 +686,7 @@ mod tests {
             )]),
             ..Default::default()
         };
-        let manifest_path = work_dir.path().join("ccpm.toml");
+        let manifest_path = work_dir.path().join("agpm.toml");
         manifest.save(&manifest_path).unwrap();
 
         // Create cache directories - one active (matches manifest), one unused
@@ -835,7 +835,7 @@ mod tests {
             ]),
             ..Default::default()
         };
-        let manifest_path = work_dir.path().join("ccpm.toml");
+        let manifest_path = work_dir.path().join("agpm.toml");
         manifest.save(&manifest_path).unwrap();
 
         // Create cache directories
@@ -898,7 +898,7 @@ mod tests {
         let cache = Cache::with_dir(temp_dir.path().to_path_buf()).unwrap();
 
         // No manifest file exists
-        let non_existent_manifest = work_dir.path().join("ccpm.toml");
+        let non_existent_manifest = work_dir.path().join("agpm.toml");
         assert!(!non_existent_manifest.exists());
 
         // Create some cache directories
@@ -958,7 +958,7 @@ mod tests {
             )]),
             ..Default::default()
         };
-        let manifest_path = work_dir.path().join("ccpm.toml");
+        let manifest_path = work_dir.path().join("agpm.toml");
         manifest.save(&manifest_path).unwrap();
 
         // Create lockfile with additional sources
@@ -983,7 +983,7 @@ mod tests {
             scripts: vec![],
             hooks: vec![],
         };
-        lockfile.save(&work_dir.path().join("ccpm.lock")).unwrap();
+        lockfile.save(&work_dir.path().join("agpm.lock")).unwrap();
 
         // Create cache directories
         let manifest_cache = temp_dir.path().join("manifest-source");

--- a/src/cli/cache.rs
+++ b/src/cli/cache.rs
@@ -326,7 +326,7 @@ impl CacheCommand {
         if let Ok(removed) = crate::cache::lock::cleanup_stale_locks(cache_dir, 3600).await
             && removed > 0
         {
-            println!("  Removed {} stale lock files", removed);
+            println!("  Removed {removed} stale lock files");
         }
 
         cache.clear_all().await?;
@@ -379,16 +379,13 @@ impl CacheCommand {
         println!("🔍 Scanning for unused cache entries...");
 
         // Find manifest to get active sources
-        let active_sources = match find_manifest_with_optional(manifest_path) {
-            Ok(manifest_path) => {
-                let manifest = Manifest::load(&manifest_path)?;
-                manifest.sources.keys().cloned().collect::<Vec<_>>()
-            }
-            Err(_) => {
-                // No manifest found, can't determine what's in use
-                println!("⚠️  No agpm.toml found. Use --all to clear entire cache.");
-                return Ok(());
-            }
+        let active_sources = if let Ok(manifest_path) = find_manifest_with_optional(manifest_path) {
+            let manifest = Manifest::load(&manifest_path)?;
+            manifest.sources.keys().cloned().collect::<Vec<_>>()
+        } else {
+            // No manifest found, can't determine what's in use
+            println!("⚠️  No agpm.toml found. Use --all to clear entire cache.");
+            return Ok(());
         };
 
         let removed = cache.clean_unused(&active_sources).await?;
@@ -402,10 +399,10 @@ impl CacheCommand {
         if removed > 0 || lock_removed > 0 {
             let mut messages = Vec::new();
             if removed > 0 {
-                messages.push(format!("{} unused cache entries", removed));
+                messages.push(format!("{removed} unused cache entries"));
             }
             if lock_removed > 0 {
-                messages.push(format!("{} stale lock files", lock_removed));
+                messages.push(format!("{lock_removed} stale lock files"));
             }
             println!(
                 "{}",

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -14,8 +14,8 @@ pub trait CommandExecutor: Sized {
     {
         async move {
             let manifest_path = find_manifest().with_context(|| {
-                "No ccpm.toml found in current directory or any parent directory. \
-                 Run 'ccpm init' to create a new project."
+                "No agpm.toml found in current directory or any parent directory. \
+                 Run 'agpm init' to create a new project."
             })?;
             self.execute_from_path(manifest_path).await
         }
@@ -31,13 +31,13 @@ pub trait CommandExecutor: Sized {
 /// Common context for CLI commands that need manifest and project information
 #[derive(Debug)]
 pub struct CommandContext {
-    /// Parsed project manifest (ccpm.toml)
+    /// Parsed project manifest (agpm.toml)
     pub manifest: Manifest,
     /// Path to the manifest file
     pub manifest_path: PathBuf,
-    /// Project root directory (containing ccpm.toml)
+    /// Project root directory (containing agpm.toml)
     pub project_dir: PathBuf,
-    /// Path to the lockfile (ccpm.lock)
+    /// Path to the lockfile (agpm.lock)
     pub lockfile_path: PathBuf,
 }
 
@@ -62,7 +62,7 @@ impl CommandContext {
             format!("Failed to parse manifest file: {}", manifest_path.display())
         })?;
 
-        let lockfile_path = project_dir.join("ccpm.lock");
+        let lockfile_path = project_dir.join("agpm.lock");
 
         Ok(Self {
             manifest,
@@ -101,7 +101,7 @@ mod tests {
     #[test]
     fn test_command_context_from_manifest_path() {
         let temp_dir = TempDir::new().unwrap();
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
 
         // Create a test manifest
         std::fs::write(
@@ -119,13 +119,13 @@ test = "https://github.com/test/repo.git"
 
         assert_eq!(context.manifest_path, manifest_path);
         assert_eq!(context.project_dir, temp_dir.path());
-        assert_eq!(context.lockfile_path, temp_dir.path().join("ccpm.lock"));
+        assert_eq!(context.lockfile_path, temp_dir.path().join("agpm.lock"));
         assert!(context.manifest.sources.contains_key("test"));
     }
 
     #[test]
     fn test_command_context_missing_manifest() {
-        let result = CommandContext::from_manifest_path("/nonexistent/ccpm.toml");
+        let result = CommandContext::from_manifest_path("/nonexistent/agpm.toml");
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("not found"));
     }
@@ -133,7 +133,7 @@ test = "https://github.com/test/repo.git"
     #[test]
     fn test_command_context_invalid_manifest() {
         let temp_dir = TempDir::new().unwrap();
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
 
         // Create an invalid manifest
         std::fs::write(&manifest_path, "invalid toml {{").unwrap();
@@ -151,8 +151,8 @@ test = "https://github.com/test/repo.git"
     #[test]
     fn test_load_lockfile_exists() {
         let temp_dir = TempDir::new().unwrap();
-        let manifest_path = temp_dir.path().join("ccpm.toml");
-        let lockfile_path = temp_dir.path().join("ccpm.lock");
+        let manifest_path = temp_dir.path().join("agpm.toml");
+        let lockfile_path = temp_dir.path().join("agpm.lock");
 
         // Create test files
         std::fs::write(&manifest_path, "[sources]\n").unwrap();
@@ -182,7 +182,7 @@ fetched_at = "2024-01-01T00:00:00Z"
     #[test]
     fn test_load_lockfile_not_exists() {
         let temp_dir = TempDir::new().unwrap();
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
 
         std::fs::write(&manifest_path, "[sources]\n").unwrap();
 
@@ -195,7 +195,7 @@ fetched_at = "2024-01-01T00:00:00Z"
     #[test]
     fn test_save_lockfile() {
         let temp_dir = TempDir::new().unwrap();
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
 
         std::fs::write(&manifest_path, "[sources]\n").unwrap();
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -1,8 +1,8 @@
-//! Manage global CCPM configuration settings.
+//! Manage global AGPM configuration settings.
 //!
 //! This module provides the `config` command which allows users to manage
-//! the global configuration file (`~/.ccpm/config.toml`) containing settings
-//! that apply across all CCPM projects. The primary use case is managing
+//! the global configuration file (`~/.agpm/config.toml`) containing settings
+//! that apply across all AGPM projects. The primary use case is managing
 //! authentication tokens and private Git repository sources.
 //!
 //! # Features
@@ -18,37 +18,37 @@
 //!
 //! | File | Purpose | Contents | Version Control |
 //! |------|---------|----------|----------------|
-//! | `~/.ccpm/config.toml` | Global settings | Auth tokens, private sources | ❌ Never commit |
-//! | `./ccpm.toml` | Project manifest | Public sources, dependencies | ✅ Commit to git |
+//! | `~/.agpm/config.toml` | Global settings | Auth tokens, private sources | ❌ Never commit |
+//! | `./agpm.toml` | Project manifest | Public sources, dependencies | ✅ Commit to git |
 //!
 //! # Examples
 //!
 //! Initialize global configuration:
 //! ```bash
-//! ccpm config init
+//! agpm config init
 //! ```
 //!
 //! Show current configuration:
 //! ```bash
-//! ccpm config show
-//! ccpm config  # defaults to show
+//! agpm config show
+//! agpm config  # defaults to show
 //! ```
 //!
 //! Edit configuration interactively:
 //! ```bash
-//! ccpm config edit
+//! agpm config edit
 //! ```
 //!
 //! Manage global sources:
 //! ```bash
-//! ccpm config add-source private https://oauth2:TOKEN@github.com/org/private.git
-//! ccpm config list-sources
-//! ccpm config remove-source private
+//! agpm config add-source private https://oauth2:TOKEN@github.com/org/private.git
+//! agpm config list-sources
+//! agpm config remove-source private
 //! ```
 //!
 //! Get configuration file path:
 //! ```bash
-//! ccpm config path
+//! agpm config path
 //! ```
 //!
 //! # Configuration File Structure
@@ -56,13 +56,13 @@
 //! The global configuration follows this format:
 //!
 //! ```toml
-//! # Global CCPM Configuration
+//! # Global AGPM Configuration
 //! # This file contains authentication tokens and private sources
 //! # DO NOT commit this file to version control
 //!
 //! [sources]
 //! # Private repository with authentication
-//! private = "https://oauth2:ghp_xxxx@github.com/company/ccpm-resources.git"
+//! private = "https://oauth2:ghp_xxxx@github.com/company/agpm-resources.git"
 //!
 //! # GitLab with deploy token
 //! gitlab-private = "https://gitlab-ci-token:TOKEN@gitlab.com/group/repo.git"
@@ -110,11 +110,11 @@ use std::path::PathBuf;
 
 use crate::config::GlobalConfig;
 
-/// Command to manage global CCPM configuration settings.
+/// Command to manage global AGPM configuration settings.
 ///
 /// This command provides comprehensive management of the global configuration
 /// file which contains authentication tokens and private sources that apply
-/// across all CCPM projects on the system.
+/// across all AGPM projects on the system.
 ///
 /// # Default Behavior
 ///
@@ -123,7 +123,7 @@ use crate::config::GlobalConfig;
 /// # Examples
 ///
 /// ```rust,ignore
-/// use ccpm::cli::config::{ConfigCommand, ConfigSubcommands};
+/// use agpm::cli::config::{ConfigCommand, ConfigSubcommands};
 ///
 /// // Show current configuration (default)
 /// let cmd = ConfigCommand { command: None };
@@ -151,7 +151,7 @@ pub struct ConfigCommand {
 /// Subcommands for global configuration management.
 ///
 /// This enum defines all available operations for managing the global
-/// CCPM configuration file and its contents.
+/// AGPM configuration file and its contents.
 #[derive(Subcommand)]
 enum ConfigSubcommands {
     /// Initialize a new global configuration with example content.
@@ -169,8 +169,8 @@ enum ConfigSubcommands {
     ///
     /// # Examples
     /// ```bash
-    /// ccpm config init               # Create new config
-    /// ccpm config init --force       # Overwrite existing config
+    /// agpm config init               # Create new config
+    /// agpm config init --force       # Overwrite existing config
     /// ```
     Init {
         /// Force overwrite existing configuration file
@@ -196,8 +196,8 @@ enum ConfigSubcommands {
     ///
     /// # Examples
     /// ```bash
-    /// ccpm config show      # Explicit show command
-    /// ccpm config           # Defaults to show
+    /// agpm config show      # Explicit show command
+    /// agpm config           # Defaults to show
     /// ```
     Show,
 
@@ -213,14 +213,14 @@ enum ConfigSubcommands {
     ///
     /// # Examples
     /// ```bash
-    /// ccpm config edit
+    /// agpm config edit
     /// ```
     Edit,
 
     /// Add a new global source repository.
     ///
     /// Adds a Git repository source to the global configuration, making it
-    /// available for use in all CCPM projects. This is particularly useful
+    /// available for use in all AGPM projects. This is particularly useful
     /// for private repositories that require authentication tokens.
     ///
     /// # Duplicate Handling
@@ -233,7 +233,7 @@ enum ConfigSubcommands {
     ///
     /// # Examples
     /// ```bash
-    /// ccpm config add-source private https://oauth2:TOKEN@github.com/org/repo.git
+    /// agpm config add-source private https://oauth2:TOKEN@github.com/org/repo.git
     /// ```
     AddSource {
         /// Name for the source (used to reference it in manifests)
@@ -263,7 +263,7 @@ enum ConfigSubcommands {
     ///
     /// # Examples
     /// ```bash
-    /// ccpm config remove-source private
+    /// agpm config remove-source private
     /// ```
     RemoveSource {
         /// Name of the source to remove
@@ -285,7 +285,7 @@ enum ConfigSubcommands {
     ///
     /// # Examples
     /// ```bash
-    /// ccpm config list-sources
+    /// agpm config list-sources
     /// ```
     ListSources,
 
@@ -299,7 +299,7 @@ enum ConfigSubcommands {
     ///
     /// # Examples
     /// ```bash
-    /// ccpm config path
+    /// agpm config path
     /// ```
     Path,
 }
@@ -340,7 +340,7 @@ impl ConfigCommand {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// use ccpm::cli::config::{ConfigCommand, ConfigSubcommands};
+    /// use agpm::cli::config::{ConfigCommand, ConfigSubcommands};
     ///
     /// # tokio_test::block_on(async {
     /// // Show current configuration
@@ -383,7 +383,7 @@ impl ConfigCommand {
 
     async fn init_with_config_path(force: bool, config_path: Option<PathBuf>) -> Result<()> {
         let config_path = config_path.unwrap_or_else(|| {
-            GlobalConfig::default_path().unwrap_or_else(|_| PathBuf::from("~/.ccpm/config.toml"))
+            GlobalConfig::default_path().unwrap_or_else(|_| PathBuf::from("~/.agpm/config.toml"))
         });
 
         if config_path.exists() && !force {
@@ -453,7 +453,7 @@ impl ConfigCommand {
     async fn show(config_path: Option<PathBuf>) -> Result<()> {
         let config = GlobalConfig::load_with_optional(config_path.clone()).await?;
         let config_path = config_path.unwrap_or_else(|| {
-            GlobalConfig::default_path().unwrap_or_else(|_| PathBuf::from("~/.ccpm/config.toml"))
+            GlobalConfig::default_path().unwrap_or_else(|_| PathBuf::from("~/.agpm/config.toml"))
         });
 
         println!("{}", "Global Configuration".bold());
@@ -462,7 +462,7 @@ impl ConfigCommand {
         if config.sources.is_empty() {
             println!("No global sources configured.");
             println!("\n{}", "Tip:".yellow());
-            println!("  Run 'ccpm config init' to create an example configuration");
+            println!("  Run 'agpm config init' to create an example configuration");
         } else {
             println!("{}", toml::to_string_pretty(&config)?);
         }
@@ -472,7 +472,7 @@ impl ConfigCommand {
 
     async fn edit_with_path(config_path: Option<PathBuf>) -> Result<()> {
         let config_path = config_path.unwrap_or_else(|| {
-            GlobalConfig::default_path().unwrap_or_else(|_| PathBuf::from("~/.ccpm/config.toml"))
+            GlobalConfig::default_path().unwrap_or_else(|_| PathBuf::from("~/.agpm/config.toml"))
         });
 
         if !config_path.exists() {
@@ -525,7 +525,7 @@ impl ConfigCommand {
 
         config.add_source(name.clone(), url.clone());
         let save_path = config_path.unwrap_or_else(|| {
-            GlobalConfig::default_path().unwrap_or_else(|_| PathBuf::from("~/.ccpm/config.toml"))
+            GlobalConfig::default_path().unwrap_or_else(|_| PathBuf::from("~/.agpm/config.toml"))
         });
         config.save_to(&save_path).await?;
 
@@ -547,7 +547,7 @@ impl ConfigCommand {
         if config.remove_source(&name) {
             let save_path = config_path.unwrap_or_else(|| {
                 GlobalConfig::default_path()
-                    .unwrap_or_else(|_| PathBuf::from("~/.ccpm/config.toml"))
+                    .unwrap_or_else(|_| PathBuf::from("~/.agpm/config.toml"))
             });
             config.save_to(&save_path).await?;
             println!("✅ Removed global source '{}'", name.red());
@@ -566,9 +566,9 @@ impl ConfigCommand {
         if config.sources.is_empty() {
             println!("No global sources configured.");
             println!("\n{}", "Tip:".yellow());
-            println!("  Add a source with: ccpm config add-source <name> <url>");
+            println!("  Add a source with: agpm config add-source <name> <url>");
             println!(
-                "  Example: ccpm config add-source private https://oauth2:TOKEN@gitlab.com/company/agents.git"
+                "  Example: agpm config add-source private https://oauth2:TOKEN@gitlab.com/company/agents.git"
             );
         } else {
             println!("{}", "Global Sources:".bold());
@@ -599,7 +599,7 @@ impl ConfigCommand {
 
     fn show_path(config_path: Option<PathBuf>) -> Result<()> {
         let config_path = config_path.unwrap_or_else(|| {
-            GlobalConfig::default_path().unwrap_or_else(|_| PathBuf::from("~/.ccpm/config.toml"))
+            GlobalConfig::default_path().unwrap_or_else(|_| PathBuf::from("~/.agpm/config.toml"))
         });
         println!("{}", config_path.display());
         Ok(())
@@ -639,7 +639,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
-    // This test specifically tests CCPM_CONFIG_PATH environment variable handling
+    // This test specifically tests AGPM_CONFIG_PATH environment variable handling
     #[tokio::test]
     async fn test_config_show_empty() {
         let temp = TempDir::new().unwrap();

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -1,24 +1,24 @@
-//! Initialize a new CCPM project with a manifest file.
+//! Initialize a new AGPM project with a manifest file.
 //!
-//! This module provides the `init` command which creates a new `ccpm.toml` manifest file
+//! This module provides the `init` command which creates a new `agpm.toml` manifest file
 //! in the specified directory (or current directory). The manifest file is the main
-//! configuration file for a CCPM project that defines dependencies on Claude Code resources.
+//! configuration file for a AGPM project that defines dependencies on Claude Code resources.
 //!
 //! # Examples
 //!
 //! Initialize a manifest in the current directory:
 //! ```bash
-//! ccpm init
+//! agpm init
 //! ```
 //!
 //! Initialize a manifest in a specific directory:
 //! ```bash
-//! ccpm init --path ./my-project
+//! agpm init --path ./my-project
 //! ```
 //!
 //! Force overwrite an existing manifest:
 //! ```bash
-//! ccpm init --force
+//! agpm init --force
 //! ```
 //!
 //! # Manifest Structure
@@ -57,16 +57,16 @@ use colored::Colorize;
 use std::fs;
 use std::path::PathBuf;
 
-/// Command to initialize a new CCPM project with a manifest file.
+/// Command to initialize a new AGPM project with a manifest file.
 ///
-/// This command creates a `ccpm.toml` manifest file in the specified directory
+/// This command creates a `agpm.toml` manifest file in the specified directory
 /// (or current directory if no path is provided). The manifest serves as the
 /// main configuration file for defining Claude Code resource dependencies.
 ///
 /// # Examples
 ///
 /// ```rust,ignore
-/// use ccpm::cli::init::InitCommand;
+/// use agpm::cli::init::InitCommand;
 /// use std::path::PathBuf;
 ///
 /// // Initialize in current directory
@@ -92,7 +92,7 @@ pub struct InitCommand {
 
     /// Force overwrite if manifest already exists
     ///
-    /// By default, the command will fail if a `ccpm.toml` file already exists
+    /// By default, the command will fail if a `agpm.toml` file already exists
     /// in the target directory. Use this flag to overwrite an existing file.
     #[arg(short, long)]
     force: bool,
@@ -109,9 +109,9 @@ impl InitCommand {
         self.execute().await
     }
 
-    /// Execute the init command to create a new CCPM manifest file.
+    /// Execute the init command to create a new AGPM manifest file.
     ///
-    /// This method creates a `ccpm.toml` manifest file with a minimal template structure
+    /// This method creates a `agpm.toml` manifest file with a minimal template structure
     /// that includes empty sections for all resource types. The file is
     /// created in the specified directory or current directory if no path is provided.
     ///
@@ -120,7 +120,7 @@ impl InitCommand {
     /// 1. Determines the target directory (from `path` option or current directory)
     /// 2. Checks if a manifest already exists and handles the `force` flag
     /// 3. Creates the target directory if it doesn't exist
-    /// 4. Writes the manifest template to `ccpm.toml`
+    /// 4. Writes the manifest template to `agpm.toml`
     /// 5. Displays success message and next steps to the user
     ///
     /// # Returns
@@ -134,7 +134,7 @@ impl InitCommand {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// use ccpm::cli::init::InitCommand;
+    /// use agpm::cli::init::InitCommand;
     /// use std::path::PathBuf;
     ///
     /// # tokio_test::block_on(async {
@@ -143,14 +143,14 @@ impl InitCommand {
     ///     force: false,
     /// };
     ///
-    /// // This would create ./test-project/ccpm.toml
+    /// // This would create ./test-project/agpm.toml
     /// // cmd.execute().await?;
     /// # Ok::<(), anyhow::Error>(())
     /// # });
     /// ```
     pub async fn execute(self) -> Result<()> {
         let target_dir = self.path.unwrap_or_else(|| PathBuf::from("."));
-        let manifest_path = target_dir.join("ccpm.toml");
+        let manifest_path = target_dir.join("agpm.toml");
         let gitignore_path = target_dir.join(".gitignore");
 
         // Check if manifest already exists
@@ -167,12 +167,12 @@ impl InitCommand {
         }
 
         // Write a minimal template with empty sections
-        let template = r#"# CCPM Manifest
+        let template = r#"# AGPM Manifest
 # This file defines your Claude Code resource dependencies
 
 [sources]
 # Add your Git repository sources here
-# Example: official = "https://github.com/aig787/ccpm-community.git"
+# Example: official = "https://github.com/aig787/agpm-community.git"
 
 [agents]
 # Add your agent dependencies here
@@ -200,8 +200,8 @@ impl InitCommand {
 "#;
         fs::write(&manifest_path, template)?;
 
-        // Update or create .gitignore with CCPM entries
-        let gitignore_entries = vec![".claude/ccpm/"];
+        // Update or create .gitignore with AGPM entries
+        let gitignore_entries = vec![".claude/agpm/"];
 
         let mut gitignore_content = if gitignore_path.exists() {
             fs::read_to_string(&gitignore_path)?
@@ -209,16 +209,16 @@ impl InitCommand {
             String::new()
         };
 
-        // Check if CCPM section exists
-        if !gitignore_content.contains("# CCPM managed directories") {
-            // Add CCPM entries
+        // Check if AGPM section exists
+        if !gitignore_content.contains("# AGPM managed directories") {
+            // Add AGPM entries
             if !gitignore_content.is_empty() && !gitignore_content.ends_with('\n') {
                 gitignore_content.push('\n');
             }
             if !gitignore_content.is_empty() {
                 gitignore_content.push('\n');
             }
-            gitignore_content.push_str("# CCPM managed directories\n");
+            gitignore_content.push_str("# AGPM managed directories\n");
 
             for entry in gitignore_entries {
                 // Check if entry doesn't already exist
@@ -229,22 +229,22 @@ impl InitCommand {
             }
 
             fs::write(&gitignore_path, gitignore_content)?;
-            println!("{} Updated .gitignore with CCPM entries", "✓".green());
+            println!("{} Updated .gitignore with AGPM entries", "✓".green());
         }
 
         println!(
-            "{} Initialized ccpm.toml at {}",
+            "{} Initialized agpm.toml at {}",
             "✓".green(),
             manifest_path.display()
         );
 
         println!("\n{}", "Next steps:".cyan());
-        println!("  Add dependencies with {}:", "ccpm add".bright_white());
+        println!("  Add dependencies with {}:", "agpm add".bright_white());
         println!(
-            "    ccpm add agent my-agent --source https://github.com/org/repo.git --path agents/my-agent.md"
+            "    agpm add agent my-agent --source https://github.com/org/repo.git --path agents/my-agent.md"
         );
-        println!("    ccpm add snippet utils --path ../local/snippets/utils.md");
-        println!("\n  Then run {} to install", "ccpm install".bright_white());
+        println!("    agpm add snippet utils --path ../local/snippets/utils.md");
+        println!("\n  Then run {} to install", "agpm install".bright_white());
 
         Ok(())
     }
@@ -266,7 +266,7 @@ mod tests {
         let result = cmd.execute().await;
         assert!(result.is_ok());
 
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
         assert!(manifest_path.exists());
 
         let content = fs::read_to_string(&manifest_path).unwrap();
@@ -289,13 +289,13 @@ mod tests {
         assert!(result.is_ok());
 
         assert!(new_dir.exists());
-        assert!(new_dir.join("ccpm.toml").exists());
+        assert!(new_dir.join("agpm.toml").exists());
     }
 
     #[tokio::test]
     async fn test_init_fails_if_manifest_exists() {
         let temp_dir = TempDir::new().unwrap();
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
         fs::write(&manifest_path, "existing content").unwrap();
 
         let cmd = InitCommand {
@@ -311,7 +311,7 @@ mod tests {
     #[tokio::test]
     async fn test_init_force_overwrites_existing() {
         let temp_dir = TempDir::new().unwrap();
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
         fs::write(&manifest_path, "old content").unwrap();
 
         let cmd = InitCommand {
@@ -339,7 +339,7 @@ mod tests {
 
         let result = cmd.execute().await;
         assert!(result.is_ok());
-        assert!(temp_dir.path().join("ccpm.toml").exists());
+        assert!(temp_dir.path().join("agpm.toml").exists());
     }
 
     #[tokio::test]
@@ -353,11 +353,11 @@ mod tests {
         let result = cmd.execute().await;
         assert!(result.is_ok());
 
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
         let content = fs::read_to_string(&manifest_path).unwrap();
 
         // Verify template content
-        assert!(content.contains("# CCPM Manifest"));
+        assert!(content.contains("# AGPM Manifest"));
         assert!(content.contains("# This file defines your Claude Code resource dependencies"));
         assert!(content.contains("# Add your Git repository sources here"));
         assert!(content.contains("# Example: official ="));
@@ -380,13 +380,13 @@ mod tests {
         let result = cmd.execute().await;
         assert!(result.is_ok());
         assert!(nested_path.exists());
-        assert!(nested_path.join("ccpm.toml").exists());
+        assert!(nested_path.join("agpm.toml").exists());
     }
 
     #[tokio::test]
     async fn test_init_force_flag_behavior() {
         let temp_dir = TempDir::new().unwrap();
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
 
         // Write initial content
         let initial_content = "# Old manifest\n[sources]\n";
@@ -414,7 +414,7 @@ mod tests {
 
         // Verify new template content
         let new_content = fs::read_to_string(&manifest_path).unwrap();
-        assert!(new_content.contains("# CCPM Manifest"));
+        assert!(new_content.contains("# AGPM Manifest"));
         assert!(!new_content.contains("# Old manifest"));
     }
 
@@ -433,8 +433,8 @@ mod tests {
         assert!(gitignore_path.exists());
 
         let content = fs::read_to_string(&gitignore_path).unwrap();
-        assert!(content.contains("# CCPM managed directories"));
-        assert!(content.contains(".claude/ccpm/"));
+        assert!(content.contains("# AGPM managed directories"));
+        assert!(content.contains(".claude/agpm/"));
     }
 
     #[tokio::test]
@@ -457,9 +457,9 @@ mod tests {
         // Should preserve existing content
         assert!(content.contains("node_modules/"));
         assert!(content.contains("*.log"));
-        // Should add CCPM entries
-        assert!(content.contains("# CCPM managed directories"));
-        assert!(content.contains(".claude/ccpm/"));
+        // Should add AGPM entries
+        assert!(content.contains("# AGPM managed directories"));
+        assert!(content.contains(".claude/agpm/"));
     }
 
     #[tokio::test]
@@ -487,10 +487,10 @@ mod tests {
 
         let second_content = fs::read_to_string(&gitignore_path).unwrap();
 
-        // Should not have duplicated the CCPM section
+        // Should not have duplicated the AGPM section
         assert_eq!(
-            first_content.matches("# CCPM managed directories").count(),
-            second_content.matches("# CCPM managed directories").count()
+            first_content.matches("# AGPM managed directories").count(),
+            second_content.matches("# AGPM managed directories").count()
         );
     }
 }

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -1,7 +1,7 @@
 //! Install Claude Code resources from manifest dependencies.
 //!
 //! This module provides the `install` command which reads dependencies from the
-//! `ccpm.toml` manifest file, resolves them, and installs the resource files
+//! `agpm.toml` manifest file, resolves them, and installs the resource files
 //! to the project directory. The command supports both fresh installations and
 //! updates to existing installations with advanced parallel processing capabilities.
 //!
@@ -9,7 +9,7 @@
 //!
 //! - **Dependency Resolution**: Resolves all dependencies defined in the manifest
 //! - **Transitive Dependencies**: Automatically discovers and installs dependencies declared in resource files
-//! - **Lockfile Management**: Generates and maintains `ccpm.lock` for reproducible builds
+//! - **Lockfile Management**: Generates and maintains `agpm.lock` for reproducible builds
 //! - **Worktree-Based Parallel Installation**: Uses Git worktrees for safe concurrent resource installation
 //! - **Multi-Phase Progress Tracking**: Shows detailed progress with phase transitions and real-time updates
 //! - **Resource Validation**: Validates markdown files and content during installation
@@ -21,42 +21,42 @@
 //!
 //! Install all dependencies from manifest:
 //! ```bash
-//! ccpm install
+//! agpm install
 //! ```
 //!
 //! Force reinstall all dependencies:
 //! ```bash
-//! ccpm install --force
+//! agpm install --force
 //! ```
 //!
 //! Install without creating lockfile:
 //! ```bash
-//! ccpm install --no-lock
+//! agpm install --no-lock
 //! ```
 //!
 //! Use frozen lockfile (CI/production):
 //! ```bash
-//! ccpm install --frozen
+//! agpm install --frozen
 //! ```
 //!
 //! Disable cache and clone fresh:
 //! ```bash
-//! ccpm install --no-cache
+//! agpm install --no-cache
 //! ```
 //!
 //! Install only direct dependencies (skip transitive):
 //! ```bash
-//! ccpm install --no-transitive
+//! agpm install --no-transitive
 //! ```
 //!
 //! Preview installation without making changes:
 //! ```bash
-//! ccpm install --dry-run
+//! agpm install --dry-run
 //! ```
 //!
 //! # Installation Process
 //!
-//! 1. **Manifest Loading**: Reads `ccpm.toml` to understand dependencies
+//! 1. **Manifest Loading**: Reads `agpm.toml` to understand dependencies
 //! 2. **Source Synchronization**: Clones/fetches Git repositories for all sources
 //! 3. **Dependency Resolution**: Resolves versions and creates dependency graph
 //! 4. **Transitive Discovery**: Extracts dependencies from resource files (YAML/JSON metadata)
@@ -65,7 +65,7 @@
 //! 7. **Parallel Resource Installation**: Installs resources concurrently using isolated worktrees
 //! 8. **Progress Coordination**: Updates multi-phase progress tracking throughout installation
 //! 9. **Configuration Updates**: Updates hooks and MCP server configurations as needed
-//! 10. **Lockfile Generation**: Creates or updates `ccpm.lock` with checksums and metadata
+//! 10. **Lockfile Generation**: Creates or updates `agpm.lock` with checksums and metadata
 //! 11. **Artifact Cleanup**: Removes old artifacts from removed or relocated dependencies
 //!
 //! # Error Conditions
@@ -102,23 +102,23 @@ use crate::resolver::DependencyResolver;
 
 /// Command to install Claude Code resources from manifest dependencies.
 ///
-/// This command reads the project's `ccpm.toml` manifest file, resolves all dependencies,
+/// This command reads the project's `agpm.toml` manifest file, resolves all dependencies,
 /// and installs the resource files to the appropriate directories. It generates or updates
-/// a `ccpm.lock` lockfile to ensure reproducible installations.
+/// a `agpm.lock` lockfile to ensure reproducible installations.
 ///
 /// # Behavior
 ///
-/// 1. Locates and loads the project manifest (`ccpm.toml`)
+/// 1. Locates and loads the project manifest (`agpm.toml`)
 /// 2. Resolves dependencies using the dependency resolver
 /// 3. Downloads or updates Git repository sources as needed
 /// 4. Installs resource files to target directories
-/// 5. Generates or updates the lockfile (`ccpm.lock`)
+/// 5. Generates or updates the lockfile (`agpm.lock`)
 /// 6. Provides progress feedback during installation
 ///
 /// # Examples
 ///
 /// ```rust,ignore
-/// use ccpm::cli::install::InstallCommand;
+/// use agpm::cli::install::InstallCommand;
 ///
 /// // Standard installation
 /// let cmd = InstallCommand {
@@ -142,7 +142,7 @@ use crate::resolver::DependencyResolver;
 pub struct InstallCommand {
     /// Don't write lockfile after installation
     ///
-    /// Prevents the command from creating or updating the `ccpm.lock` file.
+    /// Prevents the command from creating or updating the `agpm.lock` file.
     /// This is useful for development scenarios where you don't want to
     /// commit lockfile changes.
     #[arg(long)]
@@ -240,7 +240,7 @@ impl InstallCommand {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// use ccpm::cli::install::InstallCommand;
+    /// use agpm::cli::install::InstallCommand;
     ///
     /// let cmd = InstallCommand::new();
     /// // cmd can now be executed with execute_from_path()
@@ -268,7 +268,7 @@ impl InstallCommand {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// use ccpm::cli::install::InstallCommand;
+    /// use agpm::cli::install::InstallCommand;
     ///
     /// let cmd = InstallCommand::new_quiet();
     /// // cmd will execute without progress bars or status messages
@@ -290,27 +290,27 @@ impl InstallCommand {
     /// Executes the install command with automatic manifest discovery.
     ///
     /// This method provides convenient manifest file discovery, searching for
-    /// `ccpm.toml` in the current directory and parent directories if no specific
+    /// `agpm.toml` in the current directory and parent directories if no specific
     /// path is provided. It's the standard entry point for CLI usage.
     ///
     /// # Arguments
     ///
-    /// * `manifest_path` - Optional explicit path to `ccpm.toml`. If `None`,
-    ///   the method searches for `ccpm.toml` starting from the current directory
+    /// * `manifest_path` - Optional explicit path to `agpm.toml`. If `None`,
+    ///   the method searches for `agpm.toml` starting from the current directory
     ///   and walking up the directory tree.
     ///
     /// # Manifest Discovery
     ///
     /// When `manifest_path` is `None`, the search process:
-    /// 1. Checks current directory for `ccpm.toml`
-    /// 2. Walks up parent directories until `ccpm.toml` is found
+    /// 1. Checks current directory for `agpm.toml`
+    /// 2. Walks up parent directories until `agpm.toml` is found
     /// 3. Stops at filesystem root if no manifest found
     /// 4. Returns an error with helpful guidance if no manifest exists
     ///
     /// # Examples
     ///
     /// ```rust,ignore
-    /// use ccpm::cli::install::InstallCommand;
+    /// use agpm::cli::install::InstallCommand;
     /// use std::path::PathBuf;
     ///
     /// # async fn example() -> anyhow::Result<()> {
@@ -320,7 +320,7 @@ impl InstallCommand {
     /// cmd.execute_with_manifest_path(None).await?;
     ///
     /// // Use specific manifest file
-    /// cmd.execute_with_manifest_path(Some(PathBuf::from("./my-project/ccpm.toml"))).await?;
+    /// cmd.execute_with_manifest_path(Some(PathBuf::from("./my-project/agpm.toml"))).await?;
     /// # Ok(())
     /// # }
     /// ```
@@ -328,7 +328,7 @@ impl InstallCommand {
     /// # Errors
     ///
     /// Returns an error if:
-    /// - No `ccpm.toml` file found in search path
+    /// - No `agpm.toml` file found in search path
     /// - Specified manifest path doesn't exist
     /// - Manifest file contains invalid TOML syntax
     /// - Dependencies cannot be resolved
@@ -338,9 +338,9 @@ impl InstallCommand {
     ///
     /// When no manifest is found, the error includes helpful guidance:
     /// ```text
-    /// No ccpm.toml found in current directory or any parent directory.
+    /// No agpm.toml found in current directory or any parent directory.
     ///
-    /// To get started, create a ccpm.toml file with your dependencies:
+    /// To get started, create a agpm.toml file with your dependencies:
     ///
     /// [sources]
     /// official = "https://github.com/example-org/ccpm-official.git"
@@ -351,8 +351,8 @@ impl InstallCommand {
     pub async fn execute_with_manifest_path(self, manifest_path: Option<PathBuf>) -> Result<()> {
         // Find manifest file
         let manifest_path = find_manifest_with_optional(manifest_path).with_context(|| {
-"No ccpm.toml found in current directory or any parent directory.\n\n\
-            To get started, create a ccpm.toml file with your dependencies:\n\n\
+"No agpm.toml found in current directory or any parent directory.\n\n\
+            To get started, create a agpm.toml file with your dependencies:\n\n\
             [sources]\n\
             official = \"https://github.com/example-org/ccpm-official.git\"\n\n\
             [agents]\n\
@@ -371,12 +371,12 @@ impl InstallCommand {
         let manifest_path = if let Some(p) = path {
             p.to_path_buf()
         } else {
-            std::env::current_dir()?.join("ccpm.toml")
+            std::env::current_dir()?.join("agpm.toml")
         };
 
         if !manifest_path.exists() {
             return Err(anyhow::anyhow!(
-                "No ccpm.toml found at {}",
+                "No agpm.toml found at {}",
                 manifest_path.display()
             ));
         }
@@ -387,7 +387,7 @@ impl InstallCommand {
         let lockfile_path = manifest_path
             .parent()
             .unwrap_or_else(|| Path::new("."))
-            .join("ccpm.lock");
+            .join("agpm.lock");
 
         if self.frozen && lockfile_path.exists() {
             // Check for critical issues (corruption/security) but not version/path changes
@@ -413,7 +413,7 @@ impl InstallCommand {
             .ok_or_else(|| anyhow::anyhow!("Invalid manifest path"))?;
 
         // Check for existing lockfile
-        let lockfile_path = actual_project_dir.join("ccpm.lock");
+        let lockfile_path = actual_project_dir.join("agpm.lock");
 
         let existing_lockfile = if lockfile_path.exists() {
             Some(LockFile::load(&lockfile_path)?)
@@ -964,25 +964,25 @@ mod tests {
     #[tokio::test]
     async fn test_install_command_no_manifest() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         let cmd = InstallCommand::new();
         let result = cmd.execute_from_path(Some(&manifest_path)).await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("ccpm.toml"));
+        assert!(result.unwrap_err().to_string().contains("agpm.toml"));
     }
 
     #[tokio::test]
     async fn test_install_with_empty_manifest() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
         Manifest::new().save(&manifest_path).unwrap();
 
         let cmd = InstallCommand::new();
         let result = cmd.execute_from_path(Some(&manifest_path)).await;
         assert!(result.is_ok());
 
-        let lockfile_path = temp.path().join("ccpm.lock");
+        let lockfile_path = temp.path().join("agpm.lock");
         assert!(lockfile_path.exists());
         let lockfile = LockFile::load(&lockfile_path).unwrap();
         assert!(lockfile.agents.is_empty());
@@ -1002,7 +1002,7 @@ mod tests {
     #[tokio::test]
     async fn test_install_respects_no_lock_flag() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
         Manifest::new().save(&manifest_path).unwrap();
 
         let cmd = InstallCommand {
@@ -1018,13 +1018,13 @@ mod tests {
 
         let result = cmd.execute_from_path(Some(&manifest_path)).await;
         assert!(result.is_ok());
-        assert!(!temp.path().join("ccpm.lock").exists());
+        assert!(!temp.path().join("agpm.lock").exists());
     }
 
     #[tokio::test]
     async fn test_install_with_local_dependency() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
         let local_file = temp.path().join("local-agent.md");
         fs::write(
             &local_file,
@@ -1060,7 +1060,7 @@ This is a test agent.",
     #[tokio::test]
     async fn test_install_with_invalid_manifest_syntax() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
         fs::write(&manifest_path, "[invalid toml").unwrap();
 
         let cmd = InstallCommand::new();
@@ -1081,8 +1081,8 @@ This is a test agent.",
     #[tokio::test]
     async fn test_install_uses_existing_lockfile_when_frozen() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
-        let lockfile_path = temp.path().join("ccpm.lock");
+        let manifest_path = temp.path().join("agpm.toml");
+        let lockfile_path = temp.path().join("agpm.lock");
 
         let local_file = temp.path().join("test-agent.md");
         fs::write(
@@ -1153,7 +1153,7 @@ Body",
     #[tokio::test]
     async fn test_install_errors_when_local_file_missing() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         let mut manifest = Manifest::new();
         manifest.agents.insert(
@@ -1183,7 +1183,7 @@ Body",
     #[tokio::test]
     async fn test_install_single_resource_paths() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
         let snippet_file = temp.path().join("single-snippet.md");
         fs::write(
             &snippet_file,
@@ -1213,7 +1213,7 @@ Body",
         let cmd = InstallCommand::new();
         assert!(cmd.execute_from_path(Some(&manifest_path)).await.is_ok());
 
-        let lockfile = LockFile::load(&temp.path().join("ccpm.lock")).unwrap();
+        let lockfile = LockFile::load(&temp.path().join("agpm.lock")).unwrap();
         assert_eq!(lockfile.snippets.len(), 1);
         let installed_path = temp.path().join(&lockfile.snippets[0].installed_at);
         assert!(installed_path.exists());
@@ -1222,7 +1222,7 @@ Body",
     #[tokio::test]
     async fn test_install_single_command_resource() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
         let command_file = temp.path().join("single-command.md");
         fs::write(
             &command_file,
@@ -1252,7 +1252,7 @@ Body",
         let cmd = InstallCommand::new();
         assert!(cmd.execute_from_path(Some(&manifest_path)).await.is_ok());
 
-        let lockfile = LockFile::load(&temp.path().join("ccpm.lock")).unwrap();
+        let lockfile = LockFile::load(&temp.path().join("agpm.lock")).unwrap();
         assert_eq!(lockfile.commands.len(), 1);
         assert!(
             temp.path()
@@ -1264,8 +1264,8 @@ Body",
     #[tokio::test]
     async fn test_install_dry_run_mode() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
-        let lockfile_path = temp.path().join("ccpm.lock");
+        let manifest_path = temp.path().join("agpm.toml");
+        let lockfile_path = temp.path().join("agpm.lock");
         let agent_file = temp.path().join("test-agent.md");
 
         // Create a local file for the agent
@@ -1317,7 +1317,7 @@ Body",
     #[tokio::test]
     async fn test_install_summary_with_mcp_servers() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
         let agent_file = temp.path().join("summary-agent.md");
         fs::write(&agent_file, "# Agent\nBody").unwrap();
 

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -1,7 +1,7 @@
 //! List installed Claude Code resources from the lockfile.
 //!
 //! This module provides the `list` command which displays information about
-//! currently installed dependencies as recorded in the lockfile (`ccpm.lock`).
+//! currently installed dependencies as recorded in the lockfile (`agpm.lock`).
 //! The command offers various output formats and filtering options to help
 //! users understand their project's dependencies.
 //!
@@ -17,32 +17,32 @@
 //!
 //! List all installed resources:
 //! ```bash
-//! ccpm list
+//! agpm list
 //! ```
 //!
 //! List only agents:
 //! ```bash
-//! ccpm list --agents
+//! agpm list --agents
 //! ```
 //!
 //! List with detailed information:
 //! ```bash
-//! ccpm list --details
+//! agpm list --details
 //! ```
 //!
 //! Output in JSON format:
 //! ```bash
-//! ccpm list --format json
+//! agpm list --format json
 //! ```
 //!
 //! Show dependency tree:
 //! ```bash
-//! ccpm list --format tree
+//! agpm list --format tree
 //! ```
 //!
 //! List specific dependencies:
 //! ```bash
-//! ccpm list my-agent utils-snippet
+//! agpm list my-agent utils-snippet
 //! ```
 //!
 //! # Output Formats
@@ -75,8 +75,8 @@
 //! # Data Sources
 //!
 //! The command primarily reads from:
-//! - **Primary**: `ccpm.lock` - Contains installed resource information
-//! - **Secondary**: `ccpm.toml` - Used for manifest comparison and validation
+//! - **Primary**: `agpm.lock` - Contains installed resource information
+//! - **Secondary**: `agpm.toml` - Used for manifest comparison and validation
 //!
 //! # Error Conditions
 //!
@@ -128,7 +128,7 @@ struct ListItem {
 /// # Examples
 ///
 /// ```rust,ignore
-/// use ccpm::cli::list::ListCommand;
+/// use agpm::cli::list::ListCommand;
 ///
 /// // List all resources in default table format
 /// let cmd = ListCommand {
@@ -196,8 +196,8 @@ pub struct ListCommand {
 
     /// Show from manifest instead of lockfile
     ///
-    /// When enabled, shows dependencies defined in the manifest (`ccpm.toml`)
-    /// rather than installed dependencies from the lockfile (`ccpm.lock`).
+    /// When enabled, shows dependencies defined in the manifest (`agpm.toml`)
+    /// rather than installed dependencies from the lockfile (`agpm.lock`).
     /// This is useful for comparing intended vs. actual installations.
     #[arg(long)]
     manifest: bool,
@@ -271,8 +271,8 @@ impl ListCommand {
     ///
     /// # Data Sources
     ///
-    /// - **Default**: Uses lockfile (`ccpm.lock`) to show installed resources
-    /// - **Manifest Mode**: Uses manifest (`ccpm.toml`) to show defined dependencies
+    /// - **Default**: Uses lockfile (`agpm.lock`) to show installed resources
+    /// - **Manifest Mode**: Uses manifest (`agpm.toml`) to show defined dependencies
     ///
     /// # Filtering Logic
     ///
@@ -293,7 +293,7 @@ impl ListCommand {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// use ccpm::cli::list::ListCommand;
+    /// use agpm::cli::list::ListCommand;
     ///
     /// # tokio_test::block_on(async {
     /// let cmd = ListCommand {
@@ -320,7 +320,7 @@ impl ListCommand {
 
         // Find manifest file
         let manifest_path = find_manifest_with_optional(manifest_path)
-            .context("No ccpm.toml found. Please create one to define your dependencies.")?;
+            .context("No agpm.toml found. Please create one to define your dependencies.")?;
 
         self.execute_from_path(manifest_path).await
     }
@@ -454,20 +454,20 @@ impl ListCommand {
         self.sort_items(&mut items);
 
         // Output results
-        self.output_items(&items, "Dependencies from ccpm.toml:")?;
+        self.output_items(&items, "Dependencies from agpm.toml:")?;
 
         Ok(())
     }
 
     fn list_from_lockfile(&self, project_dir: &std::path::Path) -> Result<()> {
-        let lockfile_path = project_dir.join("ccpm.lock");
+        let lockfile_path = project_dir.join("agpm.lock");
 
         if !lockfile_path.exists() {
             if self.format == "json" {
                 println!("{{}}");
             } else {
                 println!("No installed resources found.");
-                println!("⚠️  ccpm.lock not found. Run 'ccpm install' first.");
+                println!("⚠️  agpm.lock not found. Run 'agpm install' first.");
             }
             return Ok(());
         }
@@ -500,7 +500,7 @@ impl ListCommand {
         // Handle special flags
 
         // Output results
-        self.output_items(&items, "Installed resources from ccpm.lock:")?;
+        self.output_items(&items, "Installed resources from agpm.lock:")?;
 
         Ok(())
     }
@@ -1003,8 +1003,8 @@ mod tests {
     #[tokio::test]
     async fn test_list_no_manifest() {
         let temp = TempDir::new().unwrap();
-        // Don't create ccpm.toml
-        let manifest_path = temp.path().join("ccpm.toml");
+        // Don't create agpm.toml
+        let manifest_path = temp.path().join("agpm.toml");
 
         let cmd = create_default_command();
 
@@ -1016,7 +1016,7 @@ mod tests {
     #[tokio::test]
     async fn test_list_empty_manifest() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create empty manifest
         let manifest = crate::manifest::Manifest::new();
@@ -1034,7 +1034,7 @@ mod tests {
     #[tokio::test]
     async fn test_list_from_manifest_with_resources() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest with resources
         let manifest = create_test_manifest();
@@ -1052,7 +1052,7 @@ mod tests {
     #[tokio::test]
     async fn test_list_from_lockfile_no_lockfile() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest but no lockfile
         let manifest = create_test_manifest();
@@ -1067,8 +1067,8 @@ mod tests {
     #[tokio::test]
     async fn test_list_from_lockfile_with_resources() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
-        let lockfile_path = temp.path().join("ccpm.lock");
+        let manifest_path = temp.path().join("agpm.toml");
+        let lockfile_path = temp.path().join("agpm.lock");
 
         // Create both manifest and lockfile
         let manifest = create_test_manifest();
@@ -1621,7 +1621,7 @@ mod tests {
     #[tokio::test]
     async fn test_list_with_json_format() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest with resources
         let manifest = create_test_manifest();
@@ -1640,7 +1640,7 @@ mod tests {
     #[tokio::test]
     async fn test_list_with_yaml_format() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest with resources
         let manifest = create_test_manifest();
@@ -1659,7 +1659,7 @@ mod tests {
     #[tokio::test]
     async fn test_list_with_compact_format() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest with resources
         let manifest = create_test_manifest();
@@ -1678,7 +1678,7 @@ mod tests {
     #[tokio::test]
     async fn test_list_with_simple_format() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest with resources
         let manifest = create_test_manifest();
@@ -1697,7 +1697,7 @@ mod tests {
     #[tokio::test]
     async fn test_list_filter_by_agents_only() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest with both agents and snippets
         let manifest = create_test_manifest();
@@ -1716,7 +1716,7 @@ mod tests {
     #[tokio::test]
     async fn test_list_filter_by_snippets_only() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest with both agents and snippets
         let manifest = create_test_manifest();
@@ -1735,7 +1735,7 @@ mod tests {
     #[tokio::test]
     async fn test_list_filter_by_type() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest with both agents and snippets
         let manifest = create_test_manifest();
@@ -1765,7 +1765,7 @@ mod tests {
     #[tokio::test]
     async fn test_list_filter_by_source() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest with resources from different sources
         let manifest = create_test_manifest();
@@ -1784,7 +1784,7 @@ mod tests {
     #[tokio::test]
     async fn test_list_search_by_pattern() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest with resources
         let manifest = create_test_manifest();
@@ -1803,7 +1803,7 @@ mod tests {
     #[tokio::test]
     async fn test_list_with_detailed_flag() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest with resources
         let manifest = create_test_manifest();
@@ -1822,7 +1822,7 @@ mod tests {
     #[tokio::test]
     async fn test_list_with_files_flag() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest with resources
         let manifest = create_test_manifest();
@@ -1841,7 +1841,7 @@ mod tests {
     #[tokio::test]
     async fn test_list_with_verbose_flag() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest with resources
         let manifest = create_test_manifest();
@@ -1860,7 +1860,7 @@ mod tests {
     #[tokio::test]
     async fn test_list_with_sort() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest with resources
         let manifest = create_test_manifest();
@@ -1879,7 +1879,7 @@ mod tests {
     #[tokio::test]
     async fn test_list_empty_lockfile_json_output() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest but no lockfile
         let manifest = create_test_manifest();

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -368,8 +368,7 @@ impl ListCommand {
                 "agents" | "snippets" => {}
                 _ => {
                     return Err(anyhow::anyhow!(
-                        "Invalid type '{}'. Valid types are: agents, snippets",
-                        t
+                        "Invalid type '{t}'. Valid types are: agents, snippets"
                     ));
                 }
             }
@@ -381,8 +380,7 @@ impl ListCommand {
                 "name" | "version" | "source" | "type" => {}
                 _ => {
                     return Err(anyhow::anyhow!(
-                        "Invalid sort field '{}'. Valid fields are: name, version, source, type",
-                        field
+                        "Invalid sort field '{field}'. Valid fields are: name, version, source, type"
                     ));
                 }
             }
@@ -512,7 +510,7 @@ impl ListCommand {
         // Check if there's a type filter
         if let Some(ref t) = self.r#type {
             let type_str = resource_type.to_string();
-            return t == &type_str || t == &format!("{}s", type_str);
+            return t == &type_str || t == &format!("{type_str}s");
         }
 
         // Check individual flags

--- a/src/cli/migrate.rs
+++ b/src/cli/migrate.rs
@@ -1,0 +1,252 @@
+//! Migration command for renaming legacy CCPM files to AGPM.
+//!
+//! This module provides functionality to migrate from the legacy CCPM (Claude Code Package Manager)
+//! naming to the new AGPM naming. It detects and renames ccpm.toml and ccpm.lock files to their
+//! agpm equivalents.
+
+use anyhow::{Context, Result, bail};
+use clap::Parser;
+use colored::Colorize;
+use std::path::{Path, PathBuf};
+
+/// Migrate from legacy CCPM naming to AGPM.
+///
+/// This command detects ccpm.toml and ccpm.lock files in the current directory
+/// and renames them to agpm.toml and agpm.lock respectively.
+///
+/// # Examples
+///
+/// ```bash
+/// # Migrate in current directory
+/// agpm migrate
+///
+/// # Migrate with custom path
+/// agpm migrate --path /path/to/project
+///
+/// # Dry run to see what would be renamed
+/// agpm migrate --dry-run
+/// ```
+#[derive(Parser, Debug)]
+#[command(name = "migrate")]
+pub struct MigrateCommand {
+    /// Path to the directory containing ccpm.toml/ccpm.lock files.
+    ///
+    /// Defaults to the current directory if not specified.
+    #[arg(short, long)]
+    path: Option<PathBuf>,
+
+    /// Show what would be renamed without actually renaming files.
+    ///
+    /// This is useful for previewing the migration before committing to it.
+    #[arg(long)]
+    dry_run: bool,
+}
+
+impl MigrateCommand {
+    /// Execute the migrate command.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` if migration succeeded or no migration was needed
+    /// - `Err(anyhow::Error)` if migration failed
+    pub async fn execute(self) -> Result<()> {
+        let dir = self.path.as_deref().unwrap_or_else(|| Path::new("."));
+        let dir = dir
+            .canonicalize()
+            .context("Failed to resolve directory path")?;
+
+        println!("🔍 Checking for legacy CCPM files in: {}", dir.display());
+
+        let ccpm_toml = dir.join("ccpm.toml");
+        let ccpm_lock = dir.join("ccpm.lock");
+        let agpm_toml = dir.join("agpm.toml");
+        let agpm_lock = dir.join("agpm.lock");
+
+        let ccpm_toml_exists = ccpm_toml.exists();
+        let ccpm_lock_exists = ccpm_lock.exists();
+        let agpm_toml_exists = agpm_toml.exists();
+        let agpm_lock_exists = agpm_lock.exists();
+
+        // Check if there are any CCPM files to migrate
+        if !ccpm_toml_exists && !ccpm_lock_exists {
+            println!("✅ {}", "No legacy CCPM files found.".green());
+            return Ok(());
+        }
+
+        // Check for conflicts
+        let mut conflicts = Vec::new();
+        if ccpm_toml_exists && agpm_toml_exists {
+            conflicts.push("agpm.toml already exists");
+        }
+        if ccpm_lock_exists && agpm_lock_exists {
+            conflicts.push("agpm.lock already exists");
+        }
+
+        if !conflicts.is_empty() {
+            bail!(
+                "Migration conflict: {}. Please resolve conflicts manually.",
+                conflicts.join(" and ")
+            );
+        }
+
+        // Display what will be migrated
+        println!("\n📦 Files to migrate:");
+        if ccpm_toml_exists {
+            println!("  • ccpm.toml → agpm.toml");
+        }
+        if ccpm_lock_exists {
+            println!("  • ccpm.lock → agpm.lock");
+        }
+
+        if self.dry_run {
+            println!(
+                "\n{} (use without --dry-run to perform migration)",
+                "Dry run complete".yellow()
+            );
+            return Ok(());
+        }
+
+        // Perform the migration
+        if ccpm_toml_exists {
+            std::fs::rename(&ccpm_toml, &agpm_toml)
+                .context("Failed to rename ccpm.toml to agpm.toml")?;
+            println!("✅ {}", "Renamed ccpm.toml → agpm.toml".green());
+        }
+
+        if ccpm_lock_exists {
+            std::fs::rename(&ccpm_lock, &agpm_lock)
+                .context("Failed to rename ccpm.lock to agpm.lock")?;
+            println!("✅ {}", "Renamed ccpm.lock → agpm.lock".green());
+        }
+
+        println!(
+            "\n🎉 {}",
+            "Migration completed successfully!".green().bold()
+        );
+        println!(
+            "\n💡 Next steps:\n  • Review the renamed files\n  • Run {} to verify\n  • Commit the changes to version control",
+            "agpm validate".cyan()
+        );
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn test_migrate_no_files() {
+        let temp_dir = TempDir::new().unwrap();
+        let cmd = MigrateCommand {
+            path: Some(temp_dir.path().to_path_buf()),
+            dry_run: false,
+        };
+
+        let result = cmd.execute().await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_migrate_both_files() {
+        let temp_dir = TempDir::new().unwrap();
+        let ccpm_toml = temp_dir.path().join("ccpm.toml");
+        let ccpm_lock = temp_dir.path().join("ccpm.lock");
+
+        fs::write(&ccpm_toml, "[sources]\n").unwrap();
+        fs::write(&ccpm_lock, "# lockfile\n").unwrap();
+
+        let cmd = MigrateCommand {
+            path: Some(temp_dir.path().to_path_buf()),
+            dry_run: false,
+        };
+
+        let result = cmd.execute().await;
+        assert!(result.is_ok());
+
+        assert!(!ccpm_toml.exists());
+        assert!(!ccpm_lock.exists());
+        assert!(temp_dir.path().join("agpm.toml").exists());
+        assert!(temp_dir.path().join("agpm.lock").exists());
+    }
+
+    #[tokio::test]
+    async fn test_migrate_dry_run() {
+        let temp_dir = TempDir::new().unwrap();
+        let ccpm_toml = temp_dir.path().join("ccpm.toml");
+
+        fs::write(&ccpm_toml, "[sources]\n").unwrap();
+
+        let cmd = MigrateCommand {
+            path: Some(temp_dir.path().to_path_buf()),
+            dry_run: true,
+        };
+
+        let result = cmd.execute().await;
+        assert!(result.is_ok());
+
+        // Files should not be renamed in dry run
+        assert!(ccpm_toml.exists());
+        assert!(!temp_dir.path().join("agpm.toml").exists());
+    }
+
+    #[tokio::test]
+    async fn test_migrate_conflict() {
+        let temp_dir = TempDir::new().unwrap();
+        let ccpm_toml = temp_dir.path().join("ccpm.toml");
+        let agpm_toml = temp_dir.path().join("agpm.toml");
+
+        fs::write(&ccpm_toml, "[sources]\n").unwrap();
+        fs::write(&agpm_toml, "[sources]\n").unwrap();
+
+        let cmd = MigrateCommand {
+            path: Some(temp_dir.path().to_path_buf()),
+            dry_run: false,
+        };
+
+        let result = cmd.execute().await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("conflict"));
+    }
+
+    #[tokio::test]
+    async fn test_migrate_only_toml() {
+        let temp_dir = TempDir::new().unwrap();
+        let ccpm_toml = temp_dir.path().join("ccpm.toml");
+
+        fs::write(&ccpm_toml, "[sources]\n").unwrap();
+
+        let cmd = MigrateCommand {
+            path: Some(temp_dir.path().to_path_buf()),
+            dry_run: false,
+        };
+
+        let result = cmd.execute().await;
+        assert!(result.is_ok());
+
+        assert!(!ccpm_toml.exists());
+        assert!(temp_dir.path().join("agpm.toml").exists());
+    }
+
+    #[tokio::test]
+    async fn test_migrate_only_lock() {
+        let temp_dir = TempDir::new().unwrap();
+        let ccpm_lock = temp_dir.path().join("ccpm.lock");
+
+        fs::write(&ccpm_lock, "# lockfile\n").unwrap();
+
+        let cmd = MigrateCommand {
+            path: Some(temp_dir.path().to_path_buf()),
+            dry_run: false,
+        };
+
+        let result = cmd.execute().await;
+        assert!(result.is_ok());
+
+        assert!(!ccpm_lock.exists());
+        assert!(temp_dir.path().join("agpm.lock").exists());
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,4 +1,4 @@
-//! Command-line interface for CCPM (Claude Code Package Manager).
+//! Command-line interface for AGPM (Claude Code Package Manager).
 //!
 //! This module contains all CLI command implementations for the Claude Code Package Manager.
 //! The CLI provides a comprehensive set of commands for managing Claude Code resources,
@@ -16,7 +16,7 @@
 //! # Available Commands
 //!
 //! ## Project Management
-//! - `init` - Initialize a new CCPM project with a manifest file
+//! - `init` - Initialize a new AGPM project with a manifest file
 //! - `add` - Add sources and dependencies to the project manifest
 //! - `remove` - Remove sources and dependencies from the project manifest  
 //! - `install` - Install dependencies from the manifest
@@ -31,57 +31,57 @@
 //! ## System Management
 //! - `cache` - Manage the global Git repository cache
 //! - `config` - Manage global configuration settings
-//! - `upgrade` - Upgrade CCPM to newer versions with backup support
+//! - `upgrade` - Upgrade AGPM to newer versions with backup support
 //!
 //! # Command Usage Patterns
 //!
 //! ## Basic Workflow
 //! ```bash
 //! # 1. Initialize a new project
-//! ccpm init
+//! agpm init
 //!
 //! # 2. Add sources and dependencies
-//! ccpm add source official https://github.com/org/ccpm-resources.git
-//! ccpm add dep official:agents/code-reviewer.md@v1.0.0 --agent
+//! agpm add source official https://github.com/org/ccpm-resources.git
+//! agpm add dep official:agents/code-reviewer.md@v1.0.0 --agent
 //!
 //! # 3. Install dependencies
-//! ccpm install
+//! agpm install
 //!
 //! # 4. List what's installed
-//! ccpm list
+//! agpm list
 //! ```
 //!
 //! ## Maintenance Operations
 //! ```bash
 //! # Check for available updates
-//! ccpm outdated
+//! agpm outdated
 //!
 //! # Validate project configuration
-//! ccpm validate --resolve --sources
+//! agpm validate --resolve --sources
 //!
 //! # Update dependencies
-//! ccpm update
+//! agpm update
 //!
 //! # Manage cache
-//! ccpm cache clean
+//! agpm cache clean
 //!
 //! # Configure global settings
-//! ccpm config add-source private https://oauth2:TOKEN@github.com/org/private.git
+//! agpm config add-source private https://oauth2:TOKEN@github.com/org/private.git
 //!
-//! # Check for and install CCPM updates
-//! ccpm upgrade --check     # Check for updates
-//! ccpm upgrade             # Upgrade to latest
-//! ccpm upgrade --rollback  # Restore previous version
+//! # Check for and install AGPM updates
+//! agpm upgrade --check     # Check for updates
+//! agpm upgrade             # Upgrade to latest
+//! agpm upgrade --rollback  # Restore previous version
 //! ```
 //!
 //! # Global vs Project Configuration
 //!
-//! CCPM uses two types of configuration:
+//! AGPM uses two types of configuration:
 //!
 //! | Type | File | Purpose | Version Control |
 //! |------|------|---------|----------------|
-//! | Project | `ccpm.toml` | Define dependencies | ✅ Commit |
-//! | Global | `~/.ccpm/config.toml` | Authentication tokens | ❌ Never commit |
+//! | Project | `agpm.toml` | Define dependencies | ✅ Commit |
+//! | Global | `~/.agpm/config.toml` | Authentication tokens | ❌ Never commit |
 //!
 //! # Cross-Platform Support
 //!
@@ -106,13 +106,13 @@
 //!
 //! ```bash
 //! # Initialize a new project
-//! ccpm init --with-examples
+//! agpm init --with-examples
 //!
 //! # Install dependencies
-//! ccpm install --verbose
+//! agpm install --verbose
 //!
 //! # Update dependencies
-//! ccpm update --no-progress
+//! agpm update --no-progress
 //! ```
 
 mod add;
@@ -126,9 +126,9 @@ mod outdated;
 mod remove;
 mod tree;
 mod update;
-/// Self-update functionality for upgrading CCPM to newer versions.
+/// Self-update functionality for upgrading AGPM to newer versions.
 ///
-/// This module provides the `upgrade` command which enables CCPM to update itself
+/// This module provides the `upgrade` command which enables AGPM to update itself
 /// by downloading and installing new versions from GitHub releases. It includes
 /// safety features like automatic backups and rollback capabilities.
 ///
@@ -170,7 +170,7 @@ use std::path::PathBuf;
 pub struct CliConfig {
     /// Log level for the `RUST_LOG` environment variable.
     ///
-    /// Controls the verbosity of logging output throughout CCPM. Common values:
+    /// Controls the verbosity of logging output throughout AGPM. Common values:
     /// - `"error"`: Only errors are logged
     /// - `"warn"`: Errors and warnings
     /// - `"info"`: Errors, warnings, and informational messages
@@ -182,7 +182,7 @@ pub struct CliConfig {
 
     /// Whether to disable progress indicators and animated output.
     ///
-    /// When `true`, sets the `CCPM_NO_PROGRESS` environment variable to disable:
+    /// When `true`, sets the `AGPM_NO_PROGRESS` environment variable to disable:
     /// - Progress bars during long operations
     /// - Spinner animations
     /// - Real-time status updates
@@ -195,8 +195,8 @@ pub struct CliConfig {
 
     /// Custom path to the global configuration file.
     ///
-    /// When specified, sets the `CCPM_CONFIG` environment variable to override
-    /// the default configuration file location (`~/.ccpm/config.toml`).
+    /// When specified, sets the `AGPM_CONFIG` environment variable to override
+    /// the default configuration file location (`~/.agpm/config.toml`).
     ///
     /// This enables:
     /// - Testing with isolated configuration files
@@ -216,7 +216,7 @@ impl CliConfig {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// use ccpm::cli::CliConfig;
+    /// use agpm::cli::CliConfig;
     ///
     /// let config = CliConfig::new();
     /// assert_eq!(config.log_level, None);
@@ -229,7 +229,7 @@ impl CliConfig {
     }
 }
 
-/// Main CLI structure for CCPM (Claude Code Package Manager).
+/// Main CLI structure for AGPM (Claude Code Package Manager).
 ///
 /// This struct represents the root command and all its global options. It uses the
 /// `clap` derive API to automatically generate command-line parsing, help text, and
@@ -254,13 +254,13 @@ impl CliConfig {
 ///
 /// ```bash
 /// # Basic command with global options
-/// ccpm --verbose install
-/// ccpm --quiet --no-progress list
-/// ccpm --config ./custom.toml validate
+/// agpm --verbose install
+/// agpm --quiet --no-progress list
+/// agpm --config ./custom.toml validate
 ///
 /// # Global options work with any subcommand
-/// ccpm --verbose install
-/// ccpm --quiet cache clean
+/// agpm --verbose install
+/// agpm --quiet cache clean
 /// ```
 ///
 /// # Subcommand Structure
@@ -278,23 +278,23 @@ impl CliConfig {
 /// - Global and project-specific configuration files
 /// - Cross-platform file system operations
 ///
-/// # Main CLI application structure for CCPM
+/// # Main CLI application structure for AGPM
 ///
 /// This struct represents the top-level command-line interface for the Claude Code
 /// Package Manager. It handles global flags and delegates to subcommands for
 /// specific operations.
 #[derive(Parser)]
 #[command(
-    name = "ccpm",
+    name = "agpm",
     about = "Claude Code Package Manager - Manage Claude Code resources",
     version,
     author,
-    long_about = "CCPM is a Git-based package manager for Claude Code resources including agents, snippets, and more."
+    long_about = "AGPM is a Git-based package manager for Claude Code resources including agents, snippets, and more."
 )]
 pub struct Cli {
     /// The subcommand to execute.
     ///
-    /// Each subcommand provides a specific functionality area within CCPM.
+    /// Each subcommand provides a specific functionality area within AGPM.
     /// The available commands are defined in the [`Commands`] enum.
     #[command(subcommand)]
     command: Commands,
@@ -313,8 +313,8 @@ pub struct Cli {
     /// # Examples
     ///
     /// ```bash
-    /// ccpm --verbose install     # Verbose installation
-    /// ccpm -v update             # Short form
+    /// agpm --verbose install     # Verbose installation
+    /// agpm -v update             # Short form
     /// ```
     #[arg(short, long, global = true)]
     verbose: bool,
@@ -332,16 +332,16 @@ pub struct Cli {
     /// # Examples
     ///
     /// ```bash
-    /// ccpm --quiet install       # Silent installation
-    /// ccpm -q list               # Short form
-    /// ccpm --quiet cache clean   # Automated cache cleanup
+    /// agpm --quiet install       # Silent installation
+    /// agpm -q list               # Short form
+    /// agpm --quiet cache clean   # Automated cache cleanup
     /// ```
     #[arg(short, long, global = true)]
     quiet: bool,
 
     /// Path to custom global configuration file.
     ///
-    /// Overrides the default configuration file location (`~/.ccpm/config.toml`)
+    /// Overrides the default configuration file location (`~/.agpm/config.toml`)
     /// with a custom path. This is useful for:
     ///
     /// - **Testing**: Using isolated configuration files
@@ -356,16 +356,16 @@ pub struct Cli {
     /// # Examples
     ///
     /// ```bash
-    /// ccpm --config ./dev-config.toml install    # Custom config
-    /// ccpm -c ~/.ccpm/team-config.toml list      # Team config
-    /// ccpm --config /etc/ccpm/global.toml update # System config
+    /// agpm --config ./dev-config.toml install    # Custom config
+    /// agpm -c ~/.agpm/team-config.toml list      # Team config
+    /// agpm --config /etc/agpm/global.toml update # System config
     /// ```
     #[arg(short, long, global = true)]
     config: Option<String>,
 
-    /// Path to the manifest file (ccpm.toml).
+    /// Path to the manifest file (agpm.toml).
     ///
-    /// By default, CCPM searches for ccpm.toml in the current directory
+    /// By default, AGPM searches for agpm.toml in the current directory
     /// and parent directories. This option allows you to specify an exact
     /// path to the manifest file, which is useful for:
     ///
@@ -376,8 +376,8 @@ pub struct Cli {
     /// # Examples
     ///
     /// ```bash
-    /// ccpm --manifest-path /path/to/ccpm.toml install
-    /// ccpm --manifest-path ../other-project/ccpm.toml list
+    /// agpm --manifest-path /path/to/agpm.toml install
+    /// agpm --manifest-path ../other-project/agpm.toml list
     /// ```
     #[arg(long, global = true)]
     manifest_path: Option<PathBuf>,
@@ -403,24 +403,24 @@ pub struct Cli {
     /// # Examples
     ///
     /// ```bash
-    /// ccpm --no-progress install         # No animations
-    /// ccpm install 2>&1 | tee log.txt   # Auto-detected non-TTY
-    /// CI=true ccpm install               # CI environment
+    /// agpm --no-progress install         # No animations
+    /// agpm install 2>&1 | tee log.txt   # Auto-detected non-TTY
+    /// CI=true agpm install               # CI environment
     /// ```
     #[arg(long, global = true)]
     no_progress: bool,
 }
 
-/// Available subcommands for the CCPM CLI.
+/// Available subcommands for the AGPM CLI.
 ///
-/// This enum defines all the subcommands available in CCPM, organized by
+/// This enum defines all the subcommands available in AGPM, organized by
 /// functional categories. Each variant contains the specific command structure
 /// with its own arguments and options.
 ///
 /// # Command Categories
 ///
 /// ## Project Management
-/// - [`Init`](Commands::Init): Initialize new CCPM projects
+/// - [`Init`](Commands::Init): Initialize new AGPM projects
 /// - [`Add`](Commands::Add): Add sources and dependencies
 /// - [`Remove`](Commands::Remove): Remove sources and dependencies
 /// - [`Install`](Commands::Install): Install dependencies from manifest
@@ -434,7 +434,7 @@ pub struct Cli {
 /// ## System Management
 /// - [`Cache`](Commands::Cache): Manage Git repository cache
 /// - [`Config`](Commands::Config): Manage global configuration
-/// - [`Upgrade`](Commands::Upgrade): Self-update CCPM to newer versions
+/// - [`Upgrade`](Commands::Upgrade): Self-update AGPM to newer versions
 ///
 /// # Command Execution
 ///
@@ -449,27 +449,27 @@ pub struct Cli {
 ///
 /// ```bash
 /// # Project setup and management
-/// ccpm init                    # Initialize new project
-/// ccpm add source official ... # Add a source repository
-/// ccpm install                 # Install all dependencies
-/// ccpm update                  # Update to latest versions
+/// agpm init                    # Initialize new project
+/// agpm add source official ... # Add a source repository
+/// agpm install                 # Install all dependencies
+/// agpm update                  # Update to latest versions
 ///
 /// # Information and validation
-/// ccpm list                    # Show installed resources
-/// ccpm outdated                # Check for available updates
-/// ccpm validate --resolve      # Comprehensive validation
+/// agpm list                    # Show installed resources
+/// agpm outdated                # Check for available updates
+/// agpm validate --resolve      # Comprehensive validation
 ///
 /// # System management
-/// ccpm cache info              # Show cache information
-/// ccpm config show             # Show configuration
+/// agpm cache info              # Show cache information
+/// agpm config show             # Show configuration
 /// ```
 #[derive(Subcommand)]
 enum Commands {
-    /// Initialize a new CCPM project with a manifest file.
+    /// Initialize a new AGPM project with a manifest file.
     ///
-    /// Creates a new `ccpm.toml` manifest file in the current directory with
+    /// Creates a new `agpm.toml` manifest file in the current directory with
     /// basic project structure and example configurations. This is the first
-    /// step in setting up a new CCPM project.
+    /// step in setting up a new AGPM project.
     ///
     /// See [`init::InitCommand`] for detailed options and behavior.
     Init(init::InitCommand),
@@ -478,7 +478,7 @@ enum Commands {
     ///
     /// Provides subcommands to add Git repository sources and resource
     /// dependencies (agents, snippets, commands, MCP servers) to the
-    /// `ccpm.toml` manifest file.
+    /// `agpm.toml` manifest file.
     ///
     /// See [`add::AddCommand`] for detailed options and behavior.
     Add(add::AddCommand),
@@ -487,16 +487,16 @@ enum Commands {
     ///
     /// Provides subcommands to remove Git repository sources and resource
     /// dependencies (agents, snippets, commands, MCP servers) from the
-    /// `ccpm.toml` manifest file.
+    /// `agpm.toml` manifest file.
     ///
     /// See [`remove::RemoveCommand`] for detailed options and behavior.
     Remove(remove::RemoveCommand),
 
     /// Install Claude Code resources from manifest dependencies.
     ///
-    /// Reads the `ccpm.toml` manifest, resolves all dependencies, downloads
+    /// Reads the `agpm.toml` manifest, resolves all dependencies, downloads
     /// resources from Git repositories, and installs them to the project
-    /// directory. Creates or updates the `ccpm.lock` lockfile.
+    /// directory. Creates or updates the `agpm.lock` lockfile.
     ///
     /// See [`install::InstallCommand`] for detailed options and behavior.
     Install(install::InstallCommand),
@@ -519,9 +519,9 @@ enum Commands {
     /// See [`outdated::OutdatedCommand`] for detailed options and behavior.
     Outdated(outdated::OutdatedCommand),
 
-    /// Upgrade CCPM to the latest version.
+    /// Upgrade AGPM to the latest version.
     ///
-    /// Downloads and installs the latest version of CCPM from GitHub releases.
+    /// Downloads and installs the latest version of AGPM from GitHub releases.
     /// Supports checking for updates, upgrading to specific versions, and
     /// rolling back to previous versions if needed.
     ///
@@ -546,7 +546,7 @@ enum Commands {
     /// See [`tree::TreeCommand`] for detailed options and behavior.
     Tree(tree::TreeCommand),
 
-    /// Validate CCPM project configuration and dependencies.
+    /// Validate AGPM project configuration and dependencies.
     ///
     /// Performs comprehensive validation of the project manifest, dependencies,
     /// source accessibility, and configuration consistency. Supports multiple
@@ -558,16 +558,16 @@ enum Commands {
     /// Manage the global Git repository cache.
     ///
     /// Provides operations for managing the global cache directory where
-    /// CCPM stores cloned Git repositories. Includes cache information,
+    /// AGPM stores cloned Git repositories. Includes cache information,
     /// cleanup, and size management.
     ///
     /// See [`cache::CacheCommand`] for detailed options and behavior.
     Cache(cache::CacheCommand),
 
-    /// Manage global CCPM configuration.
+    /// Manage global AGPM configuration.
     ///
     /// Provides operations for managing the global configuration file
-    /// (`~/.ccpm/config.toml`) which contains authentication tokens,
+    /// (`~/.agpm/config.toml`) which contains authentication tokens,
     /// default sources, and user preferences.
     ///
     /// See [`config::ConfigCommand`] for detailed options and behavior.
@@ -595,7 +595,7 @@ impl Cli {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// use ccpm::cli::Cli;
+    /// use agpm::cli::Cli;
     /// use clap::Parser;
     ///
     /// # tokio_test::block_on(async {
@@ -634,10 +634,10 @@ impl Cli {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// use ccpm::cli::Cli;
+    /// use agpm::cli::Cli;
     /// use clap::Parser;
     ///
-    /// let cli = Cli::parse_from(&["ccpm", "--verbose", "install"]);
+    /// let cli = Cli::parse_from(&["agpm", "--verbose", "install"]);
     /// let config = cli.build_config();
     /// assert_eq!(config.log_level, Some("debug".to_string()));
     /// ```
@@ -690,11 +690,11 @@ impl Cli {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// use ccpm::cli::{Cli, CliConfig};
+    /// use agpm::cli::{Cli, CliConfig};
     /// use clap::Parser;
     ///
     /// # tokio_test::block_on(async {
-    /// let cli = Cli::parse_from(&["ccpm", "install"]);
+    /// let cli = Cli::parse_from(&["agpm", "install"]);
     /// let mut config = CliConfig::new();
     /// config.log_level = Some("trace".to_string());
     /// config.no_progress = true;
@@ -743,7 +743,7 @@ impl Cli {
         }
     }
 
-    /// Check for CCPM updates automatically based on configuration.
+    /// Check for AGPM updates automatically based on configuration.
     ///
     /// This method performs a non-blocking, best-effort check for updates.
     /// It respects the user's configuration for automatic update checking

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -41,7 +41,7 @@
 //! agpm init
 //!
 //! # 2. Add sources and dependencies
-//! agpm add source official https://github.com/org/ccpm-resources.git
+//! agpm add source official https://github.com/org/agpm-resources.git
 //! agpm add dep official:agents/code-reviewer.md@v1.0.0 --agent
 //!
 //! # 3. Install dependencies
@@ -122,6 +122,7 @@ mod config;
 mod init;
 mod install;
 mod list;
+mod migrate;
 mod outdated;
 mod remove;
 mod tree;
@@ -435,6 +436,7 @@ pub struct Cli {
 /// - [`Cache`](Commands::Cache): Manage Git repository cache
 /// - [`Config`](Commands::Config): Manage global configuration
 /// - [`Upgrade`](Commands::Upgrade): Self-update AGPM to newer versions
+/// - [`Migrate`](Commands::Migrate): Migrate from legacy CCPM naming to AGPM
 ///
 /// # Command Execution
 ///
@@ -462,6 +464,7 @@ pub struct Cli {
 /// # System management
 /// agpm cache info              # Show cache information
 /// agpm config show             # Show configuration
+/// agpm migrate                 # Migrate from CCPM to AGPM
 /// ```
 #[derive(Subcommand)]
 enum Commands {
@@ -572,6 +575,13 @@ enum Commands {
     ///
     /// See [`config::ConfigCommand`] for detailed options and behavior.
     Config(config::ConfigCommand),
+
+    /// Migrate from legacy CCPM naming to AGPM.
+    ///
+    /// Detects and renames ccpm.toml and ccpm.lock files to agpm.toml
+    /// and agpm.lock respectively. This is a one-time migration command
+    /// for projects upgrading from the legacy CCPM naming.
+    Migrate(migrate::MigrateCommand),
 }
 
 impl Cli {
@@ -740,6 +750,7 @@ impl Cli {
                 let config_path = config.config_path.as_ref().map(PathBuf::from);
                 cmd.execute(config_path).await
             }
+            Commands::Migrate(cmd) => cmd.execute().await,
         }
     }
 

--- a/src/cli/outdated.rs
+++ b/src/cli/outdated.rs
@@ -7,7 +7,7 @@
 //!
 //! # Overview
 //!
-//! This module implements CCPM's update checking functionality, which:
+//! This module implements AGPM's update checking functionality, which:
 //! - Compares installed versions against repository tags
 //! - Respects semantic version constraints from the manifest
 //! - Distinguishes between compatible and major updates
@@ -21,22 +21,22 @@
 //!
 //! ```bash
 //! # Check all dependencies for updates
-//! ccpm outdated
+//! agpm outdated
 //!
 //! # Check specific dependencies
-//! ccpm outdated my-agent other-agent
+//! agpm outdated my-agent other-agent
 //!
 //! # Use cached data without fetching
-//! ccpm outdated --no-fetch
+//! agpm outdated --no-fetch
 //!
 //! # Exit with error code if updates available
-//! ccpm outdated --check
+//! agpm outdated --check
 //!
 //! # JSON output for scripting
-//! ccpm outdated --format json
+//! agpm outdated --format json
 //!
 //! # Control parallelism
-//! ccpm outdated --max-parallel 5
+//! agpm outdated --max-parallel 5
 //! ```
 //!
 //! ## Output Formats
@@ -87,7 +87,7 @@
 //!
 //! The outdated command performs sophisticated version analysis:
 //!
-//! 1. **Current Version**: The version installed and locked in `ccpm.lock`
+//! 1. **Current Version**: The version installed and locked in `agpm.lock`
 //! 2. **Latest Compatible**: The newest version that satisfies the manifest's version constraint
 //! 3. **Latest Available**: The absolute newest version in the repository
 //!
@@ -103,13 +103,13 @@
 //!
 //! # Requirements
 //!
-//! - Requires an existing `ccpm.lock` file (run `ccpm install` first)
+//! - Requires an existing `agpm.lock` file (run `agpm install` first)
 //! - Accesses Git repositories to fetch latest version information
 //! - Supports both local cache and remote fetching modes
 //!
 //! # Integration with Other Commands
 //!
-//! The outdated command complements other CCPM commands:
+//! The outdated command complements other AGPM commands:
 //!
 //! - [`crate::cli::install`] - Creates the required lockfile
 //! - [`crate::cli::update`] - Updates dependencies to newer versions
@@ -119,7 +119,7 @@
 //!
 //! Common error scenarios and their handling:
 //!
-//! - **Missing lockfile**: Returns error suggesting `ccpm install`
+//! - **Missing lockfile**: Returns error suggesting `agpm install`
 //! - **Repository not cached**: Skips dependency or fails if `--no-fetch` used
 //! - **Invalid version constraints**: Reports parsing errors with context
 //! - **Network issues**: Graceful degradation with appropriate error messages
@@ -127,7 +127,7 @@
 //! # Examples
 //!
 //! ```rust,ignore
-//! use ccpm::cli::outdated::OutdatedCommand;
+//! use agpm::cli::outdated::OutdatedCommand;
 //! use std::path::PathBuf;
 //!
 //! # async fn example() -> anyhow::Result<()> {
@@ -182,7 +182,7 @@ use crate::version::constraints::VersionConstraint;
 /// ## Check All Dependencies
 ///
 /// ```rust,ignore
-/// use ccpm::cli::outdated::OutdatedCommand;
+/// use agpm::cli::outdated::OutdatedCommand;
 ///
 /// # async fn example() -> anyhow::Result<()> {
 /// let cmd = OutdatedCommand {
@@ -202,7 +202,7 @@ use crate::version::constraints::VersionConstraint;
 /// ## Check Specific Dependencies with JSON Output
 ///
 /// ```rust,ignore
-/// use ccpm::cli::outdated::OutdatedCommand;
+/// use agpm::cli::outdated::OutdatedCommand;
 ///
 /// # async fn example() -> anyhow::Result<()> {
 /// let cmd = OutdatedCommand {
@@ -222,7 +222,7 @@ use crate::version::constraints::VersionConstraint;
 /// ## CI/CD Integration Example
 ///
 /// ```rust,ignore
-/// use ccpm::cli::outdated::OutdatedCommand;
+/// use agpm::cli::outdated::OutdatedCommand;
 ///
 /// # async fn ci_check() -> anyhow::Result<()> {
 /// // This will exit with code 1 if any updates are available
@@ -474,7 +474,7 @@ pub struct OutdatedSummary {
 /// scripts to programmatically analyze dependency update status.
 ///
 /// ```rust,ignore
-/// use ccpm::cli::outdated::{OutdatedResult, OutdatedInfo, OutdatedSummary};
+/// use agpm::cli::outdated::{OutdatedResult, OutdatedInfo, OutdatedSummary};
 /// use serde_json;
 ///
 /// # fn example() -> anyhow::Result<()> {
@@ -524,7 +524,7 @@ impl OutdatedCommand {
     ///
     /// # Arguments
     ///
-    /// * `manifest_path` - Optional path to the `ccpm.toml` file. If `None`,
+    /// * `manifest_path` - Optional path to the `agpm.toml` file. If `None`,
     ///   searches the current directory and parent directories for the manifest.
     ///
     /// # Returns
@@ -543,7 +543,7 @@ impl OutdatedCommand {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// use ccpm::cli::outdated::OutdatedCommand;
+    /// use agpm::cli::outdated::OutdatedCommand;
     /// use std::path::PathBuf;
     ///
     /// # async fn example() -> anyhow::Result<()> {
@@ -552,7 +552,7 @@ impl OutdatedCommand {
     /// cmd.execute_with_manifest_path(None).await?;
     ///
     /// // Use specific manifest path
-    /// let manifest_path = Some(PathBuf::from("/path/to/ccpm.toml"));
+    /// let manifest_path = Some(PathBuf::from("/path/to/agpm.toml"));
     /// cmd.execute_with_manifest_path(manifest_path).await?;
     /// # Ok(())
     /// # }
@@ -561,9 +561,9 @@ impl OutdatedCommand {
     /// # Errors
     ///
     /// Returns [`anyhow::Error`] for various failure conditions:
-    /// - `"No manifest found"` - No `ccpm.toml` in current or parent directories
+    /// - `"No manifest found"` - No `agpm.toml` in current or parent directories
     /// - `"Failed to load manifest"` - Manifest exists but has syntax errors
-    /// - `"No lockfile found"` - Missing `ccpm.lock` file (run `ccpm install` first)
+    /// - `"No lockfile found"` - Missing `agpm.lock` file (run `agpm install` first)
     pub async fn execute_with_manifest_path(self, manifest_path: Option<PathBuf>) -> Result<()> {
         let manifest_path = find_manifest_with_optional(manifest_path)?;
         self.execute_from_path(manifest_path).await
@@ -581,7 +581,7 @@ impl OutdatedCommand {
     ///
     /// # Arguments
     ///
-    /// * `manifest_path` - Absolute path to the `ccpm.toml` manifest file
+    /// * `manifest_path` - Absolute path to the `agpm.toml` manifest file
     ///
     /// # Returns
     ///
@@ -606,7 +606,7 @@ impl OutdatedCommand {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// use ccpm::cli::outdated::OutdatedCommand;
+    /// use agpm::cli::outdated::OutdatedCommand;
     /// use std::path::PathBuf;
     ///
     /// # async fn example() -> anyhow::Result<()> {
@@ -619,7 +619,7 @@ impl OutdatedCommand {
     ///     no_progress: false,
     /// };
     ///
-    /// let manifest_path = PathBuf::from("./ccpm.toml");
+    /// let manifest_path = PathBuf::from("./agpm.toml");
     /// cmd.execute_from_path(manifest_path).await?;
     /// # Ok(())
     /// # }
@@ -631,12 +631,12 @@ impl OutdatedCommand {
         let manifest = Manifest::load(&manifest_path)
             .with_context(|| format!("Failed to load manifest from {:?}", manifest_path))?;
 
-        let lockfile_path = manifest_path.with_file_name("ccpm.lock");
+        let lockfile_path = manifest_path.with_file_name("agpm.lock");
 
         // Check if lockfile exists first - the outdated command requires it
         if !lockfile_path.exists() {
             return Err(anyhow::anyhow!(
-                "No lockfile found at {:?}. Run 'ccpm install' first to create a lockfile.",
+                "No lockfile found at {:?}. Run 'agpm install' first to create a lockfile.",
                 lockfile_path
             ));
         }
@@ -737,7 +737,7 @@ impl OutdatedCommand {
     /// # Arguments
     ///
     /// * `name` - The dependency name from the lockfile
-    /// * `locked` - The locked resource information from `ccpm.lock`
+    /// * `locked` - The locked resource information from `agpm.lock`
     /// * `manifest` - The project manifest containing dependency specifications
     /// * `cache` - Cache instance for accessing Git repositories
     /// * `resolver` - Dependency resolver for version operations
@@ -767,11 +767,11 @@ impl OutdatedCommand {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// # use ccpm::cli::outdated::OutdatedCommand;
-    /// # use ccpm::lockfile::LockedResource;
-    /// # use ccpm::manifest::Manifest;
-    /// # use ccpm::cache::Cache;
-    /// # use ccpm::resolver::DependencyResolver;
+    /// # use agpm::cli::outdated::OutdatedCommand;
+    /// # use agpm::lockfile::LockedResource;
+    /// # use agpm::manifest::Manifest;
+    /// # use agpm::cache::Cache;
+    /// # use agpm::resolver::DependencyResolver;
     /// # async fn example(
     /// #     cmd: &OutdatedCommand,
     /// #     locked: &LockedResource,
@@ -987,7 +987,7 @@ impl OutdatedCommand {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// # use ccpm::cli::outdated::{OutdatedCommand, OutdatedInfo};
+    /// # use agpm::cli::outdated::{OutdatedCommand, OutdatedInfo};
     /// # fn example() {
     /// let cmd = OutdatedCommand::default();
     /// let outdated_deps = vec![
@@ -1038,7 +1038,7 @@ impl OutdatedCommand {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// # use ccpm::cli::outdated::{OutdatedCommand, OutdatedInfo, OutdatedSummary};
+    /// # use agpm::cli::outdated::{OutdatedCommand, OutdatedInfo, OutdatedSummary};
     /// # fn example() -> anyhow::Result<()> {
     /// let cmd = OutdatedCommand {
     ///     format: "json".to_string(),
@@ -1119,7 +1119,7 @@ impl OutdatedCommand {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// # use ccpm::cli::outdated::{OutdatedCommand, OutdatedInfo, OutdatedSummary};
+    /// # use agpm::cli::outdated::{OutdatedCommand, OutdatedInfo, OutdatedSummary};
     /// # fn example() -> anyhow::Result<()> {
     /// let cmd = OutdatedCommand::default();
     /// let outdated = vec![];
@@ -1194,7 +1194,7 @@ impl OutdatedCommand {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// # use ccpm::cli::outdated::{OutdatedCommand, OutdatedInfo, OutdatedSummary};
+    /// # use agpm::cli::outdated::{OutdatedCommand, OutdatedInfo, OutdatedSummary};
     /// # fn example() -> anyhow::Result<()> {
     /// let cmd = OutdatedCommand::default();
     /// let outdated = vec![];

--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -109,7 +109,7 @@ enum RemoveDependencySubcommand {
 }
 
 /// Helper function to get dependencies for a specific resource type
-fn get_dependencies_for_type(
+const fn get_dependencies_for_type(
     manifest: &Manifest,
     resource_type: ResourceType,
 ) -> &HashMap<String, ResourceDependency> {
@@ -124,7 +124,7 @@ fn get_dependencies_for_type(
 }
 
 /// Helper function to get mutable dependencies for a specific resource type
-fn get_dependencies_for_type_mut(
+const fn get_dependencies_for_type_mut(
     manifest: &mut Manifest,
     resource_type: ResourceType,
 ) -> &mut HashMap<String, ResourceDependency> {
@@ -167,7 +167,7 @@ fn get_installed_path_from_lockfile(
             Some(
                 project_root
                     .join(&manifest.target.mcp_servers)
-                    .join(format!("{}.json", name)),
+                    .join(format!("{name}.json")),
             )
         }
         ResourceType::Script => lockfile
@@ -267,7 +267,7 @@ async fn remove_source_with_manifest_path(
 
     // Check if source exists
     if !manifest.sources.contains_key(name) {
-        return Err(anyhow!("Source '{}' not found in manifest", name));
+        return Err(anyhow!("Source '{name}' not found in manifest"));
     }
 
     // Check if source is being used by any dependencies
@@ -279,7 +279,7 @@ async fn remove_source_with_manifest_path(
             let dependencies = get_dependencies_for_type(&manifest, *resource_type);
             for (dep_name, dep) in dependencies {
                 if dep.get_source() == Some(name) {
-                    used_by.push(format!("{} '{}'", resource_type, dep_name));
+                    used_by.push(format!("{resource_type} '{dep_name}'"));
                 }
             }
         }
@@ -370,7 +370,7 @@ async fn remove_source_with_manifest_path(
         lockfile.save(&lockfile_path)?;
     }
 
-    println!("{}", format!("Removed source '{}'", name).green());
+    println!("{}", format!("Removed source '{name}'").green());
 
     Ok(())
 }
@@ -388,7 +388,7 @@ async fn remove_dependency_with_manifest_path(
     // Parse the resource type
     let resource_type: ResourceType = dep_type
         .parse()
-        .map_err(|_| anyhow!("Invalid dependency type: {}", dep_type))?;
+        .map_err(|_| anyhow!("Invalid dependency type: {dep_type}"))?;
 
     // Get the dependencies for this resource type and check if it exists
     let dependencies = get_dependencies_for_type_mut(&mut manifest, resource_type);
@@ -426,10 +426,7 @@ async fn remove_dependency_with_manifest_path(
     )?;
 
     let dep_type_display = dep_type.replace('-', " ");
-    println!(
-        "{}",
-        format!("Removed {} '{}'", dep_type_display, name).green()
-    );
+    println!("{}", format!("Removed {dep_type_display} '{name}'").green());
 
     let project_root = manifest_path.parent().unwrap();
 

--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -1,7 +1,7 @@
-//! Remove sources and dependencies from CCPM projects.
+//! Remove sources and dependencies from AGPM projects.
 //!
 //! This module provides the `remove` command which allows users to remove
-//! sources and dependencies from the project manifest (`ccpm.toml`).
+//! sources and dependencies from the project manifest (`agpm.toml`).
 //! It complements the `add` command by providing removal functionality.
 //!
 //! # Features
@@ -15,20 +15,20 @@
 //!
 //! Remove a source:
 //! ```bash
-//! ccpm remove source private
+//! agpm remove source private
 //! ```
 //!
 //! Remove dependencies:
 //! ```bash
-//! ccpm remove dep agent code-reviewer
-//! ccpm remove dep snippet utils
-//! ccpm remove dep command deploy
-//! ccpm remove dep mcp-server filesystem
+//! agpm remove dep agent code-reviewer
+//! agpm remove dep snippet utils
+//! agpm remove dep command deploy
+//! agpm remove dep mcp-server filesystem
 //! ```
 //!
 //! Force removal without confirmation:
 //! ```bash
-//! ccpm remove source old-repo --force
+//! agpm remove source old-repo --force
 //! ```
 
 use anyhow::{Context, Result, anyhow};
@@ -42,7 +42,7 @@ use crate::utils::fs::atomic_write;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-/// Command to remove sources and dependencies from a CCPM project.
+/// Command to remove sources and dependencies from a AGPM project.
 #[derive(Args)]
 pub struct RemoveCommand {
     /// The specific remove operation to perform
@@ -198,13 +198,13 @@ fn remove_from_lockfile(lockfile: &mut LockFile, name: &str, resource_type: Reso
 impl RemoveCommand {
     /// Execute the remove command with an optional manifest path.
     ///
-    /// This method allows specifying a custom path to the ccpm.toml manifest file.
-    /// If no path is provided, it will search for ccpm.toml in the current directory
+    /// This method allows specifying a custom path to the agpm.toml manifest file.
+    /// If no path is provided, it will search for agpm.toml in the current directory
     /// and parent directories.
     ///
     /// # Arguments
     ///
-    /// * `manifest_path` - Optional path to the ccpm.toml file
+    /// * `manifest_path` - Optional path to the agpm.toml file
     ///
     /// # Returns
     ///
@@ -214,7 +214,7 @@ impl RemoveCommand {
     /// # Examples
     ///
     /// ```ignore
-    /// use ccpm::cli::remove::{RemoveCommand, RemoveSubcommand};
+    /// use agpm::cli::remove::{RemoveCommand, RemoveSubcommand};
     /// use std::path::PathBuf;
     ///
     /// let cmd = RemoveCommand {
@@ -303,7 +303,7 @@ async fn remove_source_with_manifest_path(
     )?;
 
     // Update lockfile to remove entries from this source
-    let lockfile_path = manifest_path.parent().unwrap().join("ccpm.lock");
+    let lockfile_path = manifest_path.parent().unwrap().join("agpm.lock");
 
     if lockfile_path.exists() {
         let mut lockfile = LockFile::load(&lockfile_path)?;
@@ -458,7 +458,7 @@ async fn remove_dependency_with_manifest_path(
     }
 
     // Update lockfile and remove installed files
-    let lockfile_path = manifest_path.parent().unwrap().join("ccpm.lock");
+    let lockfile_path = manifest_path.parent().unwrap().join("agpm.lock");
     if lockfile_path.exists() {
         let mut lockfile = LockFile::load(&lockfile_path)?;
 
@@ -499,7 +499,7 @@ mod tests {
     #[tokio::test]
     async fn test_remove_source_not_found() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create a minimal manifest
         let manifest_content = r#"
@@ -526,7 +526,7 @@ existing = "https://github.com/test/repo.git"
     #[tokio::test]
     async fn test_remove_source_success() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create a manifest with sources
         let manifest_content = r#"
@@ -556,7 +556,7 @@ another-source = "https://github.com/another/repo.git"
     #[tokio::test]
     async fn test_remove_source_in_use() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create a manifest with a source in use
         let manifest_content = r#"
@@ -583,7 +583,7 @@ test-agent = { source = "used-source", path = "agents/test.md", version = "v1.0.
     #[tokio::test]
     async fn test_remove_source_in_use_with_force() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create a manifest with a source in use
         let manifest_content = r#"
@@ -614,7 +614,7 @@ test-agent = { source = "used-source", path = "agents/test.md", version = "v1.0.
     #[tokio::test]
     async fn test_remove_dependency_not_found() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create a minimal manifest
         let manifest_content = r#"
@@ -640,7 +640,7 @@ test-agent = { source = "used-source", path = "agents/test.md", version = "v1.0.
     #[tokio::test]
     async fn test_remove_agent_success() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create a manifest with an agent
         let manifest_content = r#"
@@ -673,7 +673,7 @@ another-agent = "../test/another.md"
     #[tokio::test]
     async fn test_remove_snippet_success() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create a manifest with a snippet
         let manifest_content = r#"
@@ -704,7 +704,7 @@ test-snippet = "../test/snippet.md"
     #[tokio::test]
     async fn test_remove_command_success() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create a manifest with a command
         let manifest_content = r#"
@@ -735,7 +735,7 @@ test-command = "../test/command.md"
     #[tokio::test]
     async fn test_remove_mcp_server_success() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create a manifest with an MCP server
         let manifest_content = r#"
@@ -765,7 +765,7 @@ test-server = "../local/mcp-servers/test-server.json"
     #[tokio::test]
     async fn test_remove_script_success() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create a manifest with a script
         let manifest_content = r#"
@@ -798,7 +798,7 @@ another-script = "../test/another.sh"
     #[tokio::test]
     async fn test_remove_hook_success() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create a manifest with a hook
         let manifest_content = r#"
@@ -829,7 +829,7 @@ post-commit = "../test/another_hook.json"
     #[tokio::test]
     async fn test_remove_invalid_dependency_type() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create a minimal manifest
         let manifest_content = r#"
@@ -862,8 +862,8 @@ post-commit = "../test/another_hook.json"
         use crate::lockfile::{LockFile, LockedResource};
 
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
-        let lockfile_path = temp.path().join("ccpm.lock");
+        let manifest_path = temp.path().join("agpm.toml");
+        let lockfile_path = temp.path().join("agpm.lock");
 
         // Create a manifest
         let manifest_content = r#"
@@ -913,7 +913,7 @@ test-agent = "../test/agent.md"
     #[tokio::test]
     async fn test_remove_source_checks_all_dependency_types() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create a manifest with a source used by different dependency types
         let manifest_content = r#"
@@ -957,7 +957,7 @@ test-hook = { source = "used-source", path = "hooks/test.json", version = "v1.0.
     #[tokio::test]
     async fn test_execute_remove_command() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create a manifest
         let manifest_content = r#"
@@ -990,8 +990,8 @@ test = "https://github.com/test/repo.git"
 
         let temp = TempDir::new().unwrap();
         let project_dir = temp.path();
-        let manifest_path = project_dir.join("ccpm.toml");
-        let lockfile_path = project_dir.join("ccpm.lock");
+        let manifest_path = project_dir.join("agpm.toml");
+        let lockfile_path = project_dir.join("agpm.lock");
 
         // Create manifest with a dependency
         let manifest = r#"
@@ -1125,8 +1125,8 @@ test-snippet = { source = "test-source", path = "snippets/test.md", version = "v
         use crate::lockfile::{LockFile, LockedResource};
 
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
-        let lockfile_path = temp.path().join("ccpm.lock");
+        let manifest_path = temp.path().join("agpm.toml");
+        let lockfile_path = temp.path().join("agpm.lock");
 
         // Create a manifest with scripts and hooks
         let manifest_content = r#"
@@ -1153,7 +1153,7 @@ test-hook = "../test/hook.json"
             version: None,
             resolved_commit: None,
             checksum: "sha256:test".to_string(),
-            installed_at: ".claude/ccpm/scripts/test-script.sh".to_string(),
+            installed_at: ".claude/agpm/scripts/test-script.sh".to_string(),
             dependencies: vec![],
             resource_type: crate::core::ResourceType::Script,
         });
@@ -1165,7 +1165,7 @@ test-hook = "../test/hook.json"
             version: None,
             resolved_commit: None,
             checksum: "sha256:test".to_string(),
-            installed_at: ".claude/ccpm/hooks/test-hook.json".to_string(),
+            installed_at: ".claude/agpm/hooks/test-hook.json".to_string(),
             dependencies: vec![],
             resource_type: crate::core::ResourceType::Hook,
         });
@@ -1200,8 +1200,8 @@ test-hook = "../test/hook.json"
         use crate::lockfile::{LockFile, LockedResource, LockedSource};
 
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
-        let lockfile_path = temp.path().join("ccpm.lock");
+        let manifest_path = temp.path().join("agpm.toml");
+        let lockfile_path = temp.path().join("agpm.lock");
 
         // Create a manifest with dependencies
         let manifest_content = r#"
@@ -1313,7 +1313,7 @@ test-snippet = "../local/snippet.md"
     #[tokio::test]
     async fn test_remove_mcp_server_updates_settings() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
         let settings_dir = temp.path().join(".claude");
         let settings_path = settings_dir.join("settings.local.json");
 
@@ -1366,7 +1366,7 @@ test-server = "../mcp/test-server.json"
     #[tokio::test]
     async fn test_remove_hook_updates_settings() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
         let settings_dir = temp.path().join(".claude");
         let settings_path = settings_dir.join("settings.local.json");
 
@@ -1416,9 +1416,9 @@ test-hook = "../hooks/test-hook.json"
         use crate::lockfile::{LockFile, LockedResource};
 
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
-        let lockfile_path = temp.path().join("ccpm.lock");
-        let script_dir = temp.path().join(".claude/ccpm/scripts");
+        let manifest_path = temp.path().join("agpm.toml");
+        let lockfile_path = temp.path().join("agpm.lock");
+        let script_dir = temp.path().join(".claude/agpm/scripts");
         let script_file = script_dir.join("test-script.sh");
 
         // Create manifest with script
@@ -1444,7 +1444,7 @@ test-script = "../test/script.sh"
             version: None,
             resolved_commit: None,
             checksum: "sha256:test".to_string(),
-            installed_at: ".claude/ccpm/scripts/test-script.sh".to_string(),
+            installed_at: ".claude/agpm/scripts/test-script.sh".to_string(),
             dependencies: vec![],
             resource_type: crate::core::ResourceType::Script,
         });

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -26,16 +26,16 @@ mod cli_tests {
     #[test]
     fn test_cli_parsing() {
         // Test basic command parsing
-        let cli = Cli::try_parse_from(["ccpm", "--help"]);
+        let cli = Cli::try_parse_from(["agpm", "--help"]);
         assert!(cli.is_err()); // --help causes a special error
 
-        let cli = Cli::try_parse_from(["ccpm", "list"]);
+        let cli = Cli::try_parse_from(["agpm", "list"]);
         assert!(cli.is_ok());
     }
 
     #[test]
     fn test_cli_verbose_flag() {
-        let cli = Cli::try_parse_from(["ccpm", "--verbose", "list"]);
+        let cli = Cli::try_parse_from(["agpm", "--verbose", "list"]);
         assert!(cli.is_ok());
         let cli = cli.unwrap();
         assert!(cli.verbose);
@@ -43,7 +43,7 @@ mod cli_tests {
 
     #[test]
     fn test_cli_quiet_flag() {
-        let cli = Cli::try_parse_from(["ccpm", "--quiet", "list"]);
+        let cli = Cli::try_parse_from(["agpm", "--quiet", "list"]);
         assert!(cli.is_ok());
         let cli = cli.unwrap();
         assert!(cli.quiet);
@@ -51,7 +51,7 @@ mod cli_tests {
 
     #[test]
     fn test_cli_no_progress_flag() {
-        let cli = Cli::try_parse_from(["ccpm", "--no-progress", "list"]);
+        let cli = Cli::try_parse_from(["agpm", "--no-progress", "list"]);
         assert!(cli.is_ok());
         let cli = cli.unwrap();
         assert!(cli.no_progress);
@@ -59,7 +59,7 @@ mod cli_tests {
 
     #[test]
     fn test_cli_config_option() {
-        let cli = Cli::try_parse_from(["ccpm", "--config", "/path/to/config", "list"]);
+        let cli = Cli::try_parse_from(["agpm", "--config", "/path/to/config", "list"]);
         assert!(cli.is_ok());
         let cli = cli.unwrap();
         assert_eq!(cli.config, Some("/path/to/config".to_string()));
@@ -69,20 +69,20 @@ mod cli_tests {
     fn test_cli_all_commands() {
         // Test that all commands can be parsed
         let commands = vec![
-            vec!["ccpm", "init"],
+            vec!["agpm", "init"],
             vec![
-                "ccpm",
+                "agpm",
                 "add",
                 "source",
                 "test",
                 "https://github.com/test/repo.git",
             ],
-            vec!["ccpm", "install"],
-            vec!["ccpm", "update"],
-            vec!["ccpm", "list"],
-            vec!["ccpm", "validate"],
-            vec!["ccpm", "cache", "info"],
-            vec!["ccpm", "config", "show"],
+            vec!["agpm", "install"],
+            vec!["agpm", "update"],
+            vec!["agpm", "list"],
+            vec!["agpm", "validate"],
+            vec!["agpm", "cache", "info"],
+            vec!["agpm", "config", "show"],
         ];
 
         for cmd in commands {
@@ -103,7 +103,7 @@ mod cli_tests {
         let temp_path = temp_dir.path().canonicalize().unwrap();
 
         // Create the manifest
-        let manifest_path = temp_path.join("ccpm.toml");
+        let manifest_path = temp_path.join("agpm.toml");
         std::fs::write(&manifest_path, "[sources]\n").unwrap();
 
         // Verify the file exists
@@ -111,7 +111,7 @@ mod cli_tests {
 
         // Test that verbose flag creates correct config and executes successfully
         // Use config path command which doesn't need a manifest in current dir
-        let cli = Cli::try_parse_from(["ccpm", "--verbose", "config", "path"]).unwrap();
+        let cli = Cli::try_parse_from(["agpm", "--verbose", "config", "path"]).unwrap();
         assert!(cli.verbose);
         let config = cli.build_config();
         assert_eq!(config.log_level, Some("debug".to_string()));
@@ -123,7 +123,7 @@ mod cli_tests {
         assert!(result.is_ok(), "Failed to execute with verbose flag");
 
         // Test that quiet flag creates correct config
-        let cli = Cli::try_parse_from(["ccpm", "--quiet", "config", "path"]).unwrap();
+        let cli = Cli::try_parse_from(["agpm", "--quiet", "config", "path"]).unwrap();
         assert!(cli.quiet);
         let config = cli.build_config();
         assert_eq!(config.log_level, None);
@@ -133,7 +133,7 @@ mod cli_tests {
         assert!(result.is_ok(), "Failed to execute with quiet flag");
 
         // Test that no-progress flag creates correct config
-        let cli = Cli::try_parse_from(["ccpm", "--no-progress", "config", "path"]).unwrap();
+        let cli = Cli::try_parse_from(["agpm", "--no-progress", "config", "path"]).unwrap();
         assert!(cli.no_progress);
         let config = cli.build_config();
         assert!(config.no_progress);
@@ -145,7 +145,7 @@ mod cli_tests {
 
         // Test combined flags
         let cli =
-            Cli::try_parse_from(["ccpm", "--verbose", "--no-progress", "config", "path"]).unwrap();
+            Cli::try_parse_from(["agpm", "--verbose", "--no-progress", "config", "path"]).unwrap();
         assert!(cli.verbose);
         assert!(cli.no_progress);
         let config = cli.build_config();
@@ -160,28 +160,28 @@ mod cli_tests {
     #[test]
     fn test_cli_config_builder() {
         // Test verbose flag sets debug log level
-        let cli = Cli::try_parse_from(["ccpm", "--verbose", "list"]).unwrap();
+        let cli = Cli::try_parse_from(["agpm", "--verbose", "list"]).unwrap();
         let config = cli.build_config();
         assert_eq!(config.log_level, Some("debug".to_string()));
         assert!(!config.no_progress);
 
         // Test quiet flag sets no log level
-        let cli = Cli::try_parse_from(["ccpm", "--quiet", "list"]).unwrap();
+        let cli = Cli::try_parse_from(["agpm", "--quiet", "list"]).unwrap();
         let config = cli.build_config();
         assert_eq!(config.log_level, None);
 
         // Test default sets info log level
-        let cli = Cli::try_parse_from(["ccpm", "list"]).unwrap();
+        let cli = Cli::try_parse_from(["agpm", "list"]).unwrap();
         let config = cli.build_config();
         assert_eq!(config.log_level, Some("info".to_string()));
 
         // Test no-progress flag
-        let cli = Cli::try_parse_from(["ccpm", "--no-progress", "list"]).unwrap();
+        let cli = Cli::try_parse_from(["agpm", "--no-progress", "list"]).unwrap();
         let config = cli.build_config();
         assert!(config.no_progress);
 
         // Test config path
-        let cli = Cli::try_parse_from(["ccpm", "--config", "/custom/path", "list"]).unwrap();
+        let cli = Cli::try_parse_from(["agpm", "--config", "/custom/path", "list"]).unwrap();
         let config = cli.build_config();
         assert_eq!(config.config_path, Some("/custom/path".to_string()));
     }
@@ -197,7 +197,7 @@ mod cli_tests {
         let temp_path = temp_dir.path().canonicalize().unwrap();
 
         // Create the manifest in temp directory
-        let manifest_path = temp_path.join("ccpm.toml");
+        let manifest_path = temp_path.join("agpm.toml");
         std::fs::write(&manifest_path, "[sources]\n").unwrap();
 
         // Verify the file exists
@@ -208,7 +208,7 @@ mod cli_tests {
 
         // Test each command execution path - use manifest-path parameter for all
         let cli = Cli::try_parse_from([
-            "ccpm",
+            "agpm",
             "--manifest-path",
             manifest_path.to_str().unwrap(),
             "list",
@@ -221,7 +221,7 @@ mod cli_tests {
         assert!(manifest_path.exists(), "Manifest disappeared after list");
 
         let cli = Cli::try_parse_from([
-            "ccpm",
+            "agpm",
             "--manifest-path",
             manifest_path.to_str().unwrap(),
             "validate",
@@ -231,7 +231,7 @@ mod cli_tests {
         assert!(result.is_ok(), "validate command failed: {result:?}");
 
         let cli = Cli::try_parse_from([
-            "ccpm",
+            "agpm",
             "--manifest-path",
             manifest_path.to_str().unwrap(),
             "cache",
@@ -246,7 +246,7 @@ mod cli_tests {
 
         // Test install
         let cli = Cli::try_parse_from([
-            "ccpm",
+            "agpm",
             "--manifest-path",
             manifest_path.to_str().unwrap(),
             "install",
@@ -257,7 +257,7 @@ mod cli_tests {
 
         // Test update
         let cli = Cli::try_parse_from([
-            "ccpm",
+            "agpm",
             "--manifest-path",
             manifest_path.to_str().unwrap(),
             "update",
@@ -268,7 +268,7 @@ mod cli_tests {
 
         // Test add source
         let cli = Cli::try_parse_from([
-            "ccpm",
+            "agpm",
             "--manifest-path",
             manifest_path.to_str().unwrap(),
             "add",
@@ -284,7 +284,7 @@ mod cli_tests {
     #[tokio::test]
     async fn test_cli_execute_method() {
         // Test with config path command which doesn't require a manifest
-        let cli = Cli::try_parse_from(["ccpm", "config", "path"]).unwrap();
+        let cli = Cli::try_parse_from(["agpm", "config", "path"]).unwrap();
 
         // This tests the execute method path (lines 582-584)
         let result = cli.execute().await;
@@ -301,13 +301,13 @@ mod cli_tests {
         // Test Init command execution (line 692)
         // Parse the CLI to properly create the command with path option
         let cli =
-            Cli::try_parse_from(["ccpm", "init", "--path", temp_path.to_str().unwrap()]).unwrap();
+            Cli::try_parse_from(["agpm", "init", "--path", temp_path.to_str().unwrap()]).unwrap();
 
         let result = cli.execute().await;
         assert!(result.is_ok(), "Init command failed: {result:?}");
 
         // Verify the manifest was created
-        let manifest_path = temp_path.join("ccpm.toml");
+        let manifest_path = temp_path.join("agpm.toml");
         assert!(manifest_path.exists());
     }
 
@@ -319,11 +319,11 @@ mod cli_tests {
         let temp_path = temp_dir.path().canonicalize().unwrap();
 
         // Create a manifest for cache operations
-        std::fs::write(temp_path.join("ccpm.toml"), "[sources]\n").unwrap();
+        std::fs::write(temp_path.join("agpm.toml"), "[sources]\n").unwrap();
 
         // Test Cache command execution (line 698)
         // Parse the CLI to properly create the command with default subcommand
-        let cli = Cli::try_parse_from(["ccpm", "cache", "info"]).unwrap();
+        let cli = Cli::try_parse_from(["agpm", "cache", "info"]).unwrap();
 
         let result = cli.execute().await;
         assert!(result.is_ok(), "Cache command failed: {result:?}");
@@ -340,7 +340,7 @@ mod cli_tests {
 
         // Create a manifest with a source to remove
         std::fs::write(
-            temp_path.join("ccpm.toml"),
+            temp_path.join("agpm.toml"),
             r#"[sources]
 test-source = "https://github.com/test/repo.git"
 
@@ -353,7 +353,7 @@ test-source = "https://github.com/test/repo.git"
         .unwrap();
 
         // Test Remove command execution - try to remove non-existent source
-        let cli = Cli::try_parse_from(["ccpm", "remove", "source", "nonexistent"]).unwrap();
+        let cli = Cli::try_parse_from(["agpm", "remove", "source", "nonexistent"]).unwrap();
 
         let result = cli.execute().await;
 
@@ -372,7 +372,7 @@ test-source = "https://github.com/test/repo.git"
 
         // Test Config command execution (line 699)
         // Config path command doesn't need a manifest
-        let cli = Cli::try_parse_from(["ccpm", "config", "path"]).unwrap();
+        let cli = Cli::try_parse_from(["agpm", "config", "path"]).unwrap();
 
         let result = cli.execute().await;
         assert!(result.is_ok(), "Config command failed: {result:?}");
@@ -385,7 +385,7 @@ test-source = "https://github.com/test/repo.git"
 
         for cmd in &commands {
             for flag in &flags {
-                let result = Cli::try_parse_from(["ccpm", flag, cmd]);
+                let result = Cli::try_parse_from(["agpm", flag, cmd]);
                 assert!(result.is_ok(), "Failed with {flag} {cmd}");
             }
         }

--- a/src/cli/tree.rs
+++ b/src/cli/tree.rs
@@ -19,27 +19,27 @@
 //!
 //! Display the full dependency tree:
 //! ```bash
-//! ccpm tree
+//! agpm tree
 //! ```
 //!
 //! Limit tree depth:
 //! ```bash
-//! ccpm tree --depth 2
+//! agpm tree --depth 2
 //! ```
 //!
 //! Show tree for a specific package:
 //! ```bash
-//! ccpm tree --package my-agent
+//! agpm tree --package my-agent
 //! ```
 //!
 //! Show only duplicates:
 //! ```bash
-//! ccpm tree --duplicates
+//! agpm tree --duplicates
 //! ```
 //!
 //! Output as JSON:
 //! ```bash
-//! ccpm tree --format json
+//! agpm tree --format json
 //! ```
 //!
 //! # Output Format
@@ -84,8 +84,8 @@ pub struct TreeCommand {
     /// # Examples
     ///
     /// ```bash
-    /// ccpm tree --depth 1    # Show only direct dependencies
-    /// ccpm tree --depth 3    # Show up to 3 levels
+    /// agpm tree --depth 1    # Show only direct dependencies
+    /// agpm tree --depth 3    # Show up to 3 levels
     /// ```
     #[arg(short = 'd', long)]
     depth: Option<usize>,
@@ -121,8 +121,8 @@ pub struct TreeCommand {
     /// # Examples
     ///
     /// ```bash
-    /// ccpm tree --package my-agent
-    /// ccpm tree -p code-reviewer
+    /// agpm tree --package my-agent
+    /// agpm tree -p code-reviewer
     /// ```
     #[arg(short = 'p', long)]
     package: Option<String>,
@@ -167,7 +167,7 @@ impl TreeCommand {
 
         // Find manifest file
         let manifest_path = find_manifest_with_optional(manifest_path)
-            .context("No ccpm.toml found. Please create one to define your dependencies.")?;
+            .context("No agpm.toml found. Please create one to define your dependencies.")?;
 
         self.execute_from_path(manifest_path).await
     }
@@ -185,7 +185,7 @@ impl TreeCommand {
         }
 
         let project_dir = manifest_path.parent().unwrap();
-        let lockfile_path = project_dir.join("ccpm.lock");
+        let lockfile_path = project_dir.join("agpm.lock");
 
         // Derive project name from directory
         let project_name = project_dir
@@ -200,7 +200,7 @@ impl TreeCommand {
                 println!("{{}}");
             } else {
                 println!("No lockfile found.");
-                println!("⚠️  Run 'ccpm install' first to generate ccpm.lock");
+                println!("⚠️  Run 'agpm install' first to generate agpm.lock");
             }
             return Ok(());
         }

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -19,32 +19,32 @@
 //!
 //! Update all dependencies:
 //! ```bash
-//! ccpm update
+//! agpm update
 //! ```
 //!
 //! Update specific dependencies:
 //! ```bash
-//! ccpm update my-agent utils-snippet
+//! agpm update my-agent utils-snippet
 //! ```
 //!
 //! Preview updates without applying:
 //! ```bash
-//! ccpm update --dry-run
+//! agpm update --dry-run
 //! ```
 //!
 //! Check for available updates (exit code 1 if updates available):
 //! ```bash
-//! ccpm update --check
+//! agpm update --check
 //! ```
 //!
 //! Force update ignoring constraints:
 //! ```bash
-//! ccpm update --force
+//! agpm update --force
 //! ```
 //!
 //! Update with custom parallelism:
 //! ```bash
-//! ccpm update --max-parallel 4
+//! agpm update --max-parallel 4
 //! ```
 //!
 //! # Update Logic
@@ -95,25 +95,25 @@ use crate::resolver::DependencyResolver;
 /// ## Update All Dependencies
 /// Update all dependencies to their latest compatible versions:
 /// ```bash
-/// ccpm update
+/// agpm update
 /// ```
 ///
 /// ## Selective Updates
 /// Update only specific dependencies:
 /// ```bash
-/// ccpm update my-agent utils-snippet
+/// agpm update my-agent utils-snippet
 /// ```
 ///
 /// ## Preview Updates
 /// Check what would be updated without making changes:
 /// ```bash
-/// ccpm update --dry-run
+/// agpm update --dry-run
 /// ```
 ///
 /// ## Force Updates
 /// Update ignoring version constraints:
 /// ```bash
-/// ccpm update --force
+/// agpm update --force
 /// ```
 ///
 /// # Options
@@ -157,7 +157,7 @@ pub struct UpdateCommand {
     /// If provided, only these dependencies will be updated. Otherwise,
     /// all dependencies in the manifest are considered for updates.
     ///
-    /// Example: `ccpm update my-agent utils-snippet`
+    /// Example: `agpm update my-agent utils-snippet`
     #[arg(value_name = "DEPENDENCY")]
     pub dependencies: Vec<String>,
 
@@ -185,7 +185,7 @@ pub struct UpdateCommand {
 
     /// Create a backup of the lockfile before updating.
     ///
-    /// The backup is saved as `ccpm.lock.backup` and can be restored
+    /// The backup is saved as `agpm.lock.backup` and can be restored
     /// manually if the update causes issues.
     #[arg(long)]
     pub backup: bool,
@@ -263,7 +263,7 @@ impl UpdateCommand {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// use ccpm::cli::update::UpdateCommand;
+    /// use agpm::cli::update::UpdateCommand;
     ///
     /// # tokio_test::block_on(async {
     /// // Update all dependencies with backup
@@ -284,9 +284,9 @@ impl UpdateCommand {
     pub async fn execute_with_manifest_path(self, manifest_path: Option<PathBuf>) -> Result<()> {
         // Find manifest file
         let manifest_path = find_manifest_with_optional(manifest_path).with_context(|| {
-            "No ccpm.toml found in current directory or any parent directory.\n\n\
-            The update command requires a ccpm.toml file to know what dependencies to update.\n\
-            Create one first, then run 'ccpm install' before updating."
+            "No agpm.toml found in current directory or any parent directory.\n\n\
+            The update command requires a agpm.toml file to know what dependencies to update.\n\
+            Create one first, then run 'agpm install' before updating."
         })?;
 
         self.execute_from_path(manifest_path).await
@@ -318,7 +318,7 @@ impl UpdateCommand {
         })?;
 
         // Load existing lockfile or perform fresh install if missing
-        let lockfile_path = project_dir.join("ccpm.lock");
+        let lockfile_path = project_dir.join("agpm.lock");
         let existing_lockfile = if lockfile_path.exists() {
             LockFile::load(&lockfile_path)?
         } else {
@@ -654,7 +654,7 @@ mod tests {
     #[tokio::test]
     async fn test_execute_no_manifest_found() {
         let temp = TempDir::new().unwrap();
-        let non_existent_manifest = temp.path().join("ccpm.toml");
+        let non_existent_manifest = temp.path().join("agpm.toml");
         assert!(!non_existent_manifest.exists());
 
         let cmd = create_update_command();
@@ -664,14 +664,14 @@ mod tests {
 
         assert!(result.is_err());
         let error_msg = format!("{}", result.unwrap_err());
-        assert!(error_msg.contains("No ccpm.toml found"));
+        assert!(error_msg.contains("No agpm.toml found"));
         assert!(error_msg.contains("Create one first"));
     }
 
     #[tokio::test]
     async fn test_execute_from_path_nonexistent_manifest() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("nonexistent").join("ccpm.toml");
+        let manifest_path = temp.path().join("nonexistent").join("agpm.toml");
 
         let cmd = create_update_command();
         let result = cmd.execute_from_path(manifest_path.clone()).await;
@@ -685,7 +685,7 @@ mod tests {
     #[tokio::test]
     async fn test_execute_from_path_invalid_manifest() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create invalid TOML content
         fs::write(&manifest_path, "invalid toml [[[").unwrap();
@@ -702,8 +702,8 @@ mod tests {
     #[tokio::test]
     async fn test_execute_from_path_no_lockfile_fresh_install() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
-        let lockfile_path = temp.path().join("ccpm.lock");
+        let manifest_path = temp.path().join("agpm.toml");
+        let lockfile_path = temp.path().join("agpm.lock");
 
         // Create a minimal manifest with explicit empty sources
         // This ensures no sources from global config are used
@@ -737,9 +737,9 @@ mod tests {
     #[tokio::test]
     async fn test_execute_with_backup_flag() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
-        let lockfile_path = temp.path().join("ccpm.lock");
-        let backup_path = temp.path().join("ccpm.lock.backup");
+        let manifest_path = temp.path().join("agpm.toml");
+        let lockfile_path = temp.path().join("agpm.lock");
+        let backup_path = temp.path().join("agpm.lock.backup");
 
         // Create manifest and existing lockfile
         let manifest = create_test_manifest();
@@ -769,8 +769,8 @@ mod tests {
     #[tokio::test]
     async fn test_execute_with_specific_dependencies() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
-        let lockfile_path = temp.path().join("ccpm.lock");
+        let manifest_path = temp.path().join("agpm.toml");
+        let lockfile_path = temp.path().join("agpm.lock");
 
         // Create manifest and existing lockfile
         let manifest = create_test_manifest();
@@ -790,8 +790,8 @@ mod tests {
     #[tokio::test]
     async fn test_execute_dry_run_mode() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
-        let lockfile_path = temp.path().join("ccpm.lock");
+        let manifest_path = temp.path().join("agpm.toml");
+        let lockfile_path = temp.path().join("agpm.lock");
 
         // Create manifest and existing lockfile
         let manifest = create_test_manifest();
@@ -815,8 +815,8 @@ mod tests {
     #[tokio::test]
     async fn test_execute_check_mode() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
-        let lockfile_path = temp.path().join("ccpm.lock");
+        let manifest_path = temp.path().join("agpm.toml");
+        let lockfile_path = temp.path().join("agpm.lock");
 
         // Create manifest and existing lockfile
         let manifest = create_test_manifest();
@@ -840,8 +840,8 @@ mod tests {
     #[tokio::test]
     async fn test_execute_verbose_mode() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
-        let lockfile_path = temp.path().join("ccpm.lock");
+        let manifest_path = temp.path().join("agpm.toml");
+        let lockfile_path = temp.path().join("agpm.lock");
 
         // Create manifest and existing lockfile
         let manifest = create_test_manifest();
@@ -862,8 +862,8 @@ mod tests {
     #[tokio::test]
     async fn test_execute_quiet_mode() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
-        let lockfile_path = temp.path().join("ccpm.lock");
+        let manifest_path = temp.path().join("agpm.toml");
+        let lockfile_path = temp.path().join("agpm.lock");
 
         // Create manifest and existing lockfile
         let manifest = create_test_manifest();
@@ -883,8 +883,8 @@ mod tests {
     #[tokio::test]
     async fn test_update_comparison_logic() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
-        let lockfile_path = temp.path().join("ccpm.lock");
+        let manifest_path = temp.path().join("agpm.toml");
+        let lockfile_path = temp.path().join("agpm.lock");
 
         // Create manifest
         let manifest = create_test_manifest();
@@ -908,8 +908,8 @@ mod tests {
     #[tokio::test]
     async fn test_lockfile_save_error_handling() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
-        let lockfile_path = temp.path().join("ccpm.lock");
+        let manifest_path = temp.path().join("agpm.toml");
+        let lockfile_path = temp.path().join("agpm.lock");
 
         // Create manifest and existing lockfile
         let manifest = create_test_manifest();
@@ -944,9 +944,9 @@ mod tests {
     #[tokio::test]
     async fn test_backup_and_rollback_logic() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
-        let lockfile_path = temp.path().join("ccpm.lock");
-        let backup_path = temp.path().join("ccpm.lock.backup");
+        let manifest_path = temp.path().join("agpm.toml");
+        let lockfile_path = temp.path().join("agpm.lock");
+        let backup_path = temp.path().join("agpm.lock.backup");
 
         // Create manifest and existing lockfile
         let manifest = create_test_manifest();
@@ -970,8 +970,8 @@ mod tests {
     #[tokio::test]
     async fn test_dependencies_empty_vs_specific() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
-        let lockfile_path = temp.path().join("ccpm.lock");
+        let manifest_path = temp.path().join("agpm.toml");
+        let lockfile_path = temp.path().join("agpm.lock");
 
         // Create manifest and existing lockfile
         let manifest = create_test_manifest();
@@ -995,8 +995,8 @@ mod tests {
     #[tokio::test]
     async fn test_progress_bar_creation_logic() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
-        let lockfile_path = temp.path().join("ccpm.lock");
+        let manifest_path = temp.path().join("agpm.toml");
+        let lockfile_path = temp.path().join("agpm.lock");
 
         // Create manifest and existing lockfile
         let manifest = create_test_manifest();
@@ -1019,7 +1019,7 @@ mod tests {
     #[tokio::test]
     async fn test_update_output_messages() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Test fresh install message path
         let manifest = Manifest::new();
@@ -1038,8 +1038,8 @@ mod tests {
     #[tokio::test]
     async fn test_execute_main_workflow() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
-        let lockfile_path = temp.path().join("ccpm.lock");
+        let manifest_path = temp.path().join("agpm.toml");
+        let lockfile_path = temp.path().join("agpm.lock");
 
         // Create a minimal manifest with explicit empty sources
         // This ensures no sources from global config are used

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -500,7 +500,7 @@ async fn show_status(updater: &SelfUpdater, version_checker: &VersionChecker) ->
     };
 
     let info = VersionChecker::format_version_info(current_version, latest_version.as_deref());
-    println!("{}", info);
+    println!("{info}");
 
     Ok(())
 }
@@ -533,7 +533,7 @@ async fn check_for_updates(updater: &SelfUpdater, version_checker: &VersionCheck
             );
         }
         Err(e) => {
-            bail!("Failed to check for updates: {}", e);
+            bail!("Failed to check for updates: {e}");
         }
     }
 
@@ -548,7 +548,9 @@ async fn perform_upgrade(
     no_backup: bool,
 ) -> Result<()> {
     // Create backup unless explicitly skipped
-    let backup_manager = if !no_backup {
+    let backup_manager = if no_backup {
+        None
+    } else {
         println!("{}", "Creating backup...".cyan());
         let manager = BackupManager::new(current_exe.to_path_buf());
         manager
@@ -556,17 +558,15 @@ async fn perform_upgrade(
             .await
             .context("Failed to create backup")?;
         Some(manager)
-    } else {
-        None
     };
 
     // Perform the upgrade
     let upgrade_msg = if let Some(version) = target_version {
-        format!("Upgrading to version {}...", version).cyan()
+        format!("Upgrading to version {version}...").cyan()
     } else {
         "Upgrading to latest version...".cyan()
     };
-    println!("{}", upgrade_msg);
+    println!("{upgrade_msg}");
 
     let result = if let Some(version) = target_version {
         updater.update_to_version(version).await
@@ -608,14 +608,14 @@ async fn perform_upgrade(
                 if let Err(restore_err) = manager.restore_backup().await {
                     eprintln!(
                         "{}",
-                        format!("Failed to restore backup: {}", restore_err).red()
+                        format!("Failed to restore backup: {restore_err}").red()
                     );
                     eprintln!("Backup is located at: {}", manager.backup_path().display());
                 } else {
                     println!("{}", "Successfully restored from backup".green());
                 }
             }
-            bail!("Upgrade failed: {}", e);
+            bail!("Upgrade failed: {e}");
         }
     }
 

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -6,10 +6,10 @@ use colored::Colorize;
 use std::env;
 use tracing::debug;
 
-/// Command-line arguments for the CCPM upgrade command.
+/// Command-line arguments for the AGPM upgrade command.
 ///
 /// This structure defines all the options and flags available for upgrading
-/// CCPM to newer versions. The upgrade command provides multiple modes of
+/// AGPM to newer versions. The upgrade command provides multiple modes of
 /// operation from simple version checking to full upgrades with rollback support.
 ///
 /// # Command Modes
@@ -33,32 +33,32 @@ use tracing::debug;
 /// ## Basic Usage
 /// ```bash
 /// # Check for available updates
-/// ccpm upgrade --check
+/// agpm upgrade --check
 ///
 /// # Show version status
-/// ccpm upgrade --status
+/// agpm upgrade --status
 ///
 /// # Upgrade to latest version
-/// ccpm upgrade
+/// agpm upgrade
 /// ```
 ///
 /// ## Version-Specific Upgrades
 /// ```bash
 /// # Upgrade to specific version
-/// ccpm upgrade 0.4.0
-/// ccpm upgrade v0.4.0
+/// agpm upgrade 0.4.0
+/// agpm upgrade v0.4.0
 ///
 /// # Force upgrade even if already on target version
-/// ccpm upgrade 0.4.0 --force
+/// agpm upgrade 0.4.0 --force
 /// ```
 ///
 /// ## Safety and Recovery
 /// ```bash
 /// # Upgrade without creating backup (risky)
-/// ccpm upgrade --no-backup
+/// agpm upgrade --no-backup
 ///
 /// # Rollback to previous version
-/// ccpm upgrade --rollback
+/// agpm upgrade --rollback
 /// ```
 ///
 /// # Safety Features
@@ -72,7 +72,7 @@ use tracing::debug;
 pub struct UpgradeArgs {
     /// Target version to upgrade to (e.g., "0.4.0" or "v0.4.0").
     ///
-    /// When specified, CCPM will attempt to upgrade to this specific version
+    /// When specified, AGPM will attempt to upgrade to this specific version
     /// instead of the latest available version. The version string can be
     /// provided with or without the 'v' prefix.
     ///
@@ -93,9 +93,9 @@ pub struct UpgradeArgs {
     /// # Examples
     ///
     /// ```bash
-    /// ccpm upgrade 0.4.0        # Upgrade to specific stable version
-    /// ccpm upgrade v0.5.0-beta  # Upgrade to beta version
-    /// ccpm upgrade 0.3.0 --force # Downgrade to older version
+    /// agpm upgrade 0.4.0        # Upgrade to specific stable version
+    /// agpm upgrade v0.5.0-beta  # Upgrade to beta version
+    /// agpm upgrade 0.3.0 --force # Downgrade to older version
     /// ```
     #[arg(value_name = "VERSION")]
     pub version: Option<String>,
@@ -120,7 +120,7 @@ pub struct UpgradeArgs {
     /// ```text
     /// # When update is available
     /// Update available: 0.3.14 -> 0.4.0
-    /// Run `ccpm upgrade` to install the latest version
+    /// Run `agpm upgrade` to install the latest version
     ///
     /// # When up to date
     /// You are on the latest version (0.4.0)
@@ -137,13 +137,13 @@ pub struct UpgradeArgs {
 
     /// Show current version and latest available.
     ///
-    /// Displays comprehensive version information including the current CCPM
+    /// Displays comprehensive version information including the current AGPM
     /// version and the latest available version from GitHub releases. Uses
     /// cached version information when available to avoid unnecessary API calls.
     ///
     /// # Information Displayed
     ///
-    /// - Current version of the running CCPM binary
+    /// - Current version of the running AGPM binary
     /// - Latest version available on GitHub (if reachable)
     /// - Update availability status
     /// - Cache status (when version info was last fetched)
@@ -213,20 +213,20 @@ pub struct UpgradeArgs {
     ///
     /// ```bash
     /// # Reinstall current version
-    /// ccpm upgrade --force
+    /// agpm upgrade --force
     ///
     /// # Downgrade to older version
-    /// ccpm upgrade 0.3.0 --force
+    /// agpm upgrade 0.3.0 --force
     ///
     /// # Force upgrade to specific version
-    /// ccpm upgrade 0.4.0 --force
+    /// agpm upgrade 0.4.0 --force
     /// ```
     #[arg(short, long)]
     pub force: bool,
 
     /// Rollback to previous version from backup.
     ///
-    /// Restores the CCPM binary from the backup created during the most recent
+    /// Restores the AGPM binary from the backup created during the most recent
     /// upgrade. This provides a quick recovery mechanism if the current version
     /// has issues or if you need to revert to the previous version.
     ///
@@ -242,7 +242,7 @@ pub struct UpgradeArgs {
     ///
     /// - A backup must exist from a previous upgrade
     /// - Backup file must be readable and valid
-    /// - Write permissions to the CCPM binary location
+    /// - Write permissions to the AGPM binary location
     /// - Current binary must not be locked by running processes
     ///
     /// # Error Conditions
@@ -262,11 +262,11 @@ pub struct UpgradeArgs {
     ///
     /// ```bash
     /// # Simple rollback
-    /// ccpm upgrade --rollback
+    /// agpm upgrade --rollback
     ///
     /// # Check if backup exists first
-    /// ls ~/.local/bin/ccpm.backup  # Unix example
-    /// ccpm upgrade --rollback
+    /// ls ~/.local/bin/agpm.backup  # Unix example
+    /// agpm upgrade --rollback
     /// ```
     ///
     /// # Post-Rollback
@@ -281,7 +281,7 @@ pub struct UpgradeArgs {
     /// Skip creating a backup before upgrade.
     ///
     /// Disables the automatic backup creation that normally occurs before
-    /// upgrading the CCPM binary. This removes the safety net of being able
+    /// upgrading the AGPM binary. This removes the safety net of being able
     /// to rollback if the upgrade fails or the new version has issues.
     ///
     /// # ⚠️ WARNING
@@ -304,7 +304,7 @@ pub struct UpgradeArgs {
     ///
     /// Without backups:
     /// - No automatic rollback if upgrade fails
-    /// - Cannot use `ccpm upgrade --rollback` command
+    /// - Cannot use `agpm upgrade --rollback` command
     /// - Must manually reinstall if new version has issues
     /// - Requires external recovery mechanisms
     ///
@@ -320,13 +320,13 @@ pub struct UpgradeArgs {
     ///
     /// ```bash
     /// # Upgrade without backup (not recommended)
-    /// ccpm upgrade --no-backup
+    /// agpm upgrade --no-backup
     ///
     /// # Force upgrade without backup
-    /// ccpm upgrade 0.4.0 --force --no-backup
+    /// agpm upgrade 0.4.0 --force --no-backup
     ///
     /// # Check-only mode (backups not relevant)
-    /// ccpm upgrade --check
+    /// agpm upgrade --check
     /// ```
     #[arg(long)]
     pub no_backup: bool,
@@ -406,7 +406,7 @@ pub struct UpgradeArgs {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::cli::upgrade::{UpgradeArgs, execute};
+/// use agpm::cli::upgrade::{UpgradeArgs, execute};
 /// use clap::Parser;
 ///
 /// # async fn example() -> anyhow::Result<()> {
@@ -520,7 +520,7 @@ async fn check_for_updates(updater: &SelfUpdater, version_checker: &VersionCheck
                 )
                 .green()
             );
-            println!("Run `ccpm upgrade` to install the latest version");
+            println!("Run `agpm upgrade` to install the latest version");
         }
         Ok(None) => {
             println!(

--- a/src/cli/validate.rs
+++ b/src/cli/validate.rs
@@ -231,7 +231,7 @@ pub struct ValidateCommand {
 /// // For automation/CI
 /// let format = OutputFormat::Json;
 /// ```
-#[derive(Clone, Debug, PartialEq, clap::ValueEnum)]
+#[derive(Clone, Debug, PartialEq, Eq, clap::ValueEnum)]
 pub enum OutputFormat {
     /// Human-readable text output with colors and formatting.
     ///
@@ -574,11 +574,11 @@ impl ValidateCommand {
                         validation_results.errors = errors;
                         validation_results.warnings = warnings;
                         println!("{}", serde_json::to_string_pretty(&validation_results)?);
-                        return Err(anyhow::anyhow!("Source not accessible: {}", e));
+                        return Err(anyhow::anyhow!("Source not accessible: {e}"));
                     } else if !self.quiet {
                         println!("{} {}", "✗".red(), error_msg);
                     }
-                    return Err(anyhow::anyhow!("Source not accessible: {}", e));
+                    return Err(anyhow::anyhow!("Source not accessible: {e}"));
                 }
             };
 
@@ -600,11 +600,11 @@ impl ValidateCommand {
                         validation_results.errors = errors;
                         validation_results.warnings = warnings;
                         println!("{}", serde_json::to_string_pretty(&validation_results)?);
-                        return Err(anyhow::anyhow!("Source not accessible: {}", e));
+                        return Err(anyhow::anyhow!("Source not accessible: {e}"));
                     } else if !self.quiet {
                         println!("{} {}", "✗".red(), error_msg);
                     }
-                    return Err(anyhow::anyhow!("Source not accessible: {}", e));
+                    return Err(anyhow::anyhow!("Source not accessible: {e}"));
                 }
             }
         }
@@ -738,11 +738,11 @@ impl ValidateCommand {
                             validation_results.errors = errors;
                             validation_results.warnings = warnings;
                             println!("{}", serde_json::to_string_pretty(&validation_results)?);
-                            return Err(anyhow::anyhow!("Invalid lockfile syntax: {}", e));
+                            return Err(anyhow::anyhow!("Invalid lockfile syntax: {e}"));
                         } else if !self.quiet {
                             println!("{} {}", "✗".red(), error_msg);
                         }
-                        return Err(anyhow::anyhow!("Invalid lockfile syntax: {}", e));
+                        return Err(anyhow::anyhow!("Invalid lockfile syntax: {e}"));
                     }
                 }
             } else {

--- a/src/cli/validate.rs
+++ b/src/cli/validate.rs
@@ -1,13 +1,13 @@
-//! Validate CCPM project configuration and dependencies.
+//! Validate AGPM project configuration and dependencies.
 //!
 //! This module provides the `validate` command which performs comprehensive
-//! validation of a CCPM project's manifest file, dependencies, sources, and
+//! validation of a AGPM project's manifest file, dependencies, sources, and
 //! overall configuration. The command can check various aspects of the project
 //! setup and report issues or warnings.
 //!
 //! # Features
 //!
-//! - **Manifest Validation**: Checks `ccpm.toml` syntax and structure
+//! - **Manifest Validation**: Checks `agpm.toml` syntax and structure
 //! - **Dependency Resolution**: Verifies all dependencies can be resolved
 //! - **Source Accessibility**: Tests if source repositories are reachable
 //! - **Path Validation**: Checks if local file dependencies exist
@@ -19,27 +19,27 @@
 //!
 //! Basic validation:
 //! ```bash
-//! ccpm validate
+//! agpm validate
 //! ```
 //!
 //! Comprehensive validation with all checks:
 //! ```bash
-//! ccpm validate --resolve --sources --paths --check-lock
+//! agpm validate --resolve --sources --paths --check-lock
 //! ```
 //!
 //! JSON output for automation:
 //! ```bash
-//! ccpm validate --format json
+//! agpm validate --format json
 //! ```
 //!
 //! Strict mode for CI:
 //! ```bash
-//! ccpm validate --strict --quiet
+//! agpm validate --strict --quiet
 //! ```
 //!
 //! Validate specific manifest file:
 //! ```bash
-//! ccpm validate ./projects/my-project/ccpm.toml
+//! agpm validate ./projects/my-project/agpm.toml
 //! ```
 //!
 //! # Validation Levels
@@ -59,7 +59,7 @@
 //!
 //! ## Text Format (Default)
 //! ```text
-//! ✓ Valid ccpm.toml
+//! ✓ Valid agpm.toml
 //! ✓ Dependencies resolvable
 //! ⚠ Warning: No dependencies defined
 //! ```
@@ -94,9 +94,9 @@ use crate::cache::Cache;
 use crate::manifest::{Manifest, find_manifest_with_optional};
 use crate::resolver::DependencyResolver;
 
-/// Command to validate CCPM project configuration and dependencies.
+/// Command to validate AGPM project configuration and dependencies.
 ///
-/// This command performs comprehensive validation of a CCPM project, checking
+/// This command performs comprehensive validation of a AGPM project, checking
 /// various aspects from basic manifest syntax to complex dependency resolution.
 /// It supports multiple validation levels and output formats for different use cases.
 ///
@@ -111,7 +111,7 @@ use crate::resolver::DependencyResolver;
 /// # Examples
 ///
 /// ```rust,ignore
-/// use ccpm::cli::validate::{ValidateCommand, OutputFormat};
+/// use agpm::cli::validate::{ValidateCommand, OutputFormat};
 ///
 /// // Basic validation
 /// let cmd = ValidateCommand {
@@ -143,7 +143,7 @@ use crate::resolver::DependencyResolver;
 pub struct ValidateCommand {
     /// Specific manifest file path to validate
     ///
-    /// If not provided, searches for `ccpm.toml` in the current directory
+    /// If not provided, searches for `agpm.toml` in the current directory
     /// and parent directories. When specified, validates the exact file path.
     #[arg(value_name = "FILE")]
     pub file: Option<String>,
@@ -223,7 +223,7 @@ pub struct ValidateCommand {
 /// # Examples
 ///
 /// ```rust,ignore
-/// use ccpm::cli::validate::OutputFormat;
+/// use agpm::cli::validate::OutputFormat;
 ///
 /// // For human consumption
 /// let format = OutputFormat::Text;
@@ -289,7 +289,7 @@ impl ValidateCommand {
     /// # Examples
     ///
     /// ```ignore
-    /// use ccpm::cli::validate::{ValidateCommand, OutputFormat};
+    /// use agpm::cli::validate::{ValidateCommand, OutputFormat};
     ///
     /// let cmd = ValidateCommand {
     ///     file: None,
@@ -310,14 +310,14 @@ impl ValidateCommand {
 
     /// Execute the validate command with an optional manifest path.
     ///
-    /// This method performs validation of the ccpm.toml manifest file and optionally
+    /// This method performs validation of the agpm.toml manifest file and optionally
     /// the associated lockfile. It can validate manifest syntax, source availability,
     /// and dependency resolution consistency.
     ///
     /// # Arguments
     ///
-    /// * `manifest_path` - Optional path to the ccpm.toml file. If None, searches
-    ///   for ccpm.toml in current directory and parent directories. If the command
+    /// * `manifest_path` - Optional path to the agpm.toml file. If None, searches
+    ///   for agpm.toml in current directory and parent directories. If the command
     ///   has a `file` field set, that takes precedence.
     ///
     /// # Returns
@@ -328,7 +328,7 @@ impl ValidateCommand {
     /// # Examples
     ///
     /// ```ignore
-    /// use ccpm::cli::validate::ValidateCommand;
+    /// use agpm::cli::validate::ValidateCommand;
     /// use std::path::PathBuf;
     ///
     /// let cmd = ValidateCommand {
@@ -341,7 +341,7 @@ impl ValidateCommand {
     ///     fix: false,
     /// };
     ///
-    /// cmd.execute_with_manifest_path(Some(PathBuf::from("./ccpm.toml"))).await?;
+    /// cmd.execute_with_manifest_path(Some(PathBuf::from("./agpm.toml"))).await?;
     /// ```
     pub async fn execute_with_manifest_path(self, manifest_path: Option<PathBuf>) -> Result<()> {
         // Find or use specified manifest file
@@ -352,7 +352,7 @@ impl ValidateCommand {
                 Ok(path) => path,
                 Err(e) => {
                     let error_msg =
-                        "No ccpm.toml found in current directory or any parent directory";
+                        "No agpm.toml found in current directory or any parent directory";
 
                     if matches!(self.format, OutputFormat::Json) {
                         let validation_results = ValidationResults {
@@ -435,7 +435,7 @@ impl ValidateCommand {
             }
             Err(e) => {
                 let error_msg = if e.to_string().contains("TOML") {
-                    format!("Syntax error in ccpm.toml: TOML parsing failed - {e}")
+                    format!("Syntax error in agpm.toml: TOML parsing failed - {e}")
                 } else {
                     format!("Invalid manifest structure: {e}")
                 };
@@ -479,7 +479,7 @@ impl ValidateCommand {
         validation_results.manifest_valid = true;
 
         if !self.quiet && matches!(self.format, OutputFormat::Text) {
-            println!("✓ Valid ccpm.toml");
+            println!("✓ Valid agpm.toml");
         }
 
         // Check for empty manifest warnings
@@ -659,7 +659,7 @@ impl ValidateCommand {
         // Check lockfile consistency
         if self.check_lock {
             let project_dir = manifest_path.parent().unwrap();
-            let lockfile_path = project_dir.join("ccpm.lock");
+            let lockfile_path = project_dir.join("agpm.lock");
 
             if lockfile_path.exists() {
                 if self.verbose && !self.quiet {
@@ -725,7 +725,7 @@ impl ValidateCommand {
                                 for (name, type_) in missing {
                                     println!("  - {name} ({type_}))");
                                 }
-                                println!("\nRun 'ccpm install' to update the lockfile");
+                                println!("\nRun 'agpm install' to update the lockfile");
                             }
                         }
                     }
@@ -873,7 +873,7 @@ mod tests {
     #[tokio::test]
     async fn test_validate_no_manifest() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("nonexistent").join("ccpm.toml");
+        let manifest_path = temp.path().join("nonexistent").join("agpm.toml");
 
         let cmd = ValidateCommand {
             file: None,
@@ -894,7 +894,7 @@ mod tests {
     #[tokio::test]
     async fn test_validate_valid_manifest() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create valid manifest
         let mut manifest = crate::manifest::Manifest::new();
@@ -923,7 +923,7 @@ mod tests {
     #[tokio::test]
     async fn test_validate_invalid_manifest() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create invalid manifest (dependency without source)
         let mut manifest = crate::manifest::Manifest::new();
@@ -966,7 +966,7 @@ mod tests {
     #[tokio::test]
     async fn test_validate_json_format() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create valid manifest
         let mut manifest = crate::manifest::Manifest::new();
@@ -995,7 +995,7 @@ mod tests {
     #[tokio::test]
     async fn test_validate_with_resolve() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest with a source dependency that needs resolving
         let mut manifest = crate::manifest::Manifest::new();
@@ -1044,7 +1044,7 @@ mod tests {
     #[tokio::test]
     async fn test_validate_check_lock_consistent() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create a simple manifest without dependencies
         let manifest = crate::manifest::Manifest::new();
@@ -1052,7 +1052,7 @@ mod tests {
 
         // Create an empty lockfile (consistent with no dependencies)
         let lockfile = crate::lockfile::LockFile::new();
-        lockfile.save(&temp.path().join("ccpm.lock")).unwrap();
+        lockfile.save(&temp.path().join("agpm.lock")).unwrap();
 
         let cmd = ValidateCommand {
             file: None,
@@ -1074,7 +1074,7 @@ mod tests {
     #[tokio::test]
     async fn test_validate_check_lock_with_extra_entries() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create empty manifest
         let manifest = crate::manifest::Manifest::new();
@@ -1094,7 +1094,7 @@ mod tests {
             dependencies: vec![],
             resource_type: crate::core::ResourceType::Agent,
         });
-        lockfile.save(&temp.path().join("ccpm.lock")).unwrap();
+        lockfile.save(&temp.path().join("agpm.lock")).unwrap();
 
         let cmd = ValidateCommand {
             file: None,
@@ -1116,7 +1116,7 @@ mod tests {
     #[tokio::test]
     async fn test_validate_strict_mode() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest with warning (empty sources)
         let manifest = crate::manifest::Manifest::new();
@@ -1142,7 +1142,7 @@ mod tests {
     #[tokio::test]
     async fn test_validate_verbose_mode() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create valid manifest
         let mut manifest = crate::manifest::Manifest::new();
@@ -1171,7 +1171,7 @@ mod tests {
     #[tokio::test]
     async fn test_validate_check_paths_local() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create a local file to reference
         std::fs::create_dir_all(temp.path().join("local")).unwrap();
@@ -1250,7 +1250,7 @@ mod tests {
     #[tokio::test]
     async fn test_validate_json_error_format() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create invalid manifest
         let mut manifest = crate::manifest::Manifest::new();
@@ -1293,7 +1293,7 @@ mod tests {
     #[tokio::test]
     async fn test_validate_paths_check() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest with local dependency
         let mut manifest = crate::manifest::Manifest::new();
@@ -1343,7 +1343,7 @@ mod tests {
     #[tokio::test]
     async fn test_validate_check_lock() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest
         let mut manifest = crate::manifest::Manifest::new();
@@ -1392,7 +1392,7 @@ mod tests {
             scripts: vec![],
             hooks: vec![],
         };
-        lockfile.save(&temp.path().join("ccpm.lock")).unwrap();
+        lockfile.save(&temp.path().join("agpm.lock")).unwrap();
 
         let cmd = ValidateCommand {
             file: None,
@@ -1413,7 +1413,7 @@ mod tests {
     #[tokio::test]
     async fn test_validate_verbose_output() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         let manifest = crate::manifest::Manifest::new();
         manifest.save(&manifest_path).unwrap();
@@ -1437,7 +1437,7 @@ mod tests {
     #[tokio::test]
     async fn test_validate_strict_mode_with_warnings() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest that will have warnings
         let manifest = crate::manifest::Manifest::new();
@@ -1485,7 +1485,7 @@ mod tests {
     #[tokio::test]
     async fn test_validate_quiet_mode() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create valid manifest
         let manifest = crate::manifest::Manifest::new();
@@ -1510,7 +1510,7 @@ mod tests {
     #[tokio::test]
     async fn test_validate_json_output_success() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create valid manifest with dependencies
         let mut manifest = crate::manifest::Manifest::new();
@@ -1552,7 +1552,7 @@ mod tests {
     #[tokio::test]
     async fn test_validate_check_sources() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create a local git repository to use as a mock source
         let source_dir = temp.path().join("test-source");
@@ -1595,7 +1595,7 @@ mod tests {
     #[tokio::test]
     async fn test_validate_check_paths() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest with local dependency
         let mut manifest = crate::manifest::Manifest::new();
@@ -1752,7 +1752,7 @@ mod tests {
     #[tokio::test]
     async fn test_validate_manifest_toml_syntax_error() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create invalid TOML file
         std::fs::write(&manifest_path, "invalid toml syntax [[[").unwrap();
@@ -1777,7 +1777,7 @@ mod tests {
     #[tokio::test]
     async fn test_validate_manifest_toml_syntax_error_json() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create invalid TOML file
         std::fs::write(&manifest_path, "invalid toml syntax [[[").unwrap();
@@ -1802,7 +1802,7 @@ mod tests {
     #[tokio::test]
     async fn test_validate_manifest_structure_error() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest with invalid structure
         let mut manifest = crate::manifest::Manifest::new();
@@ -1846,7 +1846,7 @@ mod tests {
     #[tokio::test]
     async fn test_validate_manifest_version_conflict() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create a test manifest file that would trigger version conflict detection
         std::fs::write(
@@ -1884,7 +1884,7 @@ another-agent = { source = "test", path = "agent.md", version = "v2.0.0" }
     #[tokio::test]
     async fn test_validate_with_outdated_version_warnings() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest with v0.x versions (potentially outdated)
         let mut manifest = crate::manifest::Manifest::new();
@@ -1931,7 +1931,7 @@ another-agent = { source = "test", path = "agent.md", version = "v2.0.0" }
     #[tokio::test]
     async fn test_validate_resolve_with_error_json_output() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest with dependency that will fail to resolve
         let mut manifest = crate::manifest::Manifest::new();
@@ -1980,7 +1980,7 @@ another-agent = { source = "test", path = "agent.md", version = "v2.0.0" }
     #[tokio::test]
     async fn test_validate_resolve_dependency_not_found_error() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest with dependencies that will fail resolution
         let mut manifest = crate::manifest::Manifest::new();
@@ -2046,7 +2046,7 @@ another-agent = { source = "test", path = "agent.md", version = "v2.0.0" }
     #[tokio::test]
     async fn test_validate_sources_accessibility_error() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest with sources that will fail accessibility check
         // Use file:// URLs pointing to non-existent local paths
@@ -2088,7 +2088,7 @@ another-agent = { source = "test", path = "agent.md", version = "v2.0.0" }
     #[tokio::test]
     async fn test_validate_sources_accessibility_error_json() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest with sources that will fail accessibility check
         // Use file:// URLs pointing to non-existent local paths
@@ -2130,7 +2130,7 @@ another-agent = { source = "test", path = "agent.md", version = "v2.0.0" }
     #[tokio::test]
     async fn test_validate_check_paths_snippets_and_commands() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest with local dependencies for snippets and commands (not just agents)
         let mut manifest = crate::manifest::Manifest::new();
@@ -2201,7 +2201,7 @@ another-agent = { source = "test", path = "agent.md", version = "v2.0.0" }
     #[tokio::test]
     async fn test_validate_check_paths_missing_snippets_json() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest with missing local snippet
         let mut manifest = crate::manifest::Manifest::new();
@@ -2244,7 +2244,7 @@ another-agent = { source = "test", path = "agent.md", version = "v2.0.0" }
     #[tokio::test]
     async fn test_validate_lockfile_missing_warning() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest but no lockfile
         let manifest = crate::manifest::Manifest::new();
@@ -2270,8 +2270,8 @@ another-agent = { source = "test", path = "agent.md", version = "v2.0.0" }
     #[tokio::test]
     async fn test_validate_lockfile_syntax_error_json() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
-        let lockfile_path = temp.path().join("ccpm.lock");
+        let manifest_path = temp.path().join("agpm.toml");
+        let lockfile_path = temp.path().join("agpm.lock");
 
         // Create valid manifest
         let manifest = crate::manifest::Manifest::new();
@@ -2300,8 +2300,8 @@ another-agent = { source = "test", path = "agent.md", version = "v2.0.0" }
     #[tokio::test]
     async fn test_validate_lockfile_missing_dependencies() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
-        let lockfile_path = temp.path().join("ccpm.lock");
+        let manifest_path = temp.path().join("agpm.toml");
+        let lockfile_path = temp.path().join("agpm.lock");
 
         // Create manifest with dependencies
         let mut manifest = crate::manifest::Manifest::new();
@@ -2341,8 +2341,8 @@ another-agent = { source = "test", path = "agent.md", version = "v2.0.0" }
     #[tokio::test]
     async fn test_validate_lockfile_extra_entries_error() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
-        let lockfile_path = temp.path().join("ccpm.lock");
+        let manifest_path = temp.path().join("agpm.toml");
+        let lockfile_path = temp.path().join("agpm.lock");
 
         // Create empty manifest
         let manifest = crate::manifest::Manifest::new();
@@ -2384,7 +2384,7 @@ another-agent = { source = "test", path = "agent.md", version = "v2.0.0" }
     #[tokio::test]
     async fn test_validate_strict_mode_with_json_output() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest that will generate warnings
         let manifest = crate::manifest::Manifest::new(); // Empty manifest generates "no dependencies" warning
@@ -2410,7 +2410,7 @@ another-agent = { source = "test", path = "agent.md", version = "v2.0.0" }
     #[tokio::test]
     async fn test_validate_strict_mode_text_output() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest that will generate warnings
         let manifest = crate::manifest::Manifest::new();
@@ -2436,7 +2436,7 @@ another-agent = { source = "test", path = "agent.md", version = "v2.0.0" }
     #[tokio::test]
     async fn test_validate_final_success_with_warnings() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest that will have warnings but no errors
         let manifest = crate::manifest::Manifest::new();
@@ -2462,7 +2462,7 @@ another-agent = { source = "test", path = "agent.md", version = "v2.0.0" }
     #[tokio::test]
     async fn test_validate_verbose_mode_with_summary() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create manifest with some content for summary
         let mut manifest = crate::manifest::Manifest::new();
@@ -2502,8 +2502,8 @@ another-agent = { source = "test", path = "agent.md", version = "v2.0.0" }
     #[tokio::test]
     async fn test_validate_all_checks_enabled() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
-        let lockfile_path = temp.path().join("ccpm.lock");
+        let manifest_path = temp.path().join("agpm.toml");
+        let lockfile_path = temp.path().join("agpm.lock");
 
         // Create a manifest with dependencies
         let mut manifest = Manifest::new();
@@ -2561,7 +2561,7 @@ another-agent = { source = "test", path = "agent.md", version = "v2.0.0" }
     #[tokio::test]
     async fn test_validate_sources_check_with_invalid_url() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         let mut manifest = Manifest::new();
         manifest
@@ -2637,7 +2637,7 @@ another-agent = { source = "test", path = "agent.md", version = "v2.0.0" }
     #[tokio::test]
     async fn test_json_output_format() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         let manifest = Manifest::new();
         manifest.save(&manifest_path).unwrap();
@@ -2661,7 +2661,7 @@ another-agent = { source = "test", path = "agent.md", version = "v2.0.0" }
     #[tokio::test]
     async fn test_validation_with_verbose_mode() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         let manifest = Manifest::new();
         manifest.save(&manifest_path).unwrap();
@@ -2685,7 +2685,7 @@ another-agent = { source = "test", path = "agent.md", version = "v2.0.0" }
     #[tokio::test]
     async fn test_validation_with_quiet_mode() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         let manifest = Manifest::new();
         manifest.save(&manifest_path).unwrap();
@@ -2709,7 +2709,7 @@ another-agent = { source = "test", path = "agent.md", version = "v2.0.0" }
     #[tokio::test]
     async fn test_validation_with_strict_mode_and_warnings() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create empty manifest to trigger warning
         let manifest = Manifest::new();
@@ -2734,7 +2734,7 @@ another-agent = { source = "test", path = "agent.md", version = "v2.0.0" }
     #[tokio::test]
     async fn test_validation_with_local_paths_check() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         let mut manifest = Manifest::new();
         manifest.agents.insert(
@@ -2762,7 +2762,7 @@ another-agent = { source = "test", path = "agent.md", version = "v2.0.0" }
     #[tokio::test]
     async fn test_validation_with_existing_local_paths() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
         let local_file = temp.path().join("agent.md");
 
         // Create the local file
@@ -2794,7 +2794,7 @@ another-agent = { source = "test", path = "agent.md", version = "v2.0.0" }
     #[tokio::test]
     async fn test_validation_with_lockfile_consistency_check_no_lockfile() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         let mut manifest = Manifest::new();
         manifest.agents.insert(
@@ -2822,8 +2822,8 @@ another-agent = { source = "test", path = "agent.md", version = "v2.0.0" }
     #[tokio::test]
     async fn test_validation_with_inconsistent_lockfile() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
-        let lockfile_path = temp.path().join("ccpm.lock");
+        let manifest_path = temp.path().join("agpm.toml");
+        let lockfile_path = temp.path().join("agpm.lock");
 
         // Create manifest with agent
         let mut manifest = Manifest::new();
@@ -2868,8 +2868,8 @@ another-agent = { source = "test", path = "agent.md", version = "v2.0.0" }
     #[tokio::test]
     async fn test_validation_with_invalid_lockfile_syntax() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
-        let lockfile_path = temp.path().join("ccpm.lock");
+        let manifest_path = temp.path().join("agpm.toml");
+        let lockfile_path = temp.path().join("agpm.lock");
 
         let manifest = Manifest::new();
         manifest.save(&manifest_path).unwrap();
@@ -2896,7 +2896,7 @@ another-agent = { source = "test", path = "agent.md", version = "v2.0.0" }
     #[tokio::test]
     async fn test_validation_with_outdated_version_warning() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         let mut manifest = Manifest::new();
         // Add the source that's referenced
@@ -2940,7 +2940,7 @@ another-agent = { source = "test", path = "agent.md", version = "v2.0.0" }
     #[tokio::test]
     async fn test_validation_json_output_with_errors() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Write invalid TOML
         std::fs::write(&manifest_path, "invalid toml [[[ syntax").unwrap();
@@ -3006,8 +3006,8 @@ another-agent = { source = "test", path = "agent.md", version = "v2.0.0" }
     #[tokio::test]
     async fn test_validation_with_missing_lockfile_dependencies() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
-        let lockfile_path = temp.path().join("ccpm.lock");
+        let manifest_path = temp.path().join("agpm.toml");
+        let lockfile_path = temp.path().join("agpm.lock");
 
         // Create manifest with multiple dependencies
         let mut manifest = Manifest::new();
@@ -3127,7 +3127,7 @@ another-agent = { source = "test", path = "agent.md", version = "v2.0.0" }
     #[tokio::test]
     async fn test_validation_with_verbose_and_text_format() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         let mut manifest = Manifest::new();
         manifest.sources.insert(

--- a/src/config/agent.rs
+++ b/src/config/agent.rs
@@ -1,13 +1,13 @@
 //! Agent and snippet configuration structures.
 //!
-//! This module defines the configuration structures for CCPM resources (agents and snippets).
+//! This module defines the configuration structures for AGPM resources (agents and snippets).
 //! These structures can be used standalone or embedded as frontmatter in Markdown files.
 //! The configuration system supports rich metadata, dependency management, and platform-specific
 //! requirements.
 //!
 //! # Resource Types
 //!
-//! CCPM supports two main types of resources:
+//! AGPM supports two main types of resources:
 //!
 //! ## Agents
 //!
@@ -38,14 +38,14 @@
 //! [metadata]
 //! name = "rust-expert"
 //! description = "Expert Rust development agent"
-//! author = "CCPM Community"
+//! author = "AGPM Community"
 //! license = "MIT"
-//! homepage = "https://github.com/ccpm-community/rust-expert"
+//! homepage = "https://github.com/agpm-community/rust-expert"
 //! keywords = ["rust", "programming", "expert", "development"]
 //! categories = ["development", "programming-languages"]
 //!
 //! [requirements]
-//! ccpm_version = ">=0.1.0"
+//! agpm_version = ">=0.1.0"
 //! claude_version = "latest"
 //! platforms = ["windows", "macos", "linux"]
 //!
@@ -74,7 +74,7 @@
 //! keywords = ["python", "expert", "development"]
 //!
 //! [requirements]
-//! ccpm_version = ">=0.1.0"
+//! agpm_version = ">=0.1.0"
 //! +++
 //!
 //! # Python Expert Agent
@@ -154,7 +154,7 @@
 //! ## Loading Agent Configuration
 //!
 //! ```rust,no_run
-//! use ccpm::config::AgentManifest;
+//! use agpm::config::AgentManifest;
 //! use std::path::Path;
 //!
 //! # fn example() -> anyhow::Result<()> {
@@ -174,7 +174,7 @@
 //! ## Creating Default Configuration
 //!
 //! ```rust,ignore
-//! use ccpm::config::create_agent_manifest;
+//! use agpm::config::create_agent_manifest;
 //!
 //! let manifest = create_agent_manifest(
 //!     "my-agent".to_string(),
@@ -192,7 +192,7 @@ use std::path::Path;
 
 /// Agent configuration manifest.
 ///
-/// Represents the complete configuration for a CCPM agent, including metadata,
+/// Represents the complete configuration for a AGPM agent, including metadata,
 /// requirements, and custom configuration. This structure can be loaded from
 /// standalone TOML files or extracted from Markdown frontmatter.
 ///
@@ -207,7 +207,7 @@ use std::path::Path;
 /// ## Minimal Agent
 ///
 /// ```rust,no_run
-/// use ccpm::config::{AgentManifest, AgentMetadata};
+/// use agpm::config::{AgentManifest, AgentMetadata};
 /// use std::collections::HashMap;
 ///
 /// let manifest = AgentManifest {
@@ -229,7 +229,7 @@ use std::path::Path;
 /// ## Loading from File
 ///
 /// ```rust,no_run
-/// use ccpm::config::AgentManifest;
+/// use agpm::config::AgentManifest;
 /// use std::path::Path;
 ///
 /// # fn example() -> anyhow::Result<()> {
@@ -286,7 +286,7 @@ impl AgentManifest {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::config::AgentManifest;
+    /// use agpm::config::AgentManifest;
     /// use std::path::Path;
     ///
     /// # fn example() -> anyhow::Result<()> {
@@ -436,9 +436,9 @@ pub enum SnippetContent {
 /// Requirements and dependencies
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Requirements {
-    /// Minimum CCPM version required
+    /// Minimum AGPM version required
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ccpm_version: Option<String>,
+    pub agpm_version: Option<String>,
 
     /// Required Claude version/features
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -603,7 +603,7 @@ mod tests {
     #[test]
     fn test_requirements() {
         let req = Requirements {
-            ccpm_version: Some(">=0.1.0".to_string()),
+            agpm_version: Some(">=0.1.0".to_string()),
             claude_version: Some("latest".to_string()),
             dependencies: vec![Dependency {
                 name: "dep1".to_string(),
@@ -615,7 +615,7 @@ mod tests {
             platforms: Some(vec!["windows".to_string(), "macos".to_string()]),
         };
 
-        assert_eq!(req.ccpm_version, Some(">=0.1.0".to_string()));
+        assert_eq!(req.agpm_version, Some(">=0.1.0".to_string()));
         assert_eq!(req.dependencies.len(), 1);
         assert_eq!(req.platforms.as_ref().unwrap().len(), 2);
     }

--- a/src/config/global.rs
+++ b/src/config/global.rs
@@ -197,7 +197,7 @@ pub struct GlobalConfig {
     pub upgrade: UpgradeConfig,
 }
 
-fn is_default_upgrade_config(config: &UpgradeConfig) -> bool {
+const fn is_default_upgrade_config(config: &UpgradeConfig) -> bool {
     // Skip serializing if it's the default config
     !config.check_on_startup
         && config.check_interval == 86400
@@ -422,7 +422,7 @@ impl GlobalConfig {
     /// - **Windows**: `%LOCALAPPDATA%\agpm\config.toml`
     /// - **Unix/macOS**: `~/.agpm/config.toml`
     ///
-    /// Note: Environment variable overrides are deprecated. Use the load_with_optional()
+    /// Note: Environment variable overrides are deprecated. Use the `load_with_optional()`
     /// method with an explicit path instead for better thread safety.
     ///
     /// # Examples
@@ -798,7 +798,7 @@ impl GlobalConfigManager {
     /// let manager = GlobalConfigManager::with_path(PathBuf::from("/tmp/test.toml"));
     /// ```
     #[must_use]
-    pub fn with_path(path: PathBuf) -> Self {
+    pub const fn with_path(path: PathBuf) -> Self {
         Self { config: None, path }
     }
 

--- a/src/config/global.rs
+++ b/src/config/global.rs
@@ -1,6 +1,6 @@
-//! Global configuration management for CCPM.
+//! Global configuration management for AGPM.
 //!
-//! This module handles the global user configuration file (`~/.ccpm/config.toml`) which stores
+//! This module handles the global user configuration file (`~/.agpm/config.toml`) which stores
 //! user-wide settings including authentication tokens for private repositories. The global
 //! configuration provides a secure way to manage credentials without exposing them in
 //! version-controlled project files.
@@ -18,10 +18,10 @@
 //!
 //! The global configuration file is stored in platform-specific locations:
 //!
-//! - **Unix/macOS**: `~/.ccpm/config.toml`
-//! - **Windows**: `%LOCALAPPDATA%\ccpm\config.toml`
+//! - **Unix/macOS**: `~/.agpm/config.toml`
+//! - **Windows**: `%LOCALAPPDATA%\agpm\config.toml`
 //!
-//! The location can be overridden using the `CCPM_CONFIG_PATH` environment variable.
+//! The location can be overridden using the `AGPM_CONFIG_PATH` environment variable.
 //!
 //! # File Format
 //!
@@ -31,13 +31,13 @@
 //! # Global sources with authentication (never commit this file!)
 //! [sources]
 //! # GitHub with personal access token
-//! private = "https://oauth2:ghp_xxxxxxxxxxxx@github.com/company/private-ccpm.git"
+//! private = "https://oauth2:ghp_xxxxxxxxxxxx@github.com/company/private-agpm.git"
 //!
 //! # GitLab with deploy token
 //! enterprise = "https://gitlab-ci-token:token123@gitlab.company.com/ai/resources.git"
 //!
 //! # SSH-based authentication
-//! internal = "git@internal.company.com:team/ccpm-resources.git"
+//! internal = "git@internal.company.com:team/agpm-resources.git"
 //!
 //! # Basic authentication (not recommended)
 //! legacy = "https://username:password@old-server.com/repo.git"
@@ -69,12 +69,12 @@
 //!
 //! # Source Resolution Priority
 //!
-//! When resolving sources, CCPM follows this priority order:
+//! When resolving sources, AGPM follows this priority order:
 //!
-//! 1. **Global sources** from `~/.ccpm/config.toml` (loaded first)
-//! 2. **Project sources** from `ccpm.toml` (can override global sources)
+//! 1. **Global sources** from `~/.agpm/config.toml` (loaded first)
+//! 2. **Project sources** from `agpm.toml` (can override global sources)
 //!
-//! This allows teams to share public sources in `ccpm.toml` while keeping
+//! This allows teams to share public sources in `agpm.toml` while keeping
 //! authentication tokens private in individual global configurations.
 //!
 //! # Examples
@@ -82,7 +82,7 @@
 //! ## Basic Usage
 //!
 //! ```rust,no_run
-//! use ccpm::config::GlobalConfig;
+//! use agpm::config::GlobalConfig;
 //!
 //! # async fn example() -> anyhow::Result<()> {
 //! // Load existing configuration or create default
@@ -103,7 +103,7 @@
 //! ## Using Configuration Manager
 //!
 //! ```rust,no_run
-//! use ccpm::config::GlobalConfigManager;
+//! use agpm::config::GlobalConfigManager;
 //!
 //! # async fn example() -> anyhow::Result<()> {
 //! let mut manager = GlobalConfigManager::new()?;
@@ -129,9 +129,9 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tokio::fs;
 
-/// Global configuration structure for CCPM.
+/// Global configuration structure for AGPM.
 ///
-/// This structure represents the global user configuration file stored at `~/.ccpm/config.toml`.
+/// This structure represents the global user configuration file stored at `~/.agpm/config.toml`.
 /// It contains user-wide settings including authentication credentials for private Git repositories.
 ///
 /// # Security Considerations
@@ -153,7 +153,7 @@ use tokio::fs;
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::config::GlobalConfig;
+/// use agpm::config::GlobalConfig;
 /// use std::collections::HashMap;
 ///
 /// // Create new configuration
@@ -162,7 +162,7 @@ use tokio::fs;
 /// // Add authenticated source
 /// config.add_source(
 ///     "company".to_string(),
-///     "https://oauth2:token@github.com/company/ccpm.git".to_string()
+///     "https://oauth2:token@github.com/company/agpm.git".to_string()
 /// );
 ///
 /// assert!(config.has_source("company"));
@@ -213,14 +213,14 @@ impl GlobalConfig {
     ///
     /// # Default Locations
     ///
-    /// - **Unix/macOS**: `~/.ccpm/config.toml`
-    /// - **Windows**: `%LOCALAPPDATA%\ccpm\config.toml`
-    /// - **Override**: Set `CCPM_CONFIG_PATH` environment variable
+    /// - **Unix/macOS**: `~/.agpm/config.toml`
+    /// - **Windows**: `%LOCALAPPDATA%\agpm\config.toml`
+    /// - **Override**: Set `AGPM_CONFIG_PATH` environment variable
     ///
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::config::GlobalConfig;
+    /// use agpm::config::GlobalConfig;
     ///
     /// # async fn example() -> anyhow::Result<()> {
     /// let config = GlobalConfig::load().await?;
@@ -247,7 +247,7 @@ impl GlobalConfig {
     /// Load global configuration from an optional path.
     ///
     /// If a path is provided, loads from that path. Otherwise, loads from the
-    /// default location (`~/.ccpm/config.toml` or platform equivalent).
+    /// default location (`~/.agpm/config.toml` or platform equivalent).
     ///
     /// # Parameters
     ///
@@ -265,7 +265,7 @@ impl GlobalConfig {
     /// - The file contains invalid TOML syntax
     pub async fn load_with_optional(path: Option<PathBuf>) -> Result<Self> {
         let path = path.unwrap_or_else(|| {
-            Self::default_path().unwrap_or_else(|_| PathBuf::from("~/.ccpm/config.toml"))
+            Self::default_path().unwrap_or_else(|_| PathBuf::from("~/.agpm/config.toml"))
         });
         if path.exists() {
             Self::load_from(&path).await
@@ -286,7 +286,7 @@ impl GlobalConfig {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::config::GlobalConfig;
+    /// use agpm::config::GlobalConfig;
     /// use std::path::Path;
     ///
     /// # async fn example() -> anyhow::Result<()> {
@@ -324,7 +324,7 @@ impl GlobalConfig {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::config::GlobalConfig;
+    /// use agpm::config::GlobalConfig;
     ///
     /// # async fn example() -> anyhow::Result<()> {
     /// let mut config = GlobalConfig::load().await?;
@@ -361,7 +361,7 @@ impl GlobalConfig {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::config::GlobalConfig;
+    /// use agpm::config::GlobalConfig;
     /// use std::path::Path;
     ///
     /// # async fn example() -> anyhow::Result<()> {
@@ -419,8 +419,8 @@ impl GlobalConfig {
     ///
     /// # Path Resolution
     ///
-    /// - **Windows**: `%LOCALAPPDATA%\ccpm\config.toml`
-    /// - **Unix/macOS**: `~/.ccpm/config.toml`
+    /// - **Windows**: `%LOCALAPPDATA%\agpm\config.toml`
+    /// - **Unix/macOS**: `~/.agpm/config.toml`
     ///
     /// Note: Environment variable overrides are deprecated. Use the load_with_optional()
     /// method with an explicit path instead for better thread safety.
@@ -428,7 +428,7 @@ impl GlobalConfig {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::config::GlobalConfig;
+    /// use agpm::config::GlobalConfig;
     ///
     /// # fn example() -> anyhow::Result<()> {
     /// let path = GlobalConfig::default_path()?;
@@ -446,11 +446,11 @@ impl GlobalConfig {
         let config_dir = if cfg!(target_os = "windows") {
             dirs::data_local_dir()
                 .ok_or_else(|| anyhow::anyhow!("Unable to determine local data directory"))?
-                .join("ccpm")
+                .join("agpm")
         } else {
             dirs::home_dir()
                 .ok_or_else(|| anyhow::anyhow!("Unable to determine home directory"))?
-                .join(".ccpm")
+                .join(".agpm")
         };
 
         Ok(config_dir.join("config.toml"))
@@ -471,7 +471,7 @@ impl GlobalConfig {
     ///
     /// # Parameters
     ///
-    /// - `local_sources`: Sources from project manifest (`ccpm.toml`)
+    /// - `local_sources`: Sources from project manifest (`agpm.toml`)
     ///
     /// # Returns
     ///
@@ -480,7 +480,7 @@ impl GlobalConfig {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::config::GlobalConfig;
+    /// use agpm::config::GlobalConfig;
     /// use std::collections::HashMap;
     ///
     /// let mut global = GlobalConfig::default();
@@ -533,7 +533,7 @@ impl GlobalConfig {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::config::GlobalConfig;
+    /// use agpm::config::GlobalConfig;
     ///
     /// let mut config = GlobalConfig::default();
     ///
@@ -575,7 +575,7 @@ impl GlobalConfig {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::config::GlobalConfig;
+    /// use agpm::config::GlobalConfig;
     ///
     /// let mut config = GlobalConfig::default();
     /// config.add_source("test".to_string(), "https://example.com/repo.git".to_string());
@@ -601,7 +601,7 @@ impl GlobalConfig {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::config::GlobalConfig;
+    /// use agpm::config::GlobalConfig;
     ///
     /// let mut config = GlobalConfig::default();
     /// assert!(!config.has_source("test"));
@@ -630,7 +630,7 @@ impl GlobalConfig {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::config::GlobalConfig;
+    /// use agpm::config::GlobalConfig;
     ///
     /// let mut config = GlobalConfig::default();
     /// config.add_source(
@@ -665,7 +665,7 @@ impl GlobalConfig {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::config::GlobalConfig;
+    /// use agpm::config::GlobalConfig;
     ///
     /// let config = GlobalConfig::init_example();
     /// assert!(config.has_source("private"));
@@ -684,7 +684,7 @@ impl GlobalConfig {
         let mut sources = HashMap::new();
         sources.insert(
             "private".to_string(),
-            "https://oauth2:YOUR_TOKEN@github.com/yourcompany/private-ccpm.git".to_string(),
+            "https://oauth2:YOUR_TOKEN@github.com/yourcompany/private-agpm.git".to_string(),
         );
 
         Self {
@@ -713,7 +713,7 @@ impl GlobalConfig {
 /// ## Basic Usage
 ///
 /// ```rust,no_run
-/// use ccpm::config::GlobalConfigManager;
+/// use agpm::config::GlobalConfigManager;
 ///
 /// # async fn example() -> anyhow::Result<()> {
 /// let mut manager = GlobalConfigManager::new()?;
@@ -731,7 +731,7 @@ impl GlobalConfig {
 /// ## Modifying Configuration
 ///
 /// ```rust,no_run
-/// use ccpm::config::GlobalConfigManager;
+/// use agpm::config::GlobalConfigManager;
 ///
 /// # async fn example() -> anyhow::Result<()> {
 /// let mut manager = GlobalConfigManager::new()?;
@@ -762,7 +762,7 @@ impl GlobalConfigManager {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::config::GlobalConfigManager;
+    /// use agpm::config::GlobalConfigManager;
     ///
     /// # fn example() -> anyhow::Result<()> {
     /// let manager = GlobalConfigManager::new()?;
@@ -792,7 +792,7 @@ impl GlobalConfigManager {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::config::GlobalConfigManager;
+    /// use agpm::config::GlobalConfigManager;
     /// use std::path::PathBuf;
     ///
     /// let manager = GlobalConfigManager::with_path(PathBuf::from("/tmp/test.toml"));
@@ -814,7 +814,7 @@ impl GlobalConfigManager {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::config::GlobalConfigManager;
+    /// use agpm::config::GlobalConfigManager;
     ///
     /// # async fn example() -> anyhow::Result<()> {
     /// let mut manager = GlobalConfigManager::new()?;
@@ -853,7 +853,7 @@ impl GlobalConfigManager {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::config::GlobalConfigManager;
+    /// use agpm::config::GlobalConfigManager;
     ///
     /// # async fn example() -> anyhow::Result<()> {
     /// let mut manager = GlobalConfigManager::new()?;
@@ -892,7 +892,7 @@ impl GlobalConfigManager {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::config::GlobalConfigManager;
+    /// use agpm::config::GlobalConfigManager;
     ///
     /// # async fn example() -> anyhow::Result<()> {
     /// let mut manager = GlobalConfigManager::new()?;
@@ -928,7 +928,7 @@ impl GlobalConfigManager {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::config::GlobalConfigManager;
+    /// use agpm::config::GlobalConfigManager;
     ///
     /// # async fn example() -> anyhow::Result<()> {
     /// let mut manager = GlobalConfigManager::new()?;
@@ -1072,7 +1072,7 @@ mod tests {
         assert!(config.has_source("private"));
         assert_eq!(
             config.get_source("private"),
-            Some(&"https://oauth2:YOUR_TOKEN@github.com/yourcompany/private-ccpm.git".to_string())
+            Some(&"https://oauth2:YOUR_TOKEN@github.com/yourcompany/private-agpm.git".to_string())
         );
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,16 +1,16 @@
-//! Configuration management for CCPM
+//! Configuration management for AGPM
 //!
-//! This module provides comprehensive configuration management for the Claude Code Package Manager (CCPM).
+//! This module provides comprehensive configuration management for the AGent Package Manager (AGPM).
 //! It handles project manifests, global user configuration, and resource metadata with a focus on
 //! security, cross-platform compatibility, and reproducible builds.
 //!
 //! # Architecture Overview
 //!
-//! CCPM uses a multi-layered configuration architecture:
+//! AGPM uses a multi-layered configuration architecture:
 //!
-//! 1. **Global Configuration** (`~/.ccpm/config.toml`) - User-wide settings including authentication
-//! 2. **Project Manifest** (`ccpm.toml`) - Project dependencies and sources
-//! 3. **Lockfile** (`ccpm.lock`) - Resolved versions for reproducible builds
+//! 1. **Global Configuration** (`~/.agpm/config.toml`) - User-wide settings including authentication
+//! 2. **Project Manifest** (`agpm.toml`) - Project dependencies and sources
+//! 3. **Lockfile** (`agpm.lock`) - Resolved versions for reproducible builds
 //! 4. **Resource Metadata** - Agent and snippet configurations embedded in `.md` files
 //!
 //! # Modules
@@ -21,11 +21,11 @@
 //!
 //! # Configuration Files
 //!
-//! ## Global Configuration (`~/.ccpm/config.toml`)
+//! ## Global Configuration (`~/.agpm/config.toml`)
 //!
 //! **Location:**
-//! - Unix/macOS: `~/.ccpm/config.toml`
-//! - Windows: `%LOCALAPPDATA%\ccpm\config.toml`
+//! - Unix/macOS: `~/.agpm/config.toml`
+//! - Windows: `%LOCALAPPDATA%\agpm\config.toml`
 //!
 //! **Purpose:** Store user-wide settings including private repository access tokens.
 //! This file is never committed to version control.
@@ -33,17 +33,17 @@
 //! ```toml
 //! # Global sources with authentication tokens
 //! [sources]
-//! private = "https://oauth2:ghp_xxxxxxxxxxxx@github.com/company/private-ccpm.git"
+//! private = "https://oauth2:ghp_xxxxxxxxxxxx@github.com/company/private-agpm.git"
 //! enterprise = "https://token:abc123@gitlab.company.com/ai/resources.git"
 //! ```
 //!
-//! ## Project Manifest (`ccpm.toml`)
+//! ## Project Manifest (`agpm.toml`)
 //!
 //! **Purpose:** Define project dependencies and public sources. Safe for version control.
 //!
 //! ```toml
 //! [sources]
-//! community = "https://github.com/aig787/ccpm-community.git"
+//! community = "https://github.com/aig787/agpm-community.git"
 //!
 //! [agents]
 //! code-reviewer = { source = "community", path = "agents/code-reviewer.md", version = "v1.2.0" }
@@ -53,7 +53,7 @@
 //! rust-patterns = { source = "community", path = "snippets/rust.md", version = "^2.0" }
 //! ```
 //!
-//! ## Lockfile (`ccpm.lock`)
+//! ## Lockfile (`agpm.lock`)
 //!
 //! **Purpose:** Pin exact versions for reproducible installations. Auto-generated.
 //!
@@ -63,7 +63,7 @@
 //!
 //! [[sources]]
 //! name = "community"
-//! url = "https://github.com/aig787/ccpm-community.git"
+//! url = "https://github.com/aig787/agpm-community.git"
 //! commit = "abc123..."
 //!
 //! [[agents]]
@@ -85,9 +85,9 @@
 //!
 //! ## Configuration Priority
 //!
-//! 1. Environment variables (`CCPM_CONFIG_PATH`, `CCPM_CACHE_DIR`)
-//! 2. Global configuration (`~/.ccpm/config.toml`)
-//! 3. Project manifest (`ccpm.toml`)
+//! 1. Environment variables (`AGPM_CONFIG_PATH`, `AGPM_CACHE_DIR`)
+//! 2. Global configuration (`~/.agpm/config.toml`)
+//! 3. Project manifest (`agpm.toml`)
 //! 4. Default values
 //!
 //! # Resource Metadata
@@ -99,12 +99,12 @@
 //! [metadata]
 //! name = "rust-expert"
 //! description = "Expert Rust development agent"
-//! author = "CCPM Community"
+//! author = "AGPM Community"
 //! license = "MIT"
 //! keywords = ["rust", "programming", "expert"]
 //!
 //! [requirements]
-//! ccpm_version = ">=0.1.0"
+//! agpm_version = ">=0.1.0"
 //! claude_version = "latest"
 //! platforms = ["windows", "macos", "linux"]
 //!
@@ -124,7 +124,7 @@
 //! This module handles cross-platform configuration paths:
 //!
 //! - **Windows**: Uses `%LOCALAPPDATA%` for configuration
-//! - **macOS/Linux**: Uses `$HOME/.ccpm` directory
+//! - **macOS/Linux**: Uses `$HOME/.agpm` directory
 //! - **Path Separators**: Normalized automatically
 //! - **File Permissions**: Handles Windows vs Unix differences
 //!
@@ -133,7 +133,7 @@
 //! ## Loading Global Configuration
 //!
 //! ```rust,no_run
-//! use ccpm::config::{GlobalConfig, GlobalConfigManager};
+//! use agpm::config::{GlobalConfig, GlobalConfigManager};
 //!
 //! # async fn example() -> anyhow::Result<()> {
 //! // Simple load
@@ -158,7 +158,7 @@
 //! ## Parsing Resource Metadata
 //!
 //! ```rust,no_run
-//! use ccpm::config::{parse_config, AgentManifest};
+//! use agpm::config::{parse_config, AgentManifest};
 //! use std::path::Path;
 //!
 //! # fn example() -> anyhow::Result<()> {
@@ -170,7 +170,7 @@
 //!          agent.metadata.author);
 //!
 //! if let Some(requirements) = &agent.requirements {
-//!     println!("Requires CCPM: {:?}", requirements.ccpm_version);
+//!     println!("Requires AGPM: {:?}", requirements.agpm_version);
 //! }
 //! # Ok(())
 //! # }
@@ -179,7 +179,7 @@
 //! ## Source Resolution with Authentication
 //!
 //! ```rust,no_run
-//! use ccpm::config::GlobalConfig;
+//! use agpm::config::GlobalConfig;
 //! use std::collections::HashMap;
 //!
 //! # async fn example() -> anyhow::Result<()> {
@@ -189,7 +189,7 @@
 //! let mut local_sources = HashMap::new();
 //! local_sources.insert(
 //!     "community".to_string(),
-//!     "https://github.com/aig787/ccpm-community.git".to_string()
+//!     "https://github.com/aig787/agpm-community.git".to_string()
 //! );
 //!
 //! // Merge with global sources (may include auth tokens)
@@ -224,17 +224,17 @@ pub type SnippetConfig = SnippetManifest;
 use anyhow::Result;
 use std::path::PathBuf;
 
-/// Get the cache directory for CCPM.
+/// Get the cache directory for AGPM.
 ///
-/// Returns the directory where CCPM stores cached Git repositories and temporary files.
+/// Returns the directory where AGPM stores cached Git repositories and temporary files.
 /// The location follows platform conventions and can be overridden with environment variables.
 ///
 /// # Location Priority
 ///
-/// 1. `CCPM_CACHE_DIR` environment variable (if set)
+/// 1. `AGPM_CACHE_DIR` environment variable (if set)
 /// 2. Platform-specific cache directory:
-///    - Windows: `%LOCALAPPDATA%\ccpm\cache`
-///    - macOS/Linux: `~/.ccpm/cache`
+///    - Windows: `%LOCALAPPDATA%\agpm\cache`
+///    - macOS/Linux: `~/.agpm/cache`
 ///
 /// # Directory Creation
 ///
@@ -243,7 +243,7 @@ use std::path::PathBuf;
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::config::get_cache_dir;
+/// use agpm::config::get_cache_dir;
 ///
 /// # fn example() -> anyhow::Result<()> {
 /// let cache = get_cache_dir()?;
@@ -260,20 +260,20 @@ use std::path::PathBuf;
 /// - Insufficient permissions for directory creation
 pub fn get_cache_dir() -> Result<PathBuf> {
     // Check for environment variable override first (essential for testing)
-    if let Ok(dir) = std::env::var("CCPM_CACHE_DIR") {
+    if let Ok(dir) = std::env::var("AGPM_CACHE_DIR") {
         return Ok(PathBuf::from(dir));
     }
 
-    // Use consistent directory structure with rest of CCPM
+    // Use consistent directory structure with rest of AGPM
     let cache_dir = if cfg!(target_os = "windows") {
         dirs::data_local_dir()
             .ok_or_else(|| anyhow::anyhow!("Unable to determine local data directory"))?
-            .join("ccpm")
+            .join("agpm")
             .join("cache")
     } else {
         dirs::home_dir()
             .ok_or_else(|| anyhow::anyhow!("Unable to determine home directory"))?
-            .join(".ccpm")
+            .join(".agpm")
             .join("cache")
     };
 
@@ -292,6 +292,6 @@ mod tests {
     fn test_get_cache_dir() {
         // Test that we get a valid cache dir
         let dir = get_cache_dir().unwrap();
-        assert!(dir.to_string_lossy().contains("ccpm"));
+        assert!(dir.to_string_lossy().contains("agpm"));
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,6 +1,6 @@
 //! Configuration management for AGPM
 //!
-//! This module provides comprehensive configuration management for the AGent Package Manager (AGPM).
+//! This module provides comprehensive configuration management for the `AGent` Package Manager (AGPM).
 //! It handles project manifests, global user configuration, and resource metadata with a focus on
 //! security, cross-platform compatibility, and reproducible builds.
 //!

--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -24,7 +24,7 @@
 //! ## Direct Parsing
 //!
 //! ```rust,no_run
-//! use ccpm::config::parse_config;
+//! use agpm::config::parse_config;
 //! use serde::Deserialize;
 //! use std::path::Path;
 //!
@@ -44,7 +44,7 @@
 //! ## With Complex Types
 //!
 //! ```rust,no_run
-//! use ccpm::config::{parse_config, AgentManifest, SnippetManifest};
+//! use agpm::config::{parse_config, AgentManifest, SnippetManifest};
 //! use std::path::Path;
 //!
 //! # fn example() -> anyhow::Result<()> {
@@ -74,7 +74,7 @@
 //!
 //! # Integration
 //!
-//! This parser is used throughout CCPM for:
+//! This parser is used throughout AGPM for:
 //!
 //! - Agent manifest loading ([`AgentManifest::load`])
 //! - Snippet manifest loading ([`SnippetManifest::load`])
@@ -110,7 +110,7 @@ use std::path::Path;
 /// ## Basic Usage
 ///
 /// ```rust,no_run
-/// use ccpm::config::parse_config;
+/// use agpm::config::parse_config;
 /// use serde::Deserialize;
 /// use std::path::Path;
 ///
@@ -127,10 +127,10 @@ use std::path::Path;
 /// # }
 /// ```
 ///
-/// ## With CCPM Types
+/// ## With AGPM Types
 ///
 /// ```rust,no_run
-/// use ccpm::config::{parse_config, AgentManifest};
+/// use agpm::config::{parse_config, AgentManifest};
 /// use std::path::Path;
 ///
 /// # fn example() -> anyhow::Result<()> {
@@ -143,7 +143,7 @@ use std::path::Path;
 /// ## Error Handling
 ///
 /// ```rust,no_run
-/// use ccpm::config::parse_config;
+/// use agpm::config::parse_config;
 /// use serde::Deserialize;
 /// use std::path::Path;
 ///

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -566,140 +566,126 @@ pub enum AgpmError {
 impl Clone for AgpmError {
     fn clone(&self) -> Self {
         match self {
-            AgpmError::GitCommandError { operation, stderr } => AgpmError::GitCommandError {
+            Self::GitCommandError { operation, stderr } => Self::GitCommandError {
                 operation: operation.clone(),
                 stderr: stderr.clone(),
             },
-            AgpmError::GitNotFound => AgpmError::GitNotFound,
-            AgpmError::GitRepoInvalid { path } => AgpmError::GitRepoInvalid { path: path.clone() },
-            AgpmError::GitAuthenticationFailed { url } => {
-                AgpmError::GitAuthenticationFailed { url: url.clone() }
+            Self::GitNotFound => Self::GitNotFound,
+            Self::GitRepoInvalid { path } => Self::GitRepoInvalid { path: path.clone() },
+            Self::GitAuthenticationFailed { url } => {
+                Self::GitAuthenticationFailed { url: url.clone() }
             }
-            AgpmError::GitCloneFailed { url, reason } => AgpmError::GitCloneFailed {
+            Self::GitCloneFailed { url, reason } => Self::GitCloneFailed {
                 url: url.clone(),
                 reason: reason.clone(),
             },
-            AgpmError::GitCheckoutFailed { reference, reason } => AgpmError::GitCheckoutFailed {
+            Self::GitCheckoutFailed { reference, reason } => Self::GitCheckoutFailed {
                 reference: reference.clone(),
                 reason: reason.clone(),
             },
-            AgpmError::ConfigError { message } => AgpmError::ConfigError {
+            Self::ConfigError { message } => Self::ConfigError {
                 message: message.clone(),
             },
-            AgpmError::ManifestNotFound => AgpmError::ManifestNotFound,
-            AgpmError::ManifestParseError { file, reason } => AgpmError::ManifestParseError {
+            Self::ManifestNotFound => Self::ManifestNotFound,
+            Self::ManifestParseError { file, reason } => Self::ManifestParseError {
                 file: file.clone(),
                 reason: reason.clone(),
             },
-            AgpmError::ManifestValidationError { reason } => AgpmError::ManifestValidationError {
+            Self::ManifestValidationError { reason } => Self::ManifestValidationError {
                 reason: reason.clone(),
             },
-            AgpmError::LockfileParseError { file, reason } => AgpmError::LockfileParseError {
+            Self::LockfileParseError { file, reason } => Self::LockfileParseError {
                 file: file.clone(),
                 reason: reason.clone(),
             },
-            AgpmError::ResourceNotFound { name } => {
-                AgpmError::ResourceNotFound { name: name.clone() }
-            }
-            AgpmError::ResourceFileNotFound { path, source_name } => {
-                AgpmError::ResourceFileNotFound {
-                    path: path.clone(),
-                    source_name: source_name.clone(),
-                }
-            }
-            AgpmError::SourceNotFound { name } => AgpmError::SourceNotFound { name: name.clone() },
-            AgpmError::SourceUnreachable { name, url } => AgpmError::SourceUnreachable {
+            Self::ResourceNotFound { name } => Self::ResourceNotFound { name: name.clone() },
+            Self::ResourceFileNotFound { path, source_name } => Self::ResourceFileNotFound {
+                path: path.clone(),
+                source_name: source_name.clone(),
+            },
+            Self::SourceNotFound { name } => Self::SourceNotFound { name: name.clone() },
+            Self::SourceUnreachable { name, url } => Self::SourceUnreachable {
                 name: name.clone(),
                 url: url.clone(),
             },
-            AgpmError::InvalidVersionConstraint { constraint } => {
-                AgpmError::InvalidVersionConstraint {
-                    constraint: constraint.clone(),
-                }
-            }
-            AgpmError::VersionNotFound { resource, version } => AgpmError::VersionNotFound {
+            Self::InvalidVersionConstraint { constraint } => Self::InvalidVersionConstraint {
+                constraint: constraint.clone(),
+            },
+            Self::VersionNotFound { resource, version } => Self::VersionNotFound {
                 resource: resource.clone(),
                 version: version.clone(),
             },
-            AgpmError::AlreadyInstalled { name } => {
-                AgpmError::AlreadyInstalled { name: name.clone() }
-            }
-            AgpmError::InvalidResourceType { resource_type } => AgpmError::InvalidResourceType {
+            Self::AlreadyInstalled { name } => Self::AlreadyInstalled { name: name.clone() },
+            Self::InvalidResourceType { resource_type } => Self::InvalidResourceType {
                 resource_type: resource_type.clone(),
             },
-            AgpmError::InvalidResourceStructure { file, reason } => {
-                AgpmError::InvalidResourceStructure {
-                    file: file.clone(),
-                    reason: reason.clone(),
-                }
-            }
-            AgpmError::CircularDependency { chain } => AgpmError::CircularDependency {
+            Self::InvalidResourceStructure { file, reason } => Self::InvalidResourceStructure {
+                file: file.clone(),
+                reason: reason.clone(),
+            },
+            Self::CircularDependency { chain } => Self::CircularDependency {
                 chain: chain.clone(),
             },
-            AgpmError::DependencyResolutionFailed { reason } => {
-                AgpmError::DependencyResolutionFailed {
-                    reason: reason.clone(),
-                }
-            }
-            AgpmError::NetworkError { operation, reason } => AgpmError::NetworkError {
+            Self::DependencyResolutionFailed { reason } => Self::DependencyResolutionFailed {
+                reason: reason.clone(),
+            },
+            Self::NetworkError { operation, reason } => Self::NetworkError {
                 operation: operation.clone(),
                 reason: reason.clone(),
             },
-            AgpmError::FileSystemError { operation, path } => AgpmError::FileSystemError {
+            Self::FileSystemError { operation, path } => Self::FileSystemError {
                 operation: operation.clone(),
                 path: path.clone(),
             },
-            AgpmError::PermissionDenied { operation, path } => AgpmError::PermissionDenied {
+            Self::PermissionDenied { operation, path } => Self::PermissionDenied {
                 operation: operation.clone(),
                 path: path.clone(),
             },
-            AgpmError::DirectoryNotEmpty { path } => {
-                AgpmError::DirectoryNotEmpty { path: path.clone() }
-            }
-            AgpmError::InvalidDependency { name, reason } => AgpmError::InvalidDependency {
+            Self::DirectoryNotEmpty { path } => Self::DirectoryNotEmpty { path: path.clone() },
+            Self::InvalidDependency { name, reason } => Self::InvalidDependency {
                 name: name.clone(),
                 reason: reason.clone(),
             },
-            AgpmError::InvalidResource { name, reason } => AgpmError::InvalidResource {
+            Self::InvalidResource { name, reason } => Self::InvalidResource {
                 name: name.clone(),
                 reason: reason.clone(),
             },
-            AgpmError::DependencyNotMet {
+            Self::DependencyNotMet {
                 name,
                 required,
                 found,
-            } => AgpmError::DependencyNotMet {
+            } => Self::DependencyNotMet {
                 name: name.clone(),
                 required: required.clone(),
                 found: found.clone(),
             },
-            AgpmError::ConfigNotFound { path } => AgpmError::ConfigNotFound { path: path.clone() },
-            AgpmError::ChecksumMismatch {
+            Self::ConfigNotFound { path } => Self::ConfigNotFound { path: path.clone() },
+            Self::ChecksumMismatch {
                 name,
                 expected,
                 actual,
-            } => AgpmError::ChecksumMismatch {
+            } => Self::ChecksumMismatch {
                 name: name.clone(),
                 expected: expected.clone(),
                 actual: actual.clone(),
             },
-            AgpmError::PlatformNotSupported { operation } => AgpmError::PlatformNotSupported {
+            Self::PlatformNotSupported { operation } => Self::PlatformNotSupported {
                 operation: operation.clone(),
             },
             // For errors that don't implement Clone, convert to Other
-            AgpmError::IoError(e) => AgpmError::Other {
+            Self::IoError(e) => Self::Other {
                 message: format!("IO error: {e}"),
             },
-            AgpmError::TomlError(e) => AgpmError::Other {
+            Self::TomlError(e) => Self::Other {
                 message: format!("TOML parsing error: {e}"),
             },
-            AgpmError::TomlSerError(e) => AgpmError::Other {
+            Self::TomlSerError(e) => Self::Other {
                 message: format!("TOML serialization error: {e}"),
             },
-            AgpmError::SemverError(e) => AgpmError::Other {
+            Self::SemverError(e) => Self::Other {
                 message: format!("Semver parsing error: {e}"),
             },
-            AgpmError::Other { message } => AgpmError::Other {
+            Self::Other { message } => Self::Other {
                 message: message.clone(),
             },
         }
@@ -794,7 +780,7 @@ impl ErrorContext {
     /// [`with_suggestion`]: ErrorContext::with_suggestion
     /// [`with_details`]: ErrorContext::with_details
     #[must_use]
-    pub fn new(error: AgpmError) -> Self {
+    pub const fn new(error: AgpmError) -> Self {
         Self {
             error,
             suggestion: None,
@@ -1063,7 +1049,7 @@ pub fn user_friendly_error(error: anyhow::Error) -> ErrorContext {
     let chain: Vec<String> = error
         .chain()
         .skip(1) // Skip the root cause which is already in to_string()
-        .map(|e| e.to_string())
+        .map(std::string::ToString::to_string)
         .collect();
 
     if !chain.is_empty() {

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -1,31 +1,31 @@
-//! Error handling for CCPM
+//! Error handling for AGPM
 //!
 //! This module provides comprehensive error types and user-friendly error reporting for the
-//! CCPM package manager. The error system is designed around two core principles:
+//! AGPM package manager. The error system is designed around two core principles:
 //! 1. **Strongly-typed errors** for precise error handling in code
 //! 2. **User-friendly messages** with actionable suggestions for CLI users
 //!
 //! # Architecture
 //!
 //! The error system consists of two main types:
-//! - [`CcpmError`] - Enumerated error types for all failure cases in CCPM
+//! - [`AgpmError`] - Enumerated error types for all failure cases in AGPM
 //! - [`ErrorContext`] - Wrapper that adds user-friendly messages and suggestions
 //!
 //! # Error Categories
 //!
-//! CCPM errors are organized into several categories:
-//! - **Git Operations**: [`CcpmError::GitNotFound`], [`CcpmError::GitCommandError`], etc.
-//! - **File System**: [`CcpmError::FileSystemError`], [`CcpmError::PermissionDenied`], etc.
-//! - **Configuration**: [`CcpmError::ManifestNotFound`], [`CcpmError::ManifestParseError`], etc.
-//! - **Dependencies**: [`CcpmError::CircularDependency`], [`CcpmError::DependencyNotMet`], etc.
-//! - **Resources**: [`CcpmError::ResourceNotFound`], [`CcpmError::InvalidResource`], etc.
+//! AGPM errors are organized into several categories:
+//! - **Git Operations**: [`AgpmError::GitNotFound`], [`AgpmError::GitCommandError`], etc.
+//! - **File System**: [`AgpmError::FileSystemError`], [`AgpmError::PermissionDenied`], etc.
+//! - **Configuration**: [`AgpmError::ManifestNotFound`], [`AgpmError::ManifestParseError`], etc.
+//! - **Dependencies**: [`AgpmError::CircularDependency`], [`AgpmError::DependencyNotMet`], etc.
+//! - **Resources**: [`AgpmError::ResourceNotFound`], [`AgpmError::InvalidResource`], etc.
 //!
 //! # Error Conversion and Context
 //!
-//! Common standard library errors are automatically converted to CCPM errors:
-//! - [`std::io::Error`] → [`CcpmError::IoError`]
-//! - [`toml::de::Error`] → [`CcpmError::TomlError`]
-//! - [`semver::Error`] → [`CcpmError::SemverError`]
+//! Common standard library errors are automatically converted to AGPM errors:
+//! - [`std::io::Error`] → [`AgpmError::IoError`]
+//! - [`toml::de::Error`] → [`AgpmError::TomlError`]
+//! - [`semver::Error`] → [`AgpmError::SemverError`]
 //!
 //! Use [`user_friendly_error`] to convert any error into a user-friendly format with
 //! contextual suggestions.
@@ -35,11 +35,11 @@
 //! ## Basic Error Handling
 //!
 //! ```rust,no_run
-//! use ccpm::core::{CcpmError, ErrorContext, user_friendly_error};
+//! use agpm::core::{AgpmError, ErrorContext, user_friendly_error};
 //!
-//! fn handle_git_operation() -> Result<(), CcpmError> {
+//! fn handle_git_operation() -> Result<(), AgpmError> {
 //!     // Simulate a git operation failure
-//!     Err(CcpmError::GitNotFound)
+//!     Err(AgpmError::GitNotFound)
 //! }
 //!
 //! match handle_git_operation() {
@@ -54,12 +54,12 @@
 //! ## Creating Error Context Manually
 //!
 //! ```rust,no_run
-//! use ccpm::core::{CcpmError, ErrorContext};
+//! use agpm::core::{AgpmError, ErrorContext};
 //!
-//! let error = CcpmError::ManifestNotFound;
+//! let error = AgpmError::ManifestNotFound;
 //! let context = ErrorContext::new(error)
-//!     .with_suggestion("Create a ccpm.toml file in your project directory")
-//!     .with_details("CCPM searches for ccpm.toml in current and parent directories");
+//!     .with_suggestion("Create a agpm.toml file in your project directory")
+//!     .with_details("AGPM searches for agpm.toml in current and parent directories");
 //!
 //! // Display with colors in terminal
 //! context.display();
@@ -71,7 +71,7 @@
 //! ## Error Recovery Patterns
 //!
 //! ```rust,no_run
-//! use ccpm::core::{CcpmError, user_friendly_error};
+//! use agpm::core::{AgpmError, user_friendly_error};
 //! use anyhow::Context;
 //!
 //! fn install_dependency(name: &str) -> anyhow::Result<()> {
@@ -96,9 +96,9 @@ use colored::Colorize;
 use std::fmt;
 use thiserror::Error;
 
-/// The main error type for CCPM operations
+/// The main error type for AGPM operations
 ///
-/// This enum represents all possible errors that can occur during CCPM operations.
+/// This enum represents all possible errors that can occur during AGPM operations.
 /// Each variant is designed to provide specific context about the failure and enable
 /// appropriate error handling strategies.
 ///
@@ -125,7 +125,7 @@ use thiserror::Error;
 /// - [`IoError`] - Standard I/O errors from [`std::io::Error`]
 ///
 /// ## Configuration and Parsing
-/// - [`ManifestNotFound`] - ccpm.toml file missing
+/// - [`ManifestNotFound`] - agpm.toml file missing
 /// - [`ManifestParseError`] - Invalid TOML syntax in manifest
 /// - [`ManifestValidationError`] - Manifest content validation failed
 /// - [`LockfileParseError`] - Invalid lockfile format
@@ -164,18 +164,18 @@ use thiserror::Error;
 /// ## Pattern Matching on Errors
 ///
 /// ```rust,no_run
-/// use ccpm::core::CcpmError;
+/// use agpm::core::AgpmError;
 ///
-/// fn handle_error(error: CcpmError) {
+/// fn handle_error(error: AgpmError) {
 ///     match error {
-///         CcpmError::GitNotFound => {
-///             eprintln!("Please install git to use CCPM");
+///         AgpmError::GitNotFound => {
+///             eprintln!("Please install git to use AGPM");
 ///             std::process::exit(1);
 ///         }
-///         CcpmError::ManifestNotFound => {
-///             eprintln!("Run 'ccpm init' to create a manifest file");
+///         AgpmError::ManifestNotFound => {
+///             eprintln!("Run 'agpm init' to create a manifest file");
 ///         }
-///         CcpmError::NetworkError { operation, .. } => {
+///         AgpmError::NetworkError { operation, .. } => {
 ///             eprintln!("Network error during {}: check your connection", operation);
 ///         }
 ///         _ => {
@@ -188,61 +188,61 @@ use thiserror::Error;
 /// ## Creating Specific Errors
 ///
 /// ```rust,no_run
-/// use ccpm::core::CcpmError;
+/// use agpm::core::AgpmError;
 ///
 /// // Create a git command error with context
-/// let error = CcpmError::GitCommandError {
+/// let error = AgpmError::GitCommandError {
 ///     operation: "clone".to_string(),
 ///     stderr: "repository not found".to_string(),
 /// };
 ///
 /// // Create a resource not found error
-/// let error = CcpmError::ResourceNotFound {
+/// let error = AgpmError::ResourceNotFound {
 ///     name: "my-agent".to_string(),
 /// };
 ///
 /// // Create a version constraint error
-/// let error = CcpmError::InvalidVersionConstraint {
+/// let error = AgpmError::InvalidVersionConstraint {
 ///     constraint: "~1.x.y".to_string(),
 /// };
 /// ```
 ///
-/// [`GitNotFound`]: CcpmError::GitNotFound
-/// [`GitCommandError`]: CcpmError::GitCommandError
-/// [`GitAuthenticationFailed`]: CcpmError::GitAuthenticationFailed
-/// [`GitCloneFailed`]: CcpmError::GitCloneFailed
-/// [`GitCheckoutFailed`]: CcpmError::GitCheckoutFailed
-/// [`FileSystemError`]: CcpmError::FileSystemError
-/// [`PermissionDenied`]: CcpmError::PermissionDenied
-/// [`DirectoryNotEmpty`]: CcpmError::DirectoryNotEmpty
-/// [`IoError`]: CcpmError::IoError
-/// [`ManifestNotFound`]: CcpmError::ManifestNotFound
-/// [`ManifestParseError`]: CcpmError::ManifestParseError
-/// [`ManifestValidationError`]: CcpmError::ManifestValidationError
-/// [`LockfileParseError`]: CcpmError::LockfileParseError
-/// [`ConfigError`]: CcpmError::ConfigError
-/// [`TomlError`]: CcpmError::TomlError
-/// [`TomlSerError`]: CcpmError::TomlSerError
-/// [`ResourceNotFound`]: CcpmError::ResourceNotFound
-/// [`ResourceFileNotFound`]: CcpmError::ResourceFileNotFound
-/// [`InvalidResourceType`]: CcpmError::InvalidResourceType
-/// [`InvalidResourceStructure`]: CcpmError::InvalidResourceStructure
-/// [`InvalidResource`]: CcpmError::InvalidResource
-/// [`AlreadyInstalled`]: CcpmError::AlreadyInstalled
-/// [`CircularDependency`]: CcpmError::CircularDependency
-/// [`DependencyResolutionFailed`]: CcpmError::DependencyResolutionFailed
-/// [`DependencyNotMet`]: CcpmError::DependencyNotMet
-/// [`InvalidDependency`]: CcpmError::InvalidDependency
-/// [`InvalidVersionConstraint`]: CcpmError::InvalidVersionConstraint
-/// [`VersionNotFound`]: CcpmError::VersionNotFound
-/// [`SemverError`]: CcpmError::SemverError
-/// [`SourceNotFound`]: CcpmError::SourceNotFound
-/// [`SourceUnreachable`]: CcpmError::SourceUnreachable
-/// [`NetworkError`]: CcpmError::NetworkError
-/// [`PlatformNotSupported`]: CcpmError::PlatformNotSupported
-/// [`ChecksumMismatch`]: CcpmError::ChecksumMismatch
+/// [`GitNotFound`]: AgpmError::GitNotFound
+/// [`GitCommandError`]: AgpmError::GitCommandError
+/// [`GitAuthenticationFailed`]: AgpmError::GitAuthenticationFailed
+/// [`GitCloneFailed`]: AgpmError::GitCloneFailed
+/// [`GitCheckoutFailed`]: AgpmError::GitCheckoutFailed
+/// [`FileSystemError`]: AgpmError::FileSystemError
+/// [`PermissionDenied`]: AgpmError::PermissionDenied
+/// [`DirectoryNotEmpty`]: AgpmError::DirectoryNotEmpty
+/// [`IoError`]: AgpmError::IoError
+/// [`ManifestNotFound`]: AgpmError::ManifestNotFound
+/// [`ManifestParseError`]: AgpmError::ManifestParseError
+/// [`ManifestValidationError`]: AgpmError::ManifestValidationError
+/// [`LockfileParseError`]: AgpmError::LockfileParseError
+/// [`ConfigError`]: AgpmError::ConfigError
+/// [`TomlError`]: AgpmError::TomlError
+/// [`TomlSerError`]: AgpmError::TomlSerError
+/// [`ResourceNotFound`]: AgpmError::ResourceNotFound
+/// [`ResourceFileNotFound`]: AgpmError::ResourceFileNotFound
+/// [`InvalidResourceType`]: AgpmError::InvalidResourceType
+/// [`InvalidResourceStructure`]: AgpmError::InvalidResourceStructure
+/// [`InvalidResource`]: AgpmError::InvalidResource
+/// [`AlreadyInstalled`]: AgpmError::AlreadyInstalled
+/// [`CircularDependency`]: AgpmError::CircularDependency
+/// [`DependencyResolutionFailed`]: AgpmError::DependencyResolutionFailed
+/// [`DependencyNotMet`]: AgpmError::DependencyNotMet
+/// [`InvalidDependency`]: AgpmError::InvalidDependency
+/// [`InvalidVersionConstraint`]: AgpmError::InvalidVersionConstraint
+/// [`VersionNotFound`]: AgpmError::VersionNotFound
+/// [`SemverError`]: AgpmError::SemverError
+/// [`SourceNotFound`]: AgpmError::SourceNotFound
+/// [`SourceUnreachable`]: AgpmError::SourceUnreachable
+/// [`NetworkError`]: AgpmError::NetworkError
+/// [`PlatformNotSupported`]: AgpmError::PlatformNotSupported
+/// [`ChecksumMismatch`]: AgpmError::ChecksumMismatch
 #[derive(Error, Debug)]
-pub enum CcpmError {
+pub enum AgpmError {
     /// Git operation failed during execution
     ///
     /// This error occurs when a git command returns a non-zero exit code.
@@ -262,8 +262,8 @@ pub enum CcpmError {
 
     /// Git executable not found in PATH
     ///
-    /// This error occurs when CCPM cannot locate the `git` command in the system PATH.
-    /// CCPM requires git to be installed and available for repository operations.
+    /// This error occurs when AGPM cannot locate the `git` command in the system PATH.
+    /// AGPM requires git to be installed and available for repository operations.
     ///
     /// Common solutions:
     /// - Install git from <https://git-scm.com/>
@@ -323,14 +323,14 @@ pub enum CcpmError {
         message: String,
     },
 
-    /// Manifest file (ccpm.toml) not found
+    /// Manifest file (agpm.toml) not found
     ///
-    /// This error occurs when CCPM cannot locate a ccpm.toml file in the current
+    /// This error occurs when AGPM cannot locate a agpm.toml file in the current
     /// directory or any parent directory up to the filesystem root.
     ///
-    /// CCPM searches for ccpm.toml starting from the current working directory
+    /// AGPM searches for agpm.toml starting from the current working directory
     /// and walking up the directory tree, similar to how git searches for .git.
-    #[error("Manifest file ccpm.toml not found in current directory or any parent directory")]
+    #[error("Manifest file agpm.toml not found in current directory or any parent directory")]
     ManifestNotFound,
 
     /// Manifest parsing error
@@ -563,143 +563,143 @@ pub enum CcpmError {
     },
 }
 
-impl Clone for CcpmError {
+impl Clone for AgpmError {
     fn clone(&self) -> Self {
         match self {
-            CcpmError::GitCommandError { operation, stderr } => CcpmError::GitCommandError {
+            AgpmError::GitCommandError { operation, stderr } => AgpmError::GitCommandError {
                 operation: operation.clone(),
                 stderr: stderr.clone(),
             },
-            CcpmError::GitNotFound => CcpmError::GitNotFound,
-            CcpmError::GitRepoInvalid { path } => CcpmError::GitRepoInvalid { path: path.clone() },
-            CcpmError::GitAuthenticationFailed { url } => {
-                CcpmError::GitAuthenticationFailed { url: url.clone() }
+            AgpmError::GitNotFound => AgpmError::GitNotFound,
+            AgpmError::GitRepoInvalid { path } => AgpmError::GitRepoInvalid { path: path.clone() },
+            AgpmError::GitAuthenticationFailed { url } => {
+                AgpmError::GitAuthenticationFailed { url: url.clone() }
             }
-            CcpmError::GitCloneFailed { url, reason } => CcpmError::GitCloneFailed {
+            AgpmError::GitCloneFailed { url, reason } => AgpmError::GitCloneFailed {
                 url: url.clone(),
                 reason: reason.clone(),
             },
-            CcpmError::GitCheckoutFailed { reference, reason } => CcpmError::GitCheckoutFailed {
+            AgpmError::GitCheckoutFailed { reference, reason } => AgpmError::GitCheckoutFailed {
                 reference: reference.clone(),
                 reason: reason.clone(),
             },
-            CcpmError::ConfigError { message } => CcpmError::ConfigError {
+            AgpmError::ConfigError { message } => AgpmError::ConfigError {
                 message: message.clone(),
             },
-            CcpmError::ManifestNotFound => CcpmError::ManifestNotFound,
-            CcpmError::ManifestParseError { file, reason } => CcpmError::ManifestParseError {
+            AgpmError::ManifestNotFound => AgpmError::ManifestNotFound,
+            AgpmError::ManifestParseError { file, reason } => AgpmError::ManifestParseError {
                 file: file.clone(),
                 reason: reason.clone(),
             },
-            CcpmError::ManifestValidationError { reason } => CcpmError::ManifestValidationError {
+            AgpmError::ManifestValidationError { reason } => AgpmError::ManifestValidationError {
                 reason: reason.clone(),
             },
-            CcpmError::LockfileParseError { file, reason } => CcpmError::LockfileParseError {
+            AgpmError::LockfileParseError { file, reason } => AgpmError::LockfileParseError {
                 file: file.clone(),
                 reason: reason.clone(),
             },
-            CcpmError::ResourceNotFound { name } => {
-                CcpmError::ResourceNotFound { name: name.clone() }
+            AgpmError::ResourceNotFound { name } => {
+                AgpmError::ResourceNotFound { name: name.clone() }
             }
-            CcpmError::ResourceFileNotFound { path, source_name } => {
-                CcpmError::ResourceFileNotFound {
+            AgpmError::ResourceFileNotFound { path, source_name } => {
+                AgpmError::ResourceFileNotFound {
                     path: path.clone(),
                     source_name: source_name.clone(),
                 }
             }
-            CcpmError::SourceNotFound { name } => CcpmError::SourceNotFound { name: name.clone() },
-            CcpmError::SourceUnreachable { name, url } => CcpmError::SourceUnreachable {
+            AgpmError::SourceNotFound { name } => AgpmError::SourceNotFound { name: name.clone() },
+            AgpmError::SourceUnreachable { name, url } => AgpmError::SourceUnreachable {
                 name: name.clone(),
                 url: url.clone(),
             },
-            CcpmError::InvalidVersionConstraint { constraint } => {
-                CcpmError::InvalidVersionConstraint {
+            AgpmError::InvalidVersionConstraint { constraint } => {
+                AgpmError::InvalidVersionConstraint {
                     constraint: constraint.clone(),
                 }
             }
-            CcpmError::VersionNotFound { resource, version } => CcpmError::VersionNotFound {
+            AgpmError::VersionNotFound { resource, version } => AgpmError::VersionNotFound {
                 resource: resource.clone(),
                 version: version.clone(),
             },
-            CcpmError::AlreadyInstalled { name } => {
-                CcpmError::AlreadyInstalled { name: name.clone() }
+            AgpmError::AlreadyInstalled { name } => {
+                AgpmError::AlreadyInstalled { name: name.clone() }
             }
-            CcpmError::InvalidResourceType { resource_type } => CcpmError::InvalidResourceType {
+            AgpmError::InvalidResourceType { resource_type } => AgpmError::InvalidResourceType {
                 resource_type: resource_type.clone(),
             },
-            CcpmError::InvalidResourceStructure { file, reason } => {
-                CcpmError::InvalidResourceStructure {
+            AgpmError::InvalidResourceStructure { file, reason } => {
+                AgpmError::InvalidResourceStructure {
                     file: file.clone(),
                     reason: reason.clone(),
                 }
             }
-            CcpmError::CircularDependency { chain } => CcpmError::CircularDependency {
+            AgpmError::CircularDependency { chain } => AgpmError::CircularDependency {
                 chain: chain.clone(),
             },
-            CcpmError::DependencyResolutionFailed { reason } => {
-                CcpmError::DependencyResolutionFailed {
+            AgpmError::DependencyResolutionFailed { reason } => {
+                AgpmError::DependencyResolutionFailed {
                     reason: reason.clone(),
                 }
             }
-            CcpmError::NetworkError { operation, reason } => CcpmError::NetworkError {
+            AgpmError::NetworkError { operation, reason } => AgpmError::NetworkError {
                 operation: operation.clone(),
                 reason: reason.clone(),
             },
-            CcpmError::FileSystemError { operation, path } => CcpmError::FileSystemError {
+            AgpmError::FileSystemError { operation, path } => AgpmError::FileSystemError {
                 operation: operation.clone(),
                 path: path.clone(),
             },
-            CcpmError::PermissionDenied { operation, path } => CcpmError::PermissionDenied {
+            AgpmError::PermissionDenied { operation, path } => AgpmError::PermissionDenied {
                 operation: operation.clone(),
                 path: path.clone(),
             },
-            CcpmError::DirectoryNotEmpty { path } => {
-                CcpmError::DirectoryNotEmpty { path: path.clone() }
+            AgpmError::DirectoryNotEmpty { path } => {
+                AgpmError::DirectoryNotEmpty { path: path.clone() }
             }
-            CcpmError::InvalidDependency { name, reason } => CcpmError::InvalidDependency {
+            AgpmError::InvalidDependency { name, reason } => AgpmError::InvalidDependency {
                 name: name.clone(),
                 reason: reason.clone(),
             },
-            CcpmError::InvalidResource { name, reason } => CcpmError::InvalidResource {
+            AgpmError::InvalidResource { name, reason } => AgpmError::InvalidResource {
                 name: name.clone(),
                 reason: reason.clone(),
             },
-            CcpmError::DependencyNotMet {
+            AgpmError::DependencyNotMet {
                 name,
                 required,
                 found,
-            } => CcpmError::DependencyNotMet {
+            } => AgpmError::DependencyNotMet {
                 name: name.clone(),
                 required: required.clone(),
                 found: found.clone(),
             },
-            CcpmError::ConfigNotFound { path } => CcpmError::ConfigNotFound { path: path.clone() },
-            CcpmError::ChecksumMismatch {
+            AgpmError::ConfigNotFound { path } => AgpmError::ConfigNotFound { path: path.clone() },
+            AgpmError::ChecksumMismatch {
                 name,
                 expected,
                 actual,
-            } => CcpmError::ChecksumMismatch {
+            } => AgpmError::ChecksumMismatch {
                 name: name.clone(),
                 expected: expected.clone(),
                 actual: actual.clone(),
             },
-            CcpmError::PlatformNotSupported { operation } => CcpmError::PlatformNotSupported {
+            AgpmError::PlatformNotSupported { operation } => AgpmError::PlatformNotSupported {
                 operation: operation.clone(),
             },
             // For errors that don't implement Clone, convert to Other
-            CcpmError::IoError(e) => CcpmError::Other {
+            AgpmError::IoError(e) => AgpmError::Other {
                 message: format!("IO error: {e}"),
             },
-            CcpmError::TomlError(e) => CcpmError::Other {
+            AgpmError::TomlError(e) => AgpmError::Other {
                 message: format!("TOML parsing error: {e}"),
             },
-            CcpmError::TomlSerError(e) => CcpmError::Other {
+            AgpmError::TomlSerError(e) => AgpmError::Other {
                 message: format!("TOML serialization error: {e}"),
             },
-            CcpmError::SemverError(e) => CcpmError::Other {
+            AgpmError::SemverError(e) => AgpmError::Other {
                 message: format!("Semver parsing error: {e}"),
             },
-            CcpmError::Other { message } => CcpmError::Other {
+            AgpmError::Other { message } => AgpmError::Other {
                 message: message.clone(),
             },
         }
@@ -708,9 +708,9 @@ impl Clone for CcpmError {
 
 /// Error context wrapper that provides user-friendly error information
 ///
-/// `ErrorContext` wraps a [`CcpmError`] and adds optional user-friendly messages,
+/// `ErrorContext` wraps a [`AgpmError`] and adds optional user-friendly messages,
 /// suggestions for resolution, and additional details. This is the primary way
-/// CCPM presents errors to CLI users.
+/// AGPM presents errors to CLI users.
 ///
 /// # Design Philosophy
 ///
@@ -732,12 +732,12 @@ impl Clone for CcpmError {
 /// ## Creating Error Context
 ///
 /// ```rust,no_run
-/// use ccpm::core::{CcpmError, ErrorContext};
+/// use agpm::core::{AgpmError, ErrorContext};
 ///
-/// let error = CcpmError::GitNotFound;
+/// let error = AgpmError::GitNotFound;
 /// let context = ErrorContext::new(error)
 ///     .with_suggestion("Install git from https://git-scm.com/")
-///     .with_details("CCPM requires git for repository operations");
+///     .with_details("AGPM requires git for repository operations");
 ///
 /// // Display to terminal with colors
 /// context.display();
@@ -749,11 +749,11 @@ impl Clone for CcpmError {
 /// ## Builder Pattern Usage
 ///
 /// ```rust,no_run
-/// use ccpm::core::{CcpmError, ErrorContext};
+/// use agpm::core::{AgpmError, ErrorContext};
 ///
-/// let context = ErrorContext::new(CcpmError::ManifestNotFound)
-///     .with_suggestion("Create a ccpm.toml file in your project directory")
-///     .with_details("CCPM searches current and parent directories for ccpm.toml");
+/// let context = ErrorContext::new(AgpmError::ManifestNotFound)
+///     .with_suggestion("Create a agpm.toml file in your project directory")
+///     .with_details("AGPM searches current and parent directories for agpm.toml");
 ///
 /// println!("{}", context);
 /// ```
@@ -761,15 +761,15 @@ impl Clone for CcpmError {
 /// ## Quick Suggestion Creation
 ///
 /// ```rust,no_run
-/// use ccpm::core::ErrorContext;
+/// use agpm::core::ErrorContext;
 ///
 /// // Create context with just a suggestion (useful for generic errors)
 /// let context = ErrorContext::suggestion("Try running the command with --verbose");
 /// ```
 #[derive(Debug)]
 pub struct ErrorContext {
-    /// The underlying CCPM error
-    pub error: CcpmError,
+    /// The underlying AGPM error
+    pub error: AgpmError,
     /// Optional suggestion for resolving the error
     pub suggestion: Option<String>,
     /// Optional additional details about the error
@@ -777,7 +777,7 @@ pub struct ErrorContext {
 }
 
 impl ErrorContext {
-    /// Create a new error context from a [`CcpmError`]
+    /// Create a new error context from a [`AgpmError`]
     ///
     /// This creates a basic error context with no additional suggestions or details.
     /// Use the builder methods [`with_suggestion`] and [`with_details`] to add
@@ -786,15 +786,15 @@ impl ErrorContext {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::core::{CcpmError, ErrorContext};
+    /// use agpm::core::{AgpmError, ErrorContext};
     ///
-    /// let context = ErrorContext::new(CcpmError::GitNotFound);
+    /// let context = ErrorContext::new(AgpmError::GitNotFound);
     /// ```
     ///
     /// [`with_suggestion`]: ErrorContext::with_suggestion
     /// [`with_details`]: ErrorContext::with_details
     #[must_use]
-    pub fn new(error: CcpmError) -> Self {
+    pub fn new(error: AgpmError) -> Self {
         Self {
             error,
             suggestion: None,
@@ -810,9 +810,9 @@ impl ErrorContext {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::core::{CcpmError, ErrorContext};
+    /// use agpm::core::{AgpmError, ErrorContext};
     ///
-    /// let context = ErrorContext::new(CcpmError::GitNotFound)
+    /// let context = ErrorContext::new(AgpmError::GitNotFound)
     ///     .with_suggestion("Install git using 'brew install git' or visit https://git-scm.com/");
     /// ```
     pub fn with_suggestion(mut self, suggestion: impl Into<String>) -> Self {
@@ -829,10 +829,10 @@ impl ErrorContext {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::core::{CcpmError, ErrorContext};
+    /// use agpm::core::{AgpmError, ErrorContext};
     ///
-    /// let context = ErrorContext::new(CcpmError::ManifestNotFound)
-    ///     .with_details("CCPM looks for ccpm.toml in current directory and parent directories");
+    /// let context = ErrorContext::new(AgpmError::ManifestNotFound)
+    ///     .with_details("AGPM looks for agpm.toml in current directory and parent directories");
     /// ```
     pub fn with_details(mut self, details: impl Into<String>) -> Self {
         self.details = Some(details.into());
@@ -847,16 +847,16 @@ impl ErrorContext {
     /// - Details: Yellow
     /// - Suggestion: Green
     ///
-    /// This is the primary way CCPM presents errors to users in the CLI.
+    /// This is the primary way AGPM presents errors to users in the CLI.
     ///
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::core::{CcpmError, ErrorContext};
+    /// use agpm::core::{AgpmError, ErrorContext};
     ///
-    /// let context = ErrorContext::new(CcpmError::GitNotFound)
+    /// let context = ErrorContext::new(AgpmError::GitNotFound)
     ///     .with_suggestion("Install git from https://git-scm.com/")
-    ///     .with_details("CCPM requires git for repository operations");
+    ///     .with_details("AGPM requires git for repository operations");
     ///
     /// context.display(); // Prints colored error to stderr
     /// ```
@@ -891,18 +891,18 @@ impl fmt::Display for ErrorContext {
 
 impl std::error::Error for ErrorContext {}
 
-/// Extension trait for converting [`CcpmError`] to [`anyhow::Error`] with context
+/// Extension trait for converting [`AgpmError`] to [`anyhow::Error`] with context
 ///
-/// This trait provides a method to convert CCPM-specific errors into generic
+/// This trait provides a method to convert AGPM-specific errors into generic
 /// [`anyhow::Error`] instances while preserving user-friendly context information.
 ///
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::core::{CcpmError, ErrorContext, IntoAnyhowWithContext};
+/// use agpm::core::{AgpmError, ErrorContext, IntoAnyhowWithContext};
 ///
-/// let error = CcpmError::GitNotFound;
-/// let context = ErrorContext::new(CcpmError::Other { message: "dummy".to_string() })
+/// let error = AgpmError::GitNotFound;
+/// let context = ErrorContext::new(AgpmError::Other { message: "dummy".to_string() })
 ///     .with_suggestion("Install git");
 ///
 /// let anyhow_error = error.into_anyhow_with_context(context);
@@ -912,7 +912,7 @@ pub trait IntoAnyhowWithContext {
     fn into_anyhow_with_context(self, context: ErrorContext) -> anyhow::Error;
 }
 
-impl IntoAnyhowWithContext for CcpmError {
+impl IntoAnyhowWithContext for AgpmError {
     fn into_anyhow_with_context(self, context: ErrorContext) -> anyhow::Error {
         anyhow::Error::new(ErrorContext {
             error: self,
@@ -926,19 +926,19 @@ impl ErrorContext {
     /// Create an [`ErrorContext`] with only a suggestion (no specific error)
     ///
     /// This is useful for generic errors where you want to provide a suggestion
-    /// but don't have a specific [`CcpmError`] variant.
+    /// but don't have a specific [`AgpmError`] variant.
     ///
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::core::ErrorContext;
+    /// use agpm::core::ErrorContext;
     ///
     /// let context = ErrorContext::suggestion("Try running with --verbose for more information");
     /// context.display();
     /// ```
     pub fn suggestion(suggestion: impl Into<String>) -> Self {
         Self {
-            error: CcpmError::Other {
+            error: AgpmError::Other {
                 message: String::new(),
             },
             suggestion: Some(suggestion.into()),
@@ -956,19 +956,19 @@ impl ErrorContext {
 /// # Error Recognition
 ///
 /// The function recognizes and provides specific handling for:
-/// - [`CcpmError`] variants with tailored suggestions
+/// - [`AgpmError`] variants with tailored suggestions
 /// - [`std::io::Error`] with filesystem-specific guidance
 /// - [`toml::de::Error`] with TOML syntax help
 /// - Generic errors with basic context
 ///
 /// # Examples
 ///
-/// ## Converting CCPM Errors
+/// ## Converting AGPM Errors
 ///
 /// ```rust,no_run
-/// use ccpm::core::{CcpmError, user_friendly_error};
+/// use agpm::core::{AgpmError, user_friendly_error};
 ///
-/// let error = CcpmError::GitNotFound;
+/// let error = AgpmError::GitNotFound;
 /// let anyhow_error = anyhow::Error::from(error);
 /// let context = user_friendly_error(anyhow_error);
 ///
@@ -978,7 +978,7 @@ impl ErrorContext {
 /// ## Converting IO Errors
 ///
 /// ```rust,no_run
-/// use ccpm::core::user_friendly_error;
+/// use agpm::core::user_friendly_error;
 /// use std::io::{Error, ErrorKind};
 ///
 /// let io_error = Error::new(ErrorKind::PermissionDenied, "access denied");
@@ -991,7 +991,7 @@ impl ErrorContext {
 /// ## Converting Generic Errors
 ///
 /// ```rust,no_run
-/// use ccpm::core::user_friendly_error;
+/// use agpm::core::user_friendly_error;
 ///
 /// let error = anyhow::anyhow!("Something went wrong");
 /// let context = user_friendly_error(error);
@@ -1001,24 +1001,24 @@ impl ErrorContext {
 #[must_use]
 pub fn user_friendly_error(error: anyhow::Error) -> ErrorContext {
     // Check for specific error types and provide helpful suggestions
-    if let Some(ccmp_error) = error.downcast_ref::<CcpmError>() {
+    if let Some(ccmp_error) = error.downcast_ref::<AgpmError>() {
         return create_error_context(ccmp_error.clone());
     }
 
     if let Some(io_error) = error.downcast_ref::<std::io::Error>() {
         match io_error.kind() {
             std::io::ErrorKind::PermissionDenied => {
-                return ErrorContext::new(CcpmError::PermissionDenied {
+                return ErrorContext::new(AgpmError::PermissionDenied {
                     operation: "file access".to_string(),
                     path: "unknown".to_string(),
                 })
                 .with_suggestion(
                     "Try running with elevated permissions (sudo/Administrator) or check file ownership",
                 )
-                .with_details("This error occurs when CCPM doesn't have permission to read or write files");
+                .with_details("This error occurs when AGPM doesn't have permission to read or write files");
             }
             std::io::ErrorKind::NotFound => {
-                return ErrorContext::new(CcpmError::FileSystemError {
+                return ErrorContext::new(AgpmError::FileSystemError {
                     operation: "file access".to_string(),
                     path: "unknown".to_string(),
                 })
@@ -1028,7 +1028,7 @@ pub fn user_friendly_error(error: anyhow::Error) -> ErrorContext {
                 );
             }
             std::io::ErrorKind::AlreadyExists => {
-                return ErrorContext::new(CcpmError::FileSystemError {
+                return ErrorContext::new(AgpmError::FileSystemError {
                     operation: "file creation".to_string(),
                     path: "unknown".to_string(),
                 })
@@ -1036,7 +1036,7 @@ pub fn user_friendly_error(error: anyhow::Error) -> ErrorContext {
                 .with_details("The target file or directory already exists");
             }
             std::io::ErrorKind::InvalidData => {
-                return ErrorContext::new(CcpmError::InvalidResource {
+                return ErrorContext::new(AgpmError::InvalidResource {
                     name: "unknown".to_string(),
                     reason: "invalid file format".to_string(),
                 })
@@ -1048,11 +1048,11 @@ pub fn user_friendly_error(error: anyhow::Error) -> ErrorContext {
     }
 
     if let Some(toml_error) = error.downcast_ref::<toml::de::Error>() {
-        return ErrorContext::new(CcpmError::ManifestParseError {
-            file: "ccpm.toml".to_string(),
+        return ErrorContext::new(AgpmError::ManifestParseError {
+            file: "agpm.toml".to_string(),
             reason: toml_error.to_string(),
         })
-        .with_suggestion("Check the TOML syntax in your ccpm.toml file. Verify quotes, brackets, and indentation")
+        .with_suggestion("Check the TOML syntax in your agpm.toml file. Verify quotes, brackets, and indentation")
         .with_details("TOML parsing errors are usually caused by syntax issues like missing quotes or mismatched brackets");
     }
 
@@ -1073,12 +1073,12 @@ pub fn user_friendly_error(error: anyhow::Error) -> ErrorContext {
         }
     }
 
-    ErrorContext::new(CcpmError::Other { message })
+    ErrorContext::new(AgpmError::Other { message })
 }
 
-/// Create appropriate [`ErrorContext`] with suggestions for specific CCPM errors
+/// Create appropriate [`ErrorContext`] with suggestions for specific AGPM errors
 ///
-/// This internal function maps each [`CcpmError`] variant to an appropriate
+/// This internal function maps each [`AgpmError`] variant to an appropriate
 /// [`ErrorContext`] with tailored suggestions and details. It's used by
 /// [`user_friendly_error`] to provide consistent, helpful error messages.
 ///
@@ -1088,14 +1088,14 @@ pub fn user_friendly_error(error: anyhow::Error) -> ErrorContext {
 /// - Platform-specific suggestions are provided where applicable
 /// - Error messages focus on actionable steps rather than technical details
 /// - Cross-references to related commands or documentation are included
-fn create_error_context(error: CcpmError) -> ErrorContext {
+fn create_error_context(error: AgpmError) -> ErrorContext {
     match &error {
-        CcpmError::GitNotFound => ErrorContext::new(CcpmError::GitNotFound)
+        AgpmError::GitNotFound => ErrorContext::new(AgpmError::GitNotFound)
             .with_suggestion("Install git from https://git-scm.com/ or your package manager (e.g., 'brew install git', 'apt install git')")
-            .with_details("CCPM requires git to be installed and available in your PATH to manage repositories"),
+            .with_details("AGPM requires git to be installed and available in your PATH to manage repositories"),
 
-        CcpmError::GitCommandError { operation, stderr } => {
-            ErrorContext::new(CcpmError::GitCommandError {
+        AgpmError::GitCommandError { operation, stderr } => {
+            ErrorContext::new(AgpmError::GitCommandError {
                 operation: operation.clone(),
                 stderr: stderr.clone(),
             })
@@ -1123,13 +1123,13 @@ fn create_error_context(error: CcpmError) -> ErrorContext {
             })
         }
 
-        CcpmError::GitAuthenticationFailed { url } => ErrorContext::new(CcpmError::GitAuthenticationFailed {
+        AgpmError::GitAuthenticationFailed { url } => ErrorContext::new(AgpmError::GitAuthenticationFailed {
             url: url.clone(),
         })
             .with_suggestion("Configure git authentication: use 'git config --global user.name' and 'git config --global user.email', or set up SSH keys")
             .with_details("Authentication is required for private repositories. You may need to log in with 'git credential-manager-core' or similar"),
 
-        CcpmError::GitCloneFailed { url, reason } => ErrorContext::new(CcpmError::GitCloneFailed {
+        AgpmError::GitCloneFailed { url, reason } => ErrorContext::new(AgpmError::GitCloneFailed {
             url: url.clone(),
             reason: reason.clone(),
         })
@@ -1138,28 +1138,28 @@ fn create_error_context(error: CcpmError) -> ErrorContext {
             ))
             .with_details("Clone operations can fail due to invalid URLs, network issues, or access restrictions"),
 
-        CcpmError::ManifestNotFound => ErrorContext::new(CcpmError::ManifestNotFound)
-            .with_suggestion("Create a ccpm.toml file in your project directory. See documentation for the manifest format")
-            .with_details("CCPM looks for ccpm.toml in the current directory and parent directories up to the filesystem root"),
+        AgpmError::ManifestNotFound => ErrorContext::new(AgpmError::ManifestNotFound)
+            .with_suggestion("Create a agpm.toml file in your project directory. See documentation for the manifest format")
+            .with_details("AGPM looks for agpm.toml in the current directory and parent directories up to the filesystem root"),
 
-        CcpmError::ManifestParseError { file, reason } => ErrorContext::new(CcpmError::ManifestParseError {
+        AgpmError::ManifestParseError { file, reason } => ErrorContext::new(AgpmError::ManifestParseError {
             file: file.clone(),
             reason: reason.clone(),
         })
             .with_suggestion(format!(
                 "Check the TOML syntax in {file}. Common issues: missing quotes, unmatched brackets, invalid characters"
             ))
-            .with_details("Use a TOML validator or check the ccpm documentation for correct manifest format"),
+            .with_details("Use a TOML validator or check the agpm documentation for correct manifest format"),
 
-        CcpmError::SourceNotFound { name } => ErrorContext::new(CcpmError::SourceNotFound {
+        AgpmError::SourceNotFound { name } => ErrorContext::new(AgpmError::SourceNotFound {
             name: name.clone(),
         })
             .with_suggestion(format!(
-                "Add source '{name}' to the [sources] section in ccpm.toml with the repository URL"
+                "Add source '{name}' to the [sources] section in agpm.toml with the repository URL"
             ))
             .with_details("All dependencies must reference a source defined in the [sources] section"),
 
-        CcpmError::ResourceFileNotFound { path, source_name } => ErrorContext::new(CcpmError::ResourceFileNotFound {
+        AgpmError::ResourceFileNotFound { path, source_name } => ErrorContext::new(AgpmError::ResourceFileNotFound {
             path: path.clone(),
             source_name: source_name.clone(),
         })
@@ -1168,7 +1168,7 @@ fn create_error_context(error: CcpmError) -> ErrorContext {
             ))
             .with_details("The resource file may have been moved, renamed, or deleted in the repository"),
 
-        CcpmError::VersionNotFound { resource, version } => ErrorContext::new(CcpmError::VersionNotFound {
+        AgpmError::VersionNotFound { resource, version } => ErrorContext::new(AgpmError::VersionNotFound {
             resource: resource.clone(),
             version: version.clone(),
         })
@@ -1179,7 +1179,7 @@ fn create_error_context(error: CcpmError) -> ErrorContext {
                 "The version '{version}' doesn't exist as a git tag, branch, or commit in the repository"
             )),
 
-        CcpmError::CircularDependency { chain } => ErrorContext::new(CcpmError::CircularDependency {
+        AgpmError::CircularDependency { chain } => ErrorContext::new(AgpmError::CircularDependency {
             chain: chain.clone(),
         })
             .with_suggestion("Review your dependency graph and remove circular references")
@@ -1187,7 +1187,7 @@ fn create_error_context(error: CcpmError) -> ErrorContext {
                 "Circular dependency chain detected: {chain}. Dependencies cannot depend on themselves directly or indirectly"
             )),
 
-        CcpmError::PermissionDenied { operation, path } => ErrorContext::new(CcpmError::PermissionDenied {
+        AgpmError::PermissionDenied { operation, path } => ErrorContext::new(AgpmError::PermissionDenied {
             operation: operation.clone(),
             path: path.clone(),
         })
@@ -1199,7 +1199,7 @@ fn create_error_context(error: CcpmError) -> ErrorContext {
                 "Cannot {operation} due to insufficient permissions on {path}"
             )),
 
-        CcpmError::ChecksumMismatch { name, expected, actual } => ErrorContext::new(CcpmError::ChecksumMismatch {
+        AgpmError::ChecksumMismatch { name, expected, actual } => ErrorContext::new(AgpmError::ChecksumMismatch {
             name: name.clone(),
             expected: expected.clone(),
             actual: actual.clone(),
@@ -1219,23 +1219,23 @@ mod tests {
 
     #[test]
     fn test_error_display() {
-        let error = CcpmError::GitNotFound;
+        let error = AgpmError::GitNotFound;
         assert_eq!(
             error.to_string(),
             "Git is not installed or not found in PATH"
         );
 
-        let error = CcpmError::ResourceNotFound {
+        let error = AgpmError::ResourceNotFound {
             name: "test".to_string(),
         };
         assert_eq!(error.to_string(), "Resource 'test' not found");
 
-        let error = CcpmError::InvalidVersionConstraint {
+        let error = AgpmError::InvalidVersionConstraint {
             constraint: "bad-version".to_string(),
         };
         assert_eq!(error.to_string(), "Invalid version constraint: bad-version");
 
-        let error = CcpmError::GitCommandError {
+        let error = AgpmError::GitCommandError {
             operation: "clone".to_string(),
             stderr: "repository not found".to_string(),
         };
@@ -1244,9 +1244,9 @@ mod tests {
 
     #[test]
     fn test_error_context() {
-        let ctx = ErrorContext::new(CcpmError::GitNotFound)
+        let ctx = ErrorContext::new(AgpmError::GitNotFound)
             .with_suggestion("Install git using your package manager")
-            .with_details("Git is required for CCPM to function");
+            .with_details("Git is required for AGPM to function");
 
         assert_eq!(
             ctx.suggestion,
@@ -1254,13 +1254,13 @@ mod tests {
         );
         assert_eq!(
             ctx.details,
-            Some("Git is required for CCPM to function".to_string())
+            Some("Git is required for AGPM to function".to_string())
         );
     }
 
     #[test]
     fn test_error_context_display() {
-        let ctx = ErrorContext::new(CcpmError::GitNotFound).with_suggestion("Install git");
+        let ctx = ErrorContext::new(AgpmError::GitNotFound).with_suggestion("Install git");
 
         let display = format!("{ctx}");
         assert!(display.contains("Git is not installed or not found in PATH"));
@@ -1276,7 +1276,7 @@ mod tests {
 
         let ctx = user_friendly_error(anyhow_error);
         match ctx.error {
-            CcpmError::PermissionDenied { .. } => {}
+            AgpmError::PermissionDenied { .. } => {}
             _ => panic!("Expected PermissionDenied error"),
         }
         assert!(ctx.suggestion.is_some());
@@ -1292,7 +1292,7 @@ mod tests {
 
         let ctx = user_friendly_error(anyhow_error);
         match ctx.error {
-            CcpmError::FileSystemError { .. } => {}
+            AgpmError::FileSystemError { .. } => {}
             _ => panic!("Expected FileSystemError"),
         }
         assert!(ctx.suggestion.is_some());
@@ -1304,10 +1304,10 @@ mod tests {
         use std::io::Error;
 
         let io_error = Error::other("test error");
-        let ccpm_error = CcpmError::from(io_error);
+        let agpm_error = AgpmError::from(io_error);
 
-        match ccpm_error {
-            CcpmError::IoError(_) => {}
+        match agpm_error {
+            AgpmError::IoError(_) => {}
             _ => panic!("Expected IoError"),
         }
     }
@@ -1318,9 +1318,9 @@ mod tests {
         let result: Result<toml::Value, _> = toml::from_str(toml_str);
 
         if let Err(e) = result {
-            let ccpm_error = CcpmError::from(e);
-            match ccpm_error {
-                CcpmError::TomlError(_) => {}
+            let agpm_error = AgpmError::from(e);
+            match agpm_error {
+                AgpmError::TomlError(_) => {}
                 _ => panic!("Expected TomlError"),
             }
         }
@@ -1328,7 +1328,7 @@ mod tests {
 
     #[test]
     fn test_create_error_context_git_not_found() {
-        let ctx = create_error_context(CcpmError::GitNotFound);
+        let ctx = create_error_context(AgpmError::GitNotFound);
         assert!(ctx.suggestion.is_some());
         assert!(ctx.suggestion.unwrap().contains("Install git"));
         assert!(ctx.details.is_some());
@@ -1336,7 +1336,7 @@ mod tests {
 
     #[test]
     fn test_create_error_context_git_command_error() {
-        let ctx = create_error_context(CcpmError::GitCommandError {
+        let ctx = create_error_context(AgpmError::GitCommandError {
             operation: "clone".to_string(),
             stderr: "error".to_string(),
         });
@@ -1347,7 +1347,7 @@ mod tests {
 
     #[test]
     fn test_create_error_context_git_auth_failed() {
-        let ctx = create_error_context(CcpmError::GitAuthenticationFailed {
+        let ctx = create_error_context(AgpmError::GitAuthenticationFailed {
             url: "https://github.com/test/repo".to_string(),
         });
         assert!(ctx.suggestion.is_some());
@@ -1361,15 +1361,15 @@ mod tests {
 
     #[test]
     fn test_create_error_context_manifest_not_found() {
-        let ctx = create_error_context(CcpmError::ManifestNotFound);
+        let ctx = create_error_context(AgpmError::ManifestNotFound);
         assert!(ctx.suggestion.is_some());
-        assert!(ctx.suggestion.unwrap().contains("Create a ccpm.toml"));
+        assert!(ctx.suggestion.unwrap().contains("Create a agpm.toml"));
         assert!(ctx.details.is_some());
     }
 
     #[test]
     fn test_create_error_context_source_not_found() {
-        let ctx = create_error_context(CcpmError::SourceNotFound {
+        let ctx = create_error_context(AgpmError::SourceNotFound {
             name: "test-source".to_string(),
         });
         assert!(ctx.suggestion.is_some());
@@ -1379,7 +1379,7 @@ mod tests {
 
     #[test]
     fn test_create_error_context_version_not_found() {
-        let ctx = create_error_context(CcpmError::VersionNotFound {
+        let ctx = create_error_context(AgpmError::VersionNotFound {
             resource: "test-resource".to_string(),
             version: "v1.0.0".to_string(),
         });
@@ -1391,7 +1391,7 @@ mod tests {
 
     #[test]
     fn test_create_error_context_circular_dependency() {
-        let ctx = create_error_context(CcpmError::CircularDependency {
+        let ctx = create_error_context(AgpmError::CircularDependency {
             chain: "a -> b -> c -> a".to_string(),
         });
         assert!(ctx.suggestion.is_some());
@@ -1402,7 +1402,7 @@ mod tests {
 
     #[test]
     fn test_create_error_context_permission_denied() {
-        let ctx = create_error_context(CcpmError::PermissionDenied {
+        let ctx = create_error_context(AgpmError::PermissionDenied {
             operation: "write".to_string(),
             path: "/test/path".to_string(),
         });
@@ -1413,7 +1413,7 @@ mod tests {
 
     #[test]
     fn test_create_error_context_checksum_mismatch() {
-        let ctx = create_error_context(CcpmError::ChecksumMismatch {
+        let ctx = create_error_context(AgpmError::ChecksumMismatch {
             name: "test-resource".to_string(),
             expected: "abc123".to_string(),
             actual: "def456".to_string(),
@@ -1426,11 +1426,11 @@ mod tests {
 
     #[test]
     fn test_error_clone() {
-        let error1 = CcpmError::GitNotFound;
+        let error1 = AgpmError::GitNotFound;
         let error2 = error1.clone();
         assert_eq!(error1.to_string(), error2.to_string());
 
-        let error1 = CcpmError::ResourceNotFound {
+        let error1 = AgpmError::ResourceNotFound {
             name: "test".to_string(),
         };
         let error2 = error1.clone();
@@ -1446,8 +1446,8 @@ mod tests {
 
     #[test]
     fn test_into_anyhow_with_context() {
-        let error = CcpmError::GitNotFound;
-        let context = ErrorContext::new(CcpmError::Other {
+        let error = AgpmError::GitNotFound;
+        let context = ErrorContext::new(AgpmError::Other {
             message: "dummy".to_string(),
         })
         .with_suggestion("Test suggestion")
@@ -1467,7 +1467,7 @@ mod tests {
 
         let ctx = user_friendly_error(anyhow_error);
         match ctx.error {
-            CcpmError::FileSystemError { .. } => {}
+            AgpmError::FileSystemError { .. } => {}
             _ => panic!("Expected FileSystemError"),
         }
         assert!(ctx.suggestion.is_some());
@@ -1483,7 +1483,7 @@ mod tests {
 
         let ctx = user_friendly_error(anyhow_error);
         match ctx.error {
-            CcpmError::InvalidResource { .. } => {}
+            AgpmError::InvalidResource { .. } => {}
             _ => panic!("Expected InvalidResource"),
         }
         assert!(ctx.suggestion.is_some());
@@ -1491,13 +1491,13 @@ mod tests {
     }
 
     #[test]
-    fn test_user_friendly_error_ccpm_error() {
-        let error = CcpmError::GitNotFound;
+    fn test_user_friendly_error_agpm_error() {
+        let error = AgpmError::GitNotFound;
         let anyhow_error = anyhow::Error::from(error);
 
         let ctx = user_friendly_error(anyhow_error);
         match ctx.error {
-            CcpmError::GitNotFound => {}
+            AgpmError::GitNotFound => {}
             _ => panic!("Expected GitNotFound"),
         }
         assert!(ctx.suggestion.is_some());
@@ -1513,7 +1513,7 @@ mod tests {
             let ctx = user_friendly_error(anyhow_error);
 
             match ctx.error {
-                CcpmError::ManifestParseError { .. } => {}
+                AgpmError::ManifestParseError { .. } => {}
                 _ => panic!("Expected ManifestParseError"),
             }
             assert!(ctx.suggestion.is_some());
@@ -1527,7 +1527,7 @@ mod tests {
         let ctx = user_friendly_error(error);
 
         match ctx.error {
-            CcpmError::Other { message } => {
+            AgpmError::Other { message } => {
                 assert_eq!(message, "Generic error");
             }
             _ => panic!("Expected Other error"),
@@ -1538,9 +1538,9 @@ mod tests {
     fn test_from_semver_error() {
         let result = semver::Version::parse("invalid-version");
         if let Err(e) = result {
-            let ccpm_error = CcpmError::from(e);
-            match ccpm_error {
-                CcpmError::SemverError(_) => {}
+            let agpm_error = AgpmError::from(e);
+            match agpm_error {
+                AgpmError::SemverError(_) => {}
                 _ => panic!("Expected SemverError"),
             }
         }
@@ -1550,43 +1550,43 @@ mod tests {
     fn test_error_display_all_variants() {
         // Test display for various error variants
         let errors = vec![
-            CcpmError::GitRepoInvalid {
+            AgpmError::GitRepoInvalid {
                 path: "/test/path".to_string(),
             },
-            CcpmError::GitCheckoutFailed {
+            AgpmError::GitCheckoutFailed {
                 reference: "main".to_string(),
                 reason: "not found".to_string(),
             },
-            CcpmError::ConfigError {
+            AgpmError::ConfigError {
                 message: "config issue".to_string(),
             },
-            CcpmError::ManifestValidationError {
+            AgpmError::ManifestValidationError {
                 reason: "invalid format".to_string(),
             },
-            CcpmError::LockfileParseError {
-                file: "ccpm.lock".to_string(),
+            AgpmError::LockfileParseError {
+                file: "agpm.lock".to_string(),
                 reason: "syntax error".to_string(),
             },
-            CcpmError::ResourceFileNotFound {
+            AgpmError::ResourceFileNotFound {
                 path: "test.md".to_string(),
                 source_name: "source".to_string(),
             },
-            CcpmError::DirectoryNotEmpty {
+            AgpmError::DirectoryNotEmpty {
                 path: "/some/dir".to_string(),
             },
-            CcpmError::InvalidDependency {
+            AgpmError::InvalidDependency {
                 name: "dep".to_string(),
                 reason: "bad format".to_string(),
             },
-            CcpmError::DependencyNotMet {
+            AgpmError::DependencyNotMet {
                 name: "dep".to_string(),
                 required: "v1.0".to_string(),
                 found: "v2.0".to_string(),
             },
-            CcpmError::ConfigNotFound {
+            AgpmError::ConfigNotFound {
                 path: "/config/path".to_string(),
             },
-            CcpmError::PlatformNotSupported {
+            AgpmError::PlatformNotSupported {
                 operation: "test op".to_string(),
             },
         ];
@@ -1607,7 +1607,7 @@ mod tests {
         ];
 
         for (op, expected_text) in operations {
-            let ctx = create_error_context(CcpmError::GitCommandError {
+            let ctx = create_error_context(AgpmError::GitCommandError {
                 operation: op.to_string(),
                 stderr: "error".to_string(),
             });
@@ -1623,7 +1623,7 @@ mod tests {
 
     #[test]
     fn test_create_error_context_resource_file_not_found() {
-        let ctx = create_error_context(CcpmError::ResourceFileNotFound {
+        let ctx = create_error_context(AgpmError::ResourceFileNotFound {
             path: "agents/test.md".to_string(),
             source_name: "official".to_string(),
         });
@@ -1636,7 +1636,7 @@ mod tests {
 
     #[test]
     fn test_create_error_context_manifest_parse_error() {
-        let ctx = create_error_context(CcpmError::ManifestParseError {
+        let ctx = create_error_context(AgpmError::ManifestParseError {
             file: "custom.toml".to_string(),
             reason: "invalid syntax".to_string(),
         });
@@ -1648,7 +1648,7 @@ mod tests {
 
     #[test]
     fn test_create_error_context_git_clone_failed() {
-        let ctx = create_error_context(CcpmError::GitCloneFailed {
+        let ctx = create_error_context(AgpmError::GitCloneFailed {
             url: "https://example.com/repo.git".to_string(),
             reason: "network error".to_string(),
         });

--- a/src/core/error_builders.rs
+++ b/src/core/error_builders.rs
@@ -73,7 +73,7 @@ pub fn git_error_context(command: &str, repo: Option<&str>) -> ErrorContext {
     ErrorContext {
         error: AgpmError::GitCommandError {
             operation: command.to_string(),
-            stderr: format!("Git {} operation failed", command),
+            stderr: format!("Git {command} operation failed"),
         },
         suggestion: match command {
             "clone" => {
@@ -86,7 +86,7 @@ pub fn git_error_context(command: &str, repo: Option<&str>) -> ErrorContext {
             "status" => Some("Ensure you're in a valid git repository".to_string()),
             _ => Some("Check that git is installed and accessible".to_string()),
         },
-        details: repo.map(|r| format!("Repository: {}", r)),
+        details: repo.map(|r| format!("Repository: {r}")),
     }
 }
 
@@ -117,7 +117,7 @@ pub fn manifest_error_context(operation: &str, details: Option<&str>) -> ErrorCo
             reason: details.unwrap_or("Validation failed").to_string(),
         },
         _ => AgpmError::Other {
-            message: format!("Manifest operation '{}' failed", operation),
+            message: format!("Manifest operation '{operation}' failed"),
         },
     };
 
@@ -131,7 +131,7 @@ pub fn manifest_error_context(operation: &str, details: Option<&str>) -> ErrorCo
             }
             _ => None,
         },
-        details: details.map(|d| d.to_string()),
+        details: details.map(std::string::ToString::to_string),
     }
 }
 
@@ -182,10 +182,10 @@ pub fn network_error_context(operation: &str, url: Option<&str>) -> ErrorContext
     ErrorContext {
         error: AgpmError::NetworkError {
             operation: operation.to_string(),
-            reason: format!("Network {} failed", operation),
+            reason: format!("Network {operation} failed"),
         },
         suggestion: Some("Check your internet connection and try again".to_string()),
-        details: url.map(|u| format!("URL: {}", u)),
+        details: url.map(|u| format!("URL: {u}")),
     }
 }
 
@@ -208,7 +208,7 @@ pub fn config_error_context(config_type: &str, issue: &str) -> ErrorContext {
 
     ErrorContext {
         error: AgpmError::ConfigError {
-            message: format!("Configuration error in {} config: {}", config_type, issue),
+            message: format!("Configuration error in {config_type} config: {issue}"),
         },
         suggestion: match config_type {
             "global" => Some("Check ~/.agpm/config.toml for correct settings".to_string()),
@@ -243,8 +243,7 @@ pub fn permission_error_context(resource: &str, operation: &str) -> ErrorContext
             path: resource.to_string(),
         },
         suggestion: Some(format!(
-            "Check that you have {} permissions for: {}",
-            operation, resource
+            "Check that you have {operation} permissions for: {resource}"
         )),
         details: if cfg!(windows) {
             Some("On Windows, you may need to run as Administrator".to_string())

--- a/src/core/error_builders.rs
+++ b/src/core/error_builders.rs
@@ -20,7 +20,7 @@ use std::path::Path;
 /// ```no_run
 /// # use anyhow::{Context, Result};
 /// # fn example() -> Result<()> {
-/// use ccpm::core::error_builders::file_error_context;
+/// use agpm::core::error_builders::file_error_context;
 /// use std::fs;
 /// use std::path::Path;
 ///
@@ -31,10 +31,10 @@ use std::path::Path;
 /// # }
 /// ```
 pub fn file_error_context(operation: &str, path: &Path) -> ErrorContext {
-    use crate::core::CcpmError;
+    use crate::core::AgpmError;
 
     ErrorContext {
-        error: CcpmError::FileSystemError {
+        error: AgpmError::FileSystemError {
             operation: operation.to_string(),
             path: path.display().to_string(),
         },
@@ -63,15 +63,15 @@ pub fn file_error_context(operation: &str, path: &Path) -> ErrorContext {
 /// # Example
 ///
 /// ```no_run
-/// use ccpm::core::error_builders::git_error_context;
+/// use agpm::core::error_builders::git_error_context;
 ///
 /// let context = git_error_context("clone", Some("https://github.com/user/repo.git"));
 /// ```
 pub fn git_error_context(command: &str, repo: Option<&str>) -> ErrorContext {
-    use crate::core::CcpmError;
+    use crate::core::AgpmError;
 
     ErrorContext {
-        error: CcpmError::GitCommandError {
+        error: AgpmError::GitCommandError {
             operation: command.to_string(),
             stderr: format!("Git {} operation failed", command),
         },
@@ -100,23 +100,23 @@ pub fn git_error_context(command: &str, repo: Option<&str>) -> ErrorContext {
 /// # Example
 ///
 /// ```no_run
-/// use ccpm::core::error_builders::manifest_error_context;
+/// use agpm::core::error_builders::manifest_error_context;
 ///
 /// let context = manifest_error_context("parse", Some("Invalid TOML syntax at line 5"));
 /// ```
 pub fn manifest_error_context(operation: &str, details: Option<&str>) -> ErrorContext {
-    use crate::core::CcpmError;
+    use crate::core::AgpmError;
 
     let error = match operation {
-        "load" => CcpmError::ManifestNotFound,
-        "parse" => CcpmError::ManifestParseError {
-            file: "ccpm.toml".to_string(),
+        "load" => AgpmError::ManifestNotFound,
+        "parse" => AgpmError::ManifestParseError {
+            file: "agpm.toml".to_string(),
             reason: details.unwrap_or("Invalid TOML syntax").to_string(),
         },
-        "validate" => CcpmError::ManifestValidationError {
+        "validate" => AgpmError::ManifestValidationError {
             reason: details.unwrap_or("Validation failed").to_string(),
         },
-        _ => CcpmError::Other {
+        _ => AgpmError::Other {
             message: format!("Manifest operation '{}' failed", operation),
         },
     };
@@ -124,8 +124,8 @@ pub fn manifest_error_context(operation: &str, details: Option<&str>) -> ErrorCo
     ErrorContext {
         error,
         suggestion: match operation {
-            "load" => Some("Check that ccpm.toml exists in the project directory".to_string()),
-            "parse" => Some("Check that ccpm.toml contains valid TOML syntax".to_string()),
+            "load" => Some("Check that agpm.toml exists in the project directory".to_string()),
+            "parse" => Some("Check that agpm.toml contains valid TOML syntax".to_string()),
             "validate" => {
                 Some("Ensure all required fields are present in the manifest".to_string())
             }
@@ -145,19 +145,19 @@ pub fn manifest_error_context(operation: &str, details: Option<&str>) -> ErrorCo
 /// # Example
 ///
 /// ```no_run
-/// use ccpm::core::error_builders::dependency_error_context;
+/// use agpm::core::error_builders::dependency_error_context;
 ///
 /// let context = dependency_error_context("my-agent", "Version conflict with existing dependency");
 /// ```
 pub fn dependency_error_context(dependency: &str, reason: &str) -> ErrorContext {
-    use crate::core::CcpmError;
+    use crate::core::AgpmError;
 
     ErrorContext {
-        error: CcpmError::InvalidDependency {
+        error: AgpmError::InvalidDependency {
             name: dependency.to_string(),
             reason: reason.to_string(),
         },
-        suggestion: Some("Try running 'ccpm update' to update dependencies".to_string()),
+        suggestion: Some("Try running 'agpm update' to update dependencies".to_string()),
         details: Some(reason.to_string()),
     }
 }
@@ -172,15 +172,15 @@ pub fn dependency_error_context(dependency: &str, reason: &str) -> ErrorContext 
 /// # Example
 ///
 /// ```no_run
-/// use ccpm::core::error_builders::network_error_context;
+/// use agpm::core::error_builders::network_error_context;
 ///
 /// let context = network_error_context("fetch", Some("https://api.example.com"));
 /// ```
 pub fn network_error_context(operation: &str, url: Option<&str>) -> ErrorContext {
-    use crate::core::CcpmError;
+    use crate::core::AgpmError;
 
     ErrorContext {
-        error: CcpmError::NetworkError {
+        error: AgpmError::NetworkError {
             operation: operation.to_string(),
             reason: format!("Network {} failed", operation),
         },
@@ -199,20 +199,20 @@ pub fn network_error_context(operation: &str, url: Option<&str>) -> ErrorContext
 /// # Example
 ///
 /// ```no_run
-/// use ccpm::core::error_builders::config_error_context;
+/// use agpm::core::error_builders::config_error_context;
 ///
 /// let context = config_error_context("global", "Missing authentication token");
 /// ```
 pub fn config_error_context(config_type: &str, issue: &str) -> ErrorContext {
-    use crate::core::CcpmError;
+    use crate::core::AgpmError;
 
     ErrorContext {
-        error: CcpmError::ConfigError {
+        error: AgpmError::ConfigError {
             message: format!("Configuration error in {} config: {}", config_type, issue),
         },
         suggestion: match config_type {
-            "global" => Some("Check ~/.ccpm/config.toml for correct settings".to_string()),
-            "project" => Some("Check ccpm.toml in your project directory".to_string()),
+            "global" => Some("Check ~/.agpm/config.toml for correct settings".to_string()),
+            "project" => Some("Check agpm.toml in your project directory".to_string()),
             "mcp" => Some("Check .mcp.json for valid MCP server configurations".to_string()),
             _ => None,
         },
@@ -230,15 +230,15 @@ pub fn config_error_context(config_type: &str, issue: &str) -> ErrorContext {
 /// # Example
 ///
 /// ```no_run
-/// use ccpm::core::error_builders::permission_error_context;
+/// use agpm::core::error_builders::permission_error_context;
 ///
 /// let context = permission_error_context("/usr/local/bin", "write");
 /// ```
 pub fn permission_error_context(resource: &str, operation: &str) -> ErrorContext {
-    use crate::core::CcpmError;
+    use crate::core::AgpmError;
 
     ErrorContext {
-        error: CcpmError::PermissionDenied {
+        error: AgpmError::PermissionDenied {
             operation: operation.to_string(),
             path: resource.to_string(),
         },
@@ -302,10 +302,10 @@ where
 /// # Example
 ///
 /// ```
-/// use ccpm::{error_context, core::CcpmError};
+/// use agpm::{error_context, core::AgpmError};
 ///
 /// let context = error_context! {
-///     error: CcpmError::Other { message: "Operation failed".to_string() },
+///     error: AgpmError::Other { message: "Operation failed".to_string() },
 ///     suggestion: "Try again later",
 ///     details: "Additional information"
 /// };
@@ -351,7 +351,7 @@ mod tests {
         let context = file_error_context("read", Path::new("/tmp/test.txt"));
         assert!(matches!(
             context.error,
-            crate::core::CcpmError::FileSystemError { .. }
+            crate::core::AgpmError::FileSystemError { .. }
         ));
         assert!(context.suggestion.is_some());
         assert!(context.details.unwrap().contains("/tmp/test.txt"));
@@ -362,7 +362,7 @@ mod tests {
         let context = git_error_context("clone", Some("https://github.com/test/repo"));
         assert!(matches!(
             context.error,
-            crate::core::CcpmError::GitCommandError { .. }
+            crate::core::AgpmError::GitCommandError { .. }
         ));
         assert!(context.suggestion.unwrap().contains("network"));
         assert!(context.details.unwrap().contains("github.com"));
@@ -370,14 +370,14 @@ mod tests {
 
     #[test]
     fn test_error_context_macro() {
-        use crate::core::CcpmError;
+        use crate::core::AgpmError;
 
         let context = error_context! {
-            error: CcpmError::Other { message: "Test error".to_string() },
+            error: AgpmError::Other { message: "Test error".to_string() },
             suggestion: "Test suggestion",
             details: "Test details"
         };
-        assert!(matches!(context.error, CcpmError::Other { .. }));
+        assert!(matches!(context.error, AgpmError::Other { .. }));
         assert_eq!(context.suggestion.unwrap(), "Test suggestion");
         assert_eq!(context.details.unwrap(), "Test details");
     }
@@ -387,7 +387,7 @@ mod tests {
         let context = permission_error_context("/usr/local", "write");
         assert!(matches!(
             context.error,
-            crate::core::CcpmError::PermissionDenied { .. }
+            crate::core::AgpmError::PermissionDenied { .. }
         ));
         assert!(context.suggestion.unwrap().contains("write permissions"));
         assert!(context.details.is_some());
@@ -399,15 +399,15 @@ mod tests {
         let context = manifest_error_context("load", None);
         assert!(matches!(
             context.error,
-            crate::core::CcpmError::ManifestNotFound
+            crate::core::AgpmError::ManifestNotFound
         ));
-        assert!(context.suggestion.unwrap().contains("ccpm.toml exists"));
+        assert!(context.suggestion.unwrap().contains("agpm.toml exists"));
 
         // Test parse operation with details
         let context = manifest_error_context("parse", Some("Syntax error at line 10"));
         assert!(matches!(
             context.error,
-            crate::core::CcpmError::ManifestParseError { .. }
+            crate::core::AgpmError::ManifestParseError { .. }
         ));
         assert!(context.suggestion.unwrap().contains("valid TOML syntax"));
         assert_eq!(context.details.unwrap(), "Syntax error at line 10");
@@ -416,7 +416,7 @@ mod tests {
         let context = manifest_error_context("validate", Some("Missing required field"));
         assert!(matches!(
             context.error,
-            crate::core::CcpmError::ManifestValidationError { .. }
+            crate::core::AgpmError::ManifestValidationError { .. }
         ));
         assert!(context.suggestion.unwrap().contains("required fields"));
         assert_eq!(context.details.unwrap(), "Missing required field");
@@ -425,7 +425,7 @@ mod tests {
         let context = manifest_error_context("unknown", None);
         assert!(matches!(
             context.error,
-            crate::core::CcpmError::Other { .. }
+            crate::core::AgpmError::Other { .. }
         ));
         assert!(context.suggestion.is_none());
     }
@@ -435,9 +435,9 @@ mod tests {
         let context = dependency_error_context("test-agent", "Version not found");
         assert!(matches!(
             context.error,
-            crate::core::CcpmError::InvalidDependency { .. }
+            crate::core::AgpmError::InvalidDependency { .. }
         ));
-        assert!(context.suggestion.unwrap().contains("ccpm update"));
+        assert!(context.suggestion.unwrap().contains("agpm update"));
         assert_eq!(context.details.unwrap(), "Version not found");
     }
 
@@ -446,7 +446,7 @@ mod tests {
         let context = network_error_context("download", Some("https://example.com/file"));
         assert!(matches!(
             context.error,
-            crate::core::CcpmError::NetworkError { .. }
+            crate::core::AgpmError::NetworkError { .. }
         ));
         assert!(context.suggestion.unwrap().contains("internet connection"));
         assert!(context.details.unwrap().contains("example.com"));
@@ -458,13 +458,13 @@ mod tests {
         let context = config_error_context("global", "Invalid format");
         assert!(matches!(
             context.error,
-            crate::core::CcpmError::ConfigError { .. }
+            crate::core::AgpmError::ConfigError { .. }
         ));
-        assert!(context.suggestion.unwrap().contains("~/.ccpm/config.toml"));
+        assert!(context.suggestion.unwrap().contains("~/.agpm/config.toml"));
 
         // Test project config
         let context = config_error_context("project", "Missing dependency");
-        assert!(context.suggestion.unwrap().contains("ccpm.toml"));
+        assert!(context.suggestion.unwrap().contains("agpm.toml"));
 
         // Test MCP config
         let context = config_error_context("mcp", "Invalid server");
@@ -569,18 +569,18 @@ mod tests {
 
     #[test]
     fn test_error_context_macro_variants() {
-        use crate::core::CcpmError;
+        use crate::core::AgpmError;
 
         // Test with error only
         let context = error_context! {
-            error: CcpmError::Other { message: "Error only".to_string() }
+            error: AgpmError::Other { message: "Error only".to_string() }
         };
         assert!(context.suggestion.is_none());
         assert!(context.details.is_none());
 
         // Test with error and suggestion
         let context = error_context! {
-            error: CcpmError::Other { message: "Error".to_string() },
+            error: AgpmError::Other { message: "Error".to_string() },
             suggestion: "Do this"
         };
         assert_eq!(context.suggestion.unwrap(), "Do this");
@@ -588,7 +588,7 @@ mod tests {
 
         // Test with error and details
         let context = error_context! {
-            error: CcpmError::Other { message: "Error".to_string() },
+            error: AgpmError::Other { message: "Error".to_string() },
             details: "More info"
         };
         assert!(context.suggestion.is_none());

--- a/src/core/error_helpers.rs
+++ b/src/core/error_helpers.rs
@@ -80,7 +80,7 @@ pub trait FileOperations {
     }
 }
 
-/// Implement FileOperations for a unit struct to enable trait usage
+/// Implement `FileOperations` for a unit struct to enable trait usage
 pub struct FileOps;
 impl FileOperations for FileOps {}
 
@@ -102,7 +102,7 @@ pub trait ManifestOperations {
     }
 }
 
-/// Implement ManifestOperations for a unit struct to enable trait usage
+/// Implement `ManifestOperations` for a unit struct to enable trait usage
 pub struct ManifestOps;
 impl ManifestOperations for ManifestOps {}
 
@@ -126,7 +126,7 @@ pub trait MarkdownOperations {
     }
 }
 
-/// Implement MarkdownOperations for a unit struct to enable trait usage
+/// Implement `MarkdownOperations` for a unit struct to enable trait usage
 pub struct MarkdownOps;
 impl MarkdownOperations for MarkdownOps {}
 
@@ -151,7 +151,7 @@ pub trait LockfileOperations {
     }
 }
 
-/// Implement LockfileOperations for a unit struct to enable trait usage
+/// Implement `LockfileOperations` for a unit struct to enable trait usage
 pub struct LockfileOps;
 impl LockfileOperations for LockfileOps {}
 
@@ -177,7 +177,7 @@ pub trait JsonOperations {
     }
 }
 
-/// Implement JsonOperations for a unit struct to enable trait usage
+/// Implement `JsonOperations` for a unit struct to enable trait usage
 pub struct JsonOps;
 impl JsonOperations for JsonOps {}
 

--- a/src/core/error_helpers.rs
+++ b/src/core/error_helpers.rs
@@ -1,6 +1,6 @@
 //! Error handling helper functions and utilities
 //!
-//! This module provides common error handling patterns used throughout CCPM,
+//! This module provides common error handling patterns used throughout AGPM,
 //! reducing boilerplate and ensuring consistent error messages.
 
 use anyhow::{Context, Result};
@@ -348,7 +348,7 @@ mod tests {
     #[test]
     fn test_manifest_operations_load() {
         let temp = TempDir::new().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         // Create a valid manifest file
         let manifest_content = r#"
@@ -504,7 +504,7 @@ This is a test agent for reading.
     #[test]
     fn test_lockfile_operations_load() {
         let temp = TempDir::new().unwrap();
-        let lockfile_path = temp.path().join("ccpm.lock");
+        let lockfile_path = temp.path().join("agpm.lock");
 
         // Test loading non-existent lockfile (should create new)
         let lockfile = LockfileOps::load_lockfile_with_context(&lockfile_path).unwrap();

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,23 +1,23 @@
-//! Core types and functionality for CCPM
+//! Core types and functionality for AGPM
 //!
-//! This module forms the foundation of CCPM's type system, providing fundamental abstractions
+//! This module forms the foundation of AGPM's type system, providing fundamental abstractions
 //! for error handling, resource management, and core operations. It defines the contracts and
-//! interfaces used throughout the CCPM codebase.
+//! interfaces used throughout the AGPM codebase.
 //!
 //! # Architecture Overview
 //!
 //! The core module is organized around several key concepts:
 //!
 //! ## Error Management
-//! CCPM uses a sophisticated error handling system designed for both developer ergonomics
+//! AGPM uses a sophisticated error handling system designed for both developer ergonomics
 //! and end-user experience:
-//! - **Strongly-typed errors** ([`CcpmError`]) for precise error handling in code
+//! - **Strongly-typed errors** ([`AgpmError`]) for precise error handling in code
 //! - **User-friendly contexts** ([`ErrorContext`]) with actionable suggestions for CLI users
 //! - **Automatic error conversion** from common standard library errors
 //! - **Contextual suggestions** tailored to specific error conditions
 //!
 //! ## Resource Abstractions
-//! Resources are the core entities managed by CCPM:
+//! Resources are the core entities managed by AGPM:
 //! - **Resource types** ([`ResourceType`]) define categories (agents, snippets)
 //! - **Resource trait** provides common interface for all resource types  
 //! - **Type detection** automatically identifies resources
@@ -28,7 +28,7 @@
 //! ## `error` - Comprehensive Error Handling
 //!
 //! The error module provides:
-//! - [`CcpmError`] - Enumerated error types covering all CCPM failure modes
+//! - [`AgpmError`] - Enumerated error types covering all AGPM failure modes
 //! - [`ErrorContext`] - User-friendly error wrapper with suggestions and details
 //! - [`user_friendly_error`] - Convert any error to user-friendly format
 //! - [`IntoAnyhowWithContext`] - Extension trait for error conversion
@@ -63,12 +63,12 @@
 //! ## Error Handling Pattern
 //!
 //! ```rust,no_run
-//! use ccpm::core::{CcpmError, ErrorContext, user_friendly_error};
+//! use agpm::core::{AgpmError, ErrorContext, user_friendly_error};
 //! use anyhow::Result;
 //!
 //! fn example_operation() -> Result<String> {
 //!     // Simulate an operation that might fail
-//!     Err(CcpmError::ManifestNotFound.into())
+//!     Err(AgpmError::ManifestNotFound.into())
 //! }
 //!
 //! fn handle_operation() {
@@ -86,7 +86,7 @@
 //! ## Resource Type Detection
 //!
 //! ```rust,no_run
-//! use ccpm::core::{ResourceType, detect_resource_type};
+//! use agpm::core::{ResourceType, detect_resource_type};
 //! use std::path::Path;
 //! use tempfile::tempdir;
 //!
@@ -136,7 +136,7 @@
 //! ## Resource Trait Usage
 //!
 //! ```rust,no_run
-//! use ccpm::core::{Resource, ResourceType};
+//! use agpm::core::{Resource, ResourceType};
 //! use anyhow::Result;
 //! use std::path::Path;
 //!
@@ -169,12 +169,12 @@
 //! ## Error Context Creation
 //!
 //! ```rust,no_run
-//! use ccpm::core::{CcpmError, ErrorContext};
+//! use agpm::core::{AgpmError, ErrorContext};
 //!
 //! fn create_helpful_error() -> ErrorContext {
-//!     ErrorContext::new(CcpmError::GitNotFound)
+//!     ErrorContext::new(AgpmError::GitNotFound)
 //!         .with_suggestion("Install git from https://git-scm.com/ or use your package manager")
-//!         .with_details("CCPM requires git to clone and manage source repositories")
+//!         .with_details("AGPM requires git to clone and manage source repositories")
 //! }
 //!
 //! fn display_error() {
@@ -185,9 +185,9 @@
 //!
 //! # Integration with Other Modules
 //!
-//! The core module provides types used throughout CCPM:
-//! - **CLI commands** use [`CcpmError`] and [`ErrorContext`] for user feedback
-//! - **Git operations** return [`CcpmError`] variants for specific failure modes
+//! The core module provides types used throughout AGPM:
+//! - **CLI commands** use [`AgpmError`] and [`ErrorContext`] for user feedback
+//! - **Git operations** return [`AgpmError`] variants for specific failure modes
 //! - **Manifest parsing** uses [`Resource`] trait for type-agnostic operations
 //! - **Installation** relies on [`ResourceType`] for path generation and validation
 //! - **Dependency resolution** uses error types for constraint violations
@@ -196,7 +196,7 @@
 //!
 //! All core types are designed to be thread-safe where appropriate:
 //! - [`ResourceType`] is [`Copy`] and can be shared freely
-//! - [`CcpmError`] implements [`Clone`] for error propagation
+//! - [`AgpmError`] implements [`Clone`] for error propagation
 //! - [`Resource`] trait is object-safe for dynamic dispatch
 //!
 //! [`Result`]: std::result::Result
@@ -209,7 +209,7 @@ pub mod error_helpers;
 mod resource;
 pub mod resource_iterator;
 
-pub use error::{CcpmError, ErrorContext, IntoAnyhowWithContext, user_friendly_error};
+pub use error::{AgpmError, ErrorContext, IntoAnyhowWithContext, user_friendly_error};
 pub use error_builders::{
     ErrorContextExt, file_error_context, git_error_context, manifest_error_context,
 };
@@ -239,7 +239,7 @@ use std::path::Path;
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::core::{ResourceType, detect_resource_type};
+/// use agpm::core::{ResourceType, detect_resource_type};
 /// use tempfile::tempdir;
 /// use std::fs;
 ///

--- a/src/core/resource.rs
+++ b/src/core/resource.rs
@@ -1,12 +1,12 @@
-//! Resource abstractions for CCPM
+//! Resource abstractions for AGPM
 //!
 //! This module defines the core resource types and management traits that form the foundation
-//! of CCPM's resource system. Resources are the fundamental units that CCPM manages, installs,
+//! of AGPM's resource system. Resources are the fundamental units that AGPM manages, installs,
 //! and tracks across different source repositories.
 //!
 //! # Resource Model
 //!
-//! CCPM supports different types of resources, each with specific characteristics:
+//! AGPM supports different types of resources, each with specific characteristics:
 //! - **Agents**: AI assistant configurations and prompts
 //! - **Snippets**: Reusable code templates and examples
 //!
@@ -20,7 +20,7 @@
 //!
 //! # Resource Management
 //!
-//! Resources are defined in the project's `ccpm.toml` file and installed to specific
+//! Resources are defined in the project's `agpm.toml` file and installed to specific
 //! directories based on their type. Scripts and hooks have special handling for
 //! Claude Code integration.
 //!
@@ -29,7 +29,7 @@
 //! ## Working with Resource Types
 //!
 //! ```rust,no_run
-//! use ccpm::core::ResourceType;
+//! use agpm::core::ResourceType;
 //! use std::path::Path;
 //!
 //! // Convert strings to resource types
@@ -40,15 +40,15 @@
 //!
 //! // Get default directory names
 //! assert_eq!(agent_type.default_directory(), ".claude/agents");
-//! assert_eq!(snippet_type.default_directory(), ".claude/ccpm/snippets");
-//! assert_eq!(script_type.default_directory(), ".claude/ccpm/scripts");
-//! assert_eq!(hook_type.default_directory(), ".claude/ccpm/hooks");
+//! assert_eq!(snippet_type.default_directory(), ".claude/agpm/snippets");
+//! assert_eq!(script_type.default_directory(), ".claude/agpm/scripts");
+//! assert_eq!(hook_type.default_directory(), ".claude/agpm/hooks");
 //! ```
 //!
 //! ## Serialization Support
 //!
 //! ```rust,no_run
-//! use ccpm::core::ResourceType;
+//! use agpm::core::ResourceType;
 //!
 //! // ResourceType implements Serialize/Deserialize
 //! let agent = ResourceType::Agent;
@@ -63,9 +63,9 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
-/// Enumeration of supported resource types in CCPM
+/// Enumeration of supported resource types in AGPM
 ///
-/// This enum defines the different categories of resources that CCPM can manage.
+/// This enum defines the different categories of resources that AGPM can manage.
 /// Each resource type has specific characteristics, installation paths, and
 /// manifest file requirements.
 ///
@@ -84,17 +84,17 @@ use std::path::Path;
 ///
 /// ## Snippet  
 /// - **Purpose**: Reusable code templates, examples, and documentation fragments
-/// - **Default Directory**: `.claude/ccpm/snippets`
+/// - **Default Directory**: `.claude/agpm/snippets`
 /// - **Common Use Cases**: Code templates, configuration examples, documentation
 ///
 /// ## Script
 /// - **Purpose**: Executable files that can be run by hooks or independently
-/// - **Default Directory**: `.claude/ccpm/scripts`
+/// - **Default Directory**: `.claude/agpm/scripts`
 /// - **Common Use Cases**: Validation scripts, automation tools, hook executables
 ///
 /// ## Hook
 /// - **Purpose**: Event-based automation configurations for Claude Code
-/// - **Default Directory**: `.claude/ccpm/hooks`
+/// - **Default Directory**: `.claude/agpm/hooks`
 /// - **Common Use Cases**: Pre/Post tool use validation, custom event handlers
 ///
 /// # Examples
@@ -102,7 +102,7 @@ use std::path::Path;
 /// ## Basic Usage
 ///
 /// ```rust,no_run
-/// use ccpm::core::ResourceType;
+/// use agpm::core::ResourceType;
 ///
 /// let agent = ResourceType::Agent;
 /// let snippet = ResourceType::Snippet;
@@ -114,7 +114,7 @@ use std::path::Path;
 /// ## String Parsing
 ///
 /// ```rust,no_run
-/// use ccpm::core::ResourceType;
+/// use agpm::core::ResourceType;
 /// use std::str::FromStr;
 ///
 /// let agent: ResourceType = "agent".parse().unwrap();
@@ -130,22 +130,22 @@ use std::path::Path;
 /// ## Directory Names
 ///
 /// ```rust,no_run
-/// use ccpm::core::ResourceType;
+/// use agpm::core::ResourceType;
 ///
 /// let agent = ResourceType::Agent;
 /// assert_eq!(agent.default_directory(), ".claude/agents");
 ///
 /// let snippet = ResourceType::Snippet;  
-/// assert_eq!(snippet.default_directory(), ".claude/ccpm/snippets");
+/// assert_eq!(snippet.default_directory(), ".claude/agpm/snippets");
 ///
 /// let script = ResourceType::Script;
-/// assert_eq!(script.default_directory(), ".claude/ccpm/scripts");
+/// assert_eq!(script.default_directory(), ".claude/agpm/scripts");
 /// ```
 ///
 /// ## JSON Serialization
 ///
 /// ```rust,no_run
-/// use ccpm::core::ResourceType;
+/// use agpm::core::ResourceType;
 ///
 /// let agent = ResourceType::Agent;
 /// let json = serde_json::to_string(&agent).unwrap();
@@ -189,7 +189,7 @@ pub enum ResourceType {
     /// Executable script files
     ///
     /// Scripts are executable files (.sh, .js, .py, etc.) that can be referenced
-    /// by hooks or run independently. They are installed to .claude/ccpm/scripts/
+    /// by hooks or run independently. They are installed to .claude/agpm/scripts/
     Script,
 
     /// Hook configuration files
@@ -213,7 +213,7 @@ impl ResourceType {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::core::ResourceType;
+    /// use agpm::core::ResourceType;
     ///
     /// // Iterate over all resource types
     /// for resource_type in ResourceType::all() {
@@ -241,7 +241,7 @@ impl ResourceType {
     /// # Examples
     ///
     /// ```
-    /// use ccpm::core::ResourceType;
+    /// use agpm::core::ResourceType;
     ///
     /// assert_eq!(ResourceType::Agent.to_plural(), "agents");
     /// assert_eq!(ResourceType::McpServer.to_plural(), "mcp-servers");
@@ -260,28 +260,28 @@ impl ResourceType {
     /// Get the default installation directory name for this resource type
     ///
     /// Returns the conventional directory name where resources of this type
-    /// are typically installed in CCPM projects.
+    /// are typically installed in AGPM projects.
     ///
     /// # Returns
     ///
     /// - [`Agent`] → `".claude/agents"`
-    /// - [`Snippet`] → `".claude/ccpm/snippets"`
+    /// - [`Snippet`] → `".claude/agpm/snippets"`
     /// - [`Command`] → `.claude/commands`
-    /// - [`McpServer`] → `.claude/ccpm/mcp-servers`
-    /// - [`Script`] → `.claude/ccpm/scripts`
-    /// - [`Hook`] → `.claude/ccpm/hooks`
+    /// - [`McpServer`] → `.claude/agpm/mcp-servers`
+    /// - [`Script`] → `.claude/agpm/scripts`
+    /// - [`Hook`] → `.claude/agpm/hooks`
     ///
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::core::ResourceType;
+    /// use agpm::core::ResourceType;
     ///
     /// assert_eq!(ResourceType::Agent.default_directory(), ".claude/agents");
-    /// assert_eq!(ResourceType::Snippet.default_directory(), ".claude/ccpm/snippets");
+    /// assert_eq!(ResourceType::Snippet.default_directory(), ".claude/agpm/snippets");
     /// assert_eq!(ResourceType::Command.default_directory(), ".claude/commands");
-    /// assert_eq!(ResourceType::McpServer.default_directory(), ".claude/ccpm/mcp-servers");
-    /// assert_eq!(ResourceType::Script.default_directory(), ".claude/ccpm/scripts");
-    /// assert_eq!(ResourceType::Hook.default_directory(), ".claude/ccpm/hooks");
+    /// assert_eq!(ResourceType::McpServer.default_directory(), ".claude/agpm/mcp-servers");
+    /// assert_eq!(ResourceType::Script.default_directory(), ".claude/agpm/scripts");
+    /// assert_eq!(ResourceType::Hook.default_directory(), ".claude/agpm/hooks");
     /// ```
     ///
     /// # Note
@@ -299,11 +299,11 @@ impl ResourceType {
     pub fn default_directory(&self) -> &str {
         match self {
             ResourceType::Agent => ".claude/agents",
-            ResourceType::Snippet => ".claude/ccpm/snippets",
+            ResourceType::Snippet => ".claude/agpm/snippets",
             ResourceType::Command => ".claude/commands",
-            ResourceType::McpServer => ".claude/ccpm/mcp-servers",
-            ResourceType::Script => ".claude/ccpm/scripts",
-            ResourceType::Hook => ".claude/ccpm/hooks",
+            ResourceType::McpServer => ".claude/agpm/mcp-servers",
+            ResourceType::Script => ".claude/agpm/scripts",
+            ResourceType::Hook => ".claude/agpm/hooks",
         }
     }
 }
@@ -322,7 +322,7 @@ impl std::fmt::Display for ResourceType {
 }
 
 impl std::str::FromStr for ResourceType {
-    type Err = crate::core::CcpmError;
+    type Err = crate::core::AgpmError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
@@ -332,17 +332,17 @@ impl std::str::FromStr for ResourceType {
             "mcp-server" | "mcp-servers" | "mcpserver" | "mcp" => Ok(ResourceType::McpServer),
             "script" | "scripts" => Ok(ResourceType::Script),
             "hook" | "hooks" => Ok(ResourceType::Hook),
-            _ => Err(crate::core::CcpmError::InvalidResourceType {
+            _ => Err(crate::core::AgpmError::InvalidResourceType {
                 resource_type: s.to_string(),
             }),
         }
     }
 }
 
-/// Base trait defining the interface for all CCPM resources
+/// Base trait defining the interface for all AGPM resources
 ///
 /// This trait provides a common interface for different types of resources (agents, snippets)
-/// managed by CCPM. It abstracts the core operations that can be performed on any resource,
+/// managed by AGPM. It abstracts the core operations that can be performed on any resource,
 /// including validation, installation, and metadata access.
 ///
 /// # Design Principles
@@ -366,7 +366,7 @@ impl std::str::FromStr for ResourceType {
 /// ## Basic Resource Usage Pattern
 ///
 /// ```rust,no_run
-/// use ccpm::core::{Resource, ResourceType};
+/// use agpm::core::{Resource, ResourceType};
 /// use anyhow::Result;
 /// use std::path::Path;
 ///
@@ -394,7 +394,7 @@ impl std::str::FromStr for ResourceType {
 /// ## Metadata Extraction
 ///
 /// ```rust,no_run
-/// use ccpm::core::Resource;
+/// use agpm::core::Resource;
 /// use anyhow::Result;
 ///
 /// fn extract_metadata(resource: &dyn Resource) -> Result<()> {
@@ -418,7 +418,7 @@ impl std::str::FromStr for ResourceType {
 /// The trait is object-safe and can be used as a trait object:
 ///
 /// ```rust,no_run
-/// use ccpm::core::Resource;
+/// use agpm::core::Resource;
 /// use std::any::Any;
 ///
 /// fn handle_resource(resource: Box<dyn Resource>) {
@@ -442,7 +442,7 @@ pub trait Resource {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::core::Resource;
+    /// use agpm::core::Resource;
     ///
     /// fn print_resource_info(resource: &dyn Resource) {
     ///     println!("Resource name: {}", resource.name());
@@ -462,7 +462,7 @@ pub trait Resource {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::core::{Resource, ResourceType};
+    /// use agpm::core::{Resource, ResourceType};
     ///
     /// fn categorize_resource(resource: &dyn Resource) {
     ///     match resource.resource_type() {
@@ -491,7 +491,7 @@ pub trait Resource {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::core::Resource;
+    /// use agpm::core::Resource;
     ///
     /// fn show_resource_details(resource: &dyn Resource) {
     ///     println!("Name: {}", resource.name());
@@ -518,7 +518,7 @@ pub trait Resource {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::core::Resource;
+    /// use agpm::core::Resource;
     ///
     /// fn check_dependencies(resource: &dyn Resource) {
     ///     if let Some(deps) = resource.dependencies() {
@@ -549,7 +549,7 @@ pub trait Resource {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::core::Resource;
+    /// use agpm::core::Resource;
     /// use anyhow::Result;
     ///
     /// fn validate_before_install(resource: &dyn Resource) -> Result<()> {
@@ -581,7 +581,7 @@ pub trait Resource {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::core::Resource;
+    /// use agpm::core::Resource;
     /// use std::path::Path;
     /// use anyhow::Result;
     ///
@@ -616,7 +616,7 @@ pub trait Resource {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::core::Resource;
+    /// use agpm::core::Resource;
     /// use std::path::Path;
     ///
     /// fn check_install_location(resource: &dyn Resource) {
@@ -655,7 +655,7 @@ pub trait Resource {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::core::Resource;
+    /// use agpm::core::Resource;
     /// use anyhow::Result;
     ///
     /// fn show_resource_metadata(resource: &dyn Resource) -> Result<()> {
@@ -690,7 +690,7 @@ pub trait Resource {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::core::Resource;
+    /// use agpm::core::Resource;
     /// use std::any::Any;
     ///
     /// // Hypothetical concrete resource type
@@ -721,7 +721,7 @@ mod tests {
         assert_eq!(ResourceType::Agent.default_directory(), ".claude/agents");
         assert_eq!(
             ResourceType::Snippet.default_directory(),
-            ".claude/ccpm/snippets"
+            ".claude/agpm/snippets"
         );
         assert_eq!(
             ResourceType::Command.default_directory(),
@@ -729,13 +729,13 @@ mod tests {
         );
         assert_eq!(
             ResourceType::McpServer.default_directory(),
-            ".claude/ccpm/mcp-servers"
+            ".claude/agpm/mcp-servers"
         );
         assert_eq!(
             ResourceType::Script.default_directory(),
-            ".claude/ccpm/scripts"
+            ".claude/agpm/scripts"
         );
-        assert_eq!(ResourceType::Hook.default_directory(), ".claude/ccpm/hooks");
+        assert_eq!(ResourceType::Hook.default_directory(), ".claude/agpm/hooks");
     }
 
     #[test]

--- a/src/core/resource.rs
+++ b/src/core/resource.rs
@@ -195,7 +195,7 @@ pub enum ResourceType {
     /// Hook configuration files
     ///
     /// Hooks define event-based automation in Claude Code. They are JSON files
-    /// that configure scripts to run at specific events (PreToolUse, PostToolUse, etc.)
+    /// that configure scripts to run at specific events (`PreToolUse`, `PostToolUse`, etc.)
     /// and are merged into settings.local.json
     Hook,
     // Future resource types can be added here
@@ -208,7 +208,7 @@ impl ResourceType {
     /// for iterating over all resource types when processing manifests, lockfiles,
     /// or performing batch operations.
     ///
-    /// The order is guaranteed to be stable: Agent, Snippet, Command, McpServer, Script, Hook
+    /// The order is guaranteed to be stable: Agent, Snippet, Command, `McpServer`, Script, Hook
     ///
     /// # Examples
     ///
@@ -223,14 +223,14 @@ impl ResourceType {
     /// // Count total resource types
     /// assert_eq!(ResourceType::all().len(), 6);
     /// ```
-    pub const fn all() -> &'static [ResourceType] {
+    pub const fn all() -> &'static [Self] {
         &[
-            ResourceType::Agent,
-            ResourceType::Snippet,
-            ResourceType::Command,
-            ResourceType::McpServer,
-            ResourceType::Script,
-            ResourceType::Hook,
+            Self::Agent,
+            Self::Snippet,
+            Self::Command,
+            Self::McpServer,
+            Self::Script,
+            Self::Hook,
         ]
     }
 
@@ -248,12 +248,12 @@ impl ResourceType {
     /// ```
     pub const fn to_plural(&self) -> &'static str {
         match self {
-            ResourceType::Agent => "agents",
-            ResourceType::Snippet => "snippets",
-            ResourceType::Command => "commands",
-            ResourceType::Script => "scripts",
-            ResourceType::Hook => "hooks",
-            ResourceType::McpServer => "mcp-servers",
+            Self::Agent => "agents",
+            Self::Snippet => "snippets",
+            Self::Command => "commands",
+            Self::Script => "scripts",
+            Self::Hook => "hooks",
+            Self::McpServer => "mcp-servers",
         }
     }
 
@@ -296,14 +296,14 @@ impl ResourceType {
     /// [`Script`]: ResourceType::Script
     /// [`Hook`]: ResourceType::Hook
     #[must_use]
-    pub fn default_directory(&self) -> &str {
+    pub const fn default_directory(&self) -> &str {
         match self {
-            ResourceType::Agent => ".claude/agents",
-            ResourceType::Snippet => ".claude/agpm/snippets",
-            ResourceType::Command => ".claude/commands",
-            ResourceType::McpServer => ".claude/agpm/mcp-servers",
-            ResourceType::Script => ".claude/agpm/scripts",
-            ResourceType::Hook => ".claude/agpm/hooks",
+            Self::Agent => ".claude/agents",
+            Self::Snippet => ".claude/agpm/snippets",
+            Self::Command => ".claude/commands",
+            Self::McpServer => ".claude/agpm/mcp-servers",
+            Self::Script => ".claude/agpm/scripts",
+            Self::Hook => ".claude/agpm/hooks",
         }
     }
 }
@@ -311,12 +311,12 @@ impl ResourceType {
 impl std::fmt::Display for ResourceType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ResourceType::Agent => write!(f, "agent"),
-            ResourceType::Snippet => write!(f, "snippet"),
-            ResourceType::Command => write!(f, "command"),
-            ResourceType::McpServer => write!(f, "mcp-server"),
-            ResourceType::Script => write!(f, "script"),
-            ResourceType::Hook => write!(f, "hook"),
+            Self::Agent => write!(f, "agent"),
+            Self::Snippet => write!(f, "snippet"),
+            Self::Command => write!(f, "command"),
+            Self::McpServer => write!(f, "mcp-server"),
+            Self::Script => write!(f, "script"),
+            Self::Hook => write!(f, "hook"),
         }
     }
 }
@@ -326,12 +326,12 @@ impl std::str::FromStr for ResourceType {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
-            "agent" | "agents" => Ok(ResourceType::Agent),
-            "snippet" | "snippets" => Ok(ResourceType::Snippet),
-            "command" | "commands" => Ok(ResourceType::Command),
-            "mcp-server" | "mcp-servers" | "mcpserver" | "mcp" => Ok(ResourceType::McpServer),
-            "script" | "scripts" => Ok(ResourceType::Script),
-            "hook" | "hooks" => Ok(ResourceType::Hook),
+            "agent" | "agents" => Ok(Self::Agent),
+            "snippet" | "snippets" => Ok(Self::Snippet),
+            "command" | "commands" => Ok(Self::Command),
+            "mcp-server" | "mcp-servers" | "mcpserver" | "mcp" => Ok(Self::McpServer),
+            "script" | "scripts" => Ok(Self::Script),
+            "hook" | "hooks" => Ok(Self::Hook),
             _ => Err(crate::core::AgpmError::InvalidResourceType {
                 resource_type: s.to_string(),
             }),

--- a/src/core/resource_iterator.rs
+++ b/src/core/resource_iterator.rs
@@ -176,14 +176,14 @@ impl ResourceTypeExt for ResourceType {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::core::resource_iterator::ResourceIterator;
-/// use ccpm::lockfile::LockFile;
-/// use ccpm::manifest::Manifest;
+/// use agpm::core::resource_iterator::ResourceIterator;
+/// use agpm::lockfile::LockFile;
+/// use agpm::manifest::Manifest;
 /// use std::path::Path;
 ///
 /// # fn example() -> anyhow::Result<()> {
-/// let lockfile = LockFile::load(Path::new("ccpm.lock"))?;
-/// let manifest = Manifest::load(Path::new("ccpm.toml"))?;
+/// let lockfile = LockFile::load(Path::new("agpm.lock"))?;
+/// let manifest = Manifest::load(Path::new("agpm.toml"))?;
 ///
 /// // Collect all resources for parallel installation
 /// let all_entries = ResourceIterator::collect_all_entries(&lockfile, &manifest);
@@ -497,7 +497,7 @@ mod tests {
             version: Some("v1.0.0".to_string()),
             resolved_commit: Some("jkl012".to_string()),
             checksum: "sha256:jkl4".to_string(),
-            installed_at: ".claude/ccpm/scripts/script1.sh".to_string(),
+            installed_at: ".claude/agpm/scripts/script1.sh".to_string(),
             dependencies: vec![],
             resource_type: crate::core::ResourceType::Script,
         });
@@ -511,7 +511,7 @@ mod tests {
             version: Some("v1.0.0".to_string()),
             resolved_commit: Some("mno345".to_string()),
             checksum: "sha256:mno5".to_string(),
-            installed_at: ".claude/ccpm/hooks/hook1.json".to_string(),
+            installed_at: ".claude/agpm/hooks/hook1.json".to_string(),
             dependencies: vec![],
             resource_type: crate::core::ResourceType::Hook,
         });
@@ -525,7 +525,7 @@ mod tests {
             version: Some("v1.0.0".to_string()),
             resolved_commit: Some("pqr678".to_string()),
             checksum: "sha256:pqr6".to_string(),
-            installed_at: ".claude/ccpm/mcp-servers/mcp1.json".to_string(),
+            installed_at: ".claude/agpm/mcp-servers/mcp1.json".to_string(),
             dependencies: vec![],
             resource_type: crate::core::ResourceType::McpServer,
         });
@@ -539,7 +539,7 @@ mod tests {
             version: None,
             resolved_commit: None,
             checksum: "sha256:local".to_string(),
-            installed_at: ".claude/ccpm/snippets/local-snippet.md".to_string(),
+            installed_at: ".claude/agpm/snippets/local-snippet.md".to_string(),
             dependencies: vec![],
             resource_type: crate::core::ResourceType::Snippet,
         });
@@ -622,7 +622,7 @@ mod tests {
         assert_eq!(entries[0].1, ".claude/agents");
 
         assert_eq!(entries[1].0.name, "test-snippet");
-        assert_eq!(entries[1].1, ".claude/ccpm/snippets");
+        assert_eq!(entries[1].1, ".claude/agpm/snippets");
     }
 
     #[test]
@@ -1089,7 +1089,7 @@ mod tests {
         );
         assert_eq!(
             ResourceType::Snippet.get_target_dir(targets),
-            ".claude/ccpm/snippets"
+            ".claude/agpm/snippets"
         );
         assert_eq!(
             ResourceType::Command.get_target_dir(targets),
@@ -1097,15 +1097,15 @@ mod tests {
         );
         assert_eq!(
             ResourceType::Script.get_target_dir(targets),
-            ".claude/ccpm/scripts"
+            ".claude/agpm/scripts"
         );
         assert_eq!(
             ResourceType::Hook.get_target_dir(targets),
-            ".claude/ccpm/hooks"
+            ".claude/agpm/hooks"
         );
         assert_eq!(
             ResourceType::McpServer.get_target_dir(targets),
-            ".claude/ccpm/mcp-servers"
+            ".claude/agpm/mcp-servers"
         );
     }
 }

--- a/src/core/resource_iterator.rs
+++ b/src/core/resource_iterator.rs
@@ -24,7 +24,7 @@ use crate::lockfile::{LockFile, LockedResource};
 use crate::manifest::{Manifest, ResourceDependency, TargetConfig};
 use std::collections::HashMap;
 
-/// Extension trait for ResourceType that adds lockfile and manifest operations
+/// Extension trait for `ResourceType` that adds lockfile and manifest operations
 ///
 /// This trait extends the base [`ResourceType`] enum with methods for working with
 /// lockfiles and manifests in a type-safe way. It provides the foundation for
@@ -99,23 +99,23 @@ pub trait ResourceTypeExt {
 impl ResourceTypeExt for ResourceType {
     fn all() -> Vec<ResourceType> {
         vec![
-            ResourceType::Agent,
-            ResourceType::Snippet,
-            ResourceType::Command,
-            ResourceType::McpServer,
-            ResourceType::Script,
-            ResourceType::Hook,
+            Self::Agent,
+            Self::Snippet,
+            Self::Command,
+            Self::McpServer,
+            Self::Script,
+            Self::Hook,
         ]
     }
 
     fn get_lockfile_entries<'a>(&self, lockfile: &'a LockFile) -> &'a [LockedResource] {
         match self {
-            ResourceType::Agent => &lockfile.agents,
-            ResourceType::Snippet => &lockfile.snippets,
-            ResourceType::Command => &lockfile.commands,
-            ResourceType::Script => &lockfile.scripts,
-            ResourceType::Hook => &lockfile.hooks,
-            ResourceType::McpServer => &lockfile.mcp_servers,
+            Self::Agent => &lockfile.agents,
+            Self::Snippet => &lockfile.snippets,
+            Self::Command => &lockfile.commands,
+            Self::Script => &lockfile.scripts,
+            Self::Hook => &lockfile.hooks,
+            Self::McpServer => &lockfile.mcp_servers,
         }
     }
 
@@ -124,23 +124,23 @@ impl ResourceTypeExt for ResourceType {
         lockfile: &'a mut LockFile,
     ) -> &'a mut Vec<LockedResource> {
         match self {
-            ResourceType::Agent => &mut lockfile.agents,
-            ResourceType::Snippet => &mut lockfile.snippets,
-            ResourceType::Command => &mut lockfile.commands,
-            ResourceType::Script => &mut lockfile.scripts,
-            ResourceType::Hook => &mut lockfile.hooks,
-            ResourceType::McpServer => &mut lockfile.mcp_servers,
+            Self::Agent => &mut lockfile.agents,
+            Self::Snippet => &mut lockfile.snippets,
+            Self::Command => &mut lockfile.commands,
+            Self::Script => &mut lockfile.scripts,
+            Self::Hook => &mut lockfile.hooks,
+            Self::McpServer => &mut lockfile.mcp_servers,
         }
     }
 
     fn get_target_dir<'a>(&self, targets: &'a TargetConfig) -> &'a str {
         match self {
-            ResourceType::Agent => targets.agents.as_str(),
-            ResourceType::Snippet => targets.snippets.as_str(),
-            ResourceType::Command => targets.commands.as_str(),
-            ResourceType::Script => targets.scripts.as_str(),
-            ResourceType::Hook => targets.hooks.as_str(),
-            ResourceType::McpServer => targets.mcp_servers.as_str(),
+            Self::Agent => targets.agents.as_str(),
+            Self::Snippet => targets.snippets.as_str(),
+            Self::Command => targets.commands.as_str(),
+            Self::Script => targets.scripts.as_str(),
+            Self::Hook => targets.hooks.as_str(),
+            Self::McpServer => targets.mcp_servers.as_str(),
         }
     }
 
@@ -149,12 +149,12 @@ impl ResourceTypeExt for ResourceType {
         manifest: &'a Manifest,
     ) -> &'a HashMap<String, ResourceDependency> {
         match self {
-            ResourceType::Agent => &manifest.agents,
-            ResourceType::Snippet => &manifest.snippets,
-            ResourceType::Command => &manifest.commands,
-            ResourceType::Script => &manifest.scripts,
-            ResourceType::Hook => &manifest.hooks,
-            ResourceType::McpServer => &manifest.mcp_servers,
+            Self::Agent => &manifest.agents,
+            Self::Snippet => &manifest.snippets,
+            Self::Command => &manifest.commands,
+            Self::Script => &manifest.scripts,
+            Self::Hook => &manifest.hooks,
+            Self::McpServer => &manifest.mcp_servers,
         }
     }
 }
@@ -251,7 +251,7 @@ impl ResourceIterator {
         lockfile: &'a LockFile,
         name: &str,
     ) -> Option<(ResourceType, &'a LockedResource)> {
-        for resource_type in ResourceType::all().iter() {
+        for resource_type in ResourceType::all() {
             if let Some(entry) = resource_type
                 .get_lockfile_entries(lockfile)
                 .iter()
@@ -280,7 +280,7 @@ impl ResourceIterator {
         name: &str,
         source: Option<&str>,
     ) -> Option<(ResourceType, &'a LockedResource)> {
-        for resource_type in ResourceType::all().iter() {
+        for resource_type in ResourceType::all() {
             if let Some(entry) = resource_type
                 .get_lockfile_entries(lockfile)
                 .iter()
@@ -344,7 +344,7 @@ impl ResourceIterator {
     where
         F: FnMut(ResourceType, &LockedResource),
     {
-        for resource_type in ResourceType::all().iter() {
+        for resource_type in ResourceType::all() {
             for entry in resource_type.get_lockfile_entries(lockfile) {
                 f(*resource_type, entry);
             }

--- a/src/git/command_builder.rs
+++ b/src/git/command_builder.rs
@@ -10,13 +10,13 @@ use std::time::Duration;
 use tokio::process::Command;
 use tokio::time::timeout;
 
-use crate::core::CcpmError;
+use crate::core::AgpmError;
 use crate::utils::platform::get_git_command;
 
 /// Type-safe builder for constructing and executing Git commands with consistent error handling.
 ///
 /// This builder provides a fluent API for Git command construction that ensures
-/// consistent behavior across CCPM's Git operations. It handles platform-specific
+/// consistent behavior across AGPM's Git operations. It handles platform-specific
 /// differences, timeout management, error context, and output capture in a unified way.
 ///
 /// # Features
@@ -31,7 +31,7 @@ use crate::utils::platform::get_git_command;
 /// # Examples
 ///
 /// ```rust,ignore
-/// use ccpm::git::command_builder::GitCommand;
+/// use agpm::git::command_builder::GitCommand;
 /// use std::path::Path;
 ///
 /// # async fn example() -> anyhow::Result<()> {
@@ -121,7 +121,7 @@ impl GitCommand {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// use ccpm::git::command_builder::GitCommand;
+    /// use agpm::git::command_builder::GitCommand;
     ///
     /// let cmd = GitCommand::new()
     ///     .args(["status", "--short"])
@@ -144,7 +144,7 @@ impl GitCommand {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// use ccpm::git::command_builder::GitCommand;
+    /// use agpm::git::command_builder::GitCommand;
     /// use std::path::Path;
     ///
     /// let cmd = GitCommand::new()
@@ -175,7 +175,7 @@ impl GitCommand {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// use ccpm::git::command_builder::GitCommand;
+    /// use agpm::git::command_builder::GitCommand;
     ///
     /// let cmd = GitCommand::new()
     ///     .arg("clone")
@@ -206,7 +206,7 @@ impl GitCommand {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// use ccpm::git::command_builder::GitCommand;
+    /// use agpm::git::command_builder::GitCommand;
     ///
     /// // Using array literals
     /// let cmd = GitCommand::new()
@@ -244,7 +244,7 @@ impl GitCommand {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// use ccpm::git::command_builder::GitCommand;
+    /// use agpm::git::command_builder::GitCommand;
     ///
     /// // Set Git configuration for this command only
     /// let cmd = GitCommand::new()
@@ -285,7 +285,7 @@ impl GitCommand {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::git::command_builder::GitCommand;
+    /// use agpm::git::command_builder::GitCommand;
     ///
     /// // Interactive merge that may require user input
     /// # async fn example() -> anyhow::Result<()> {
@@ -333,7 +333,7 @@ impl GitCommand {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::git::command_builder::GitCommand;
+    /// use agpm::git::command_builder::GitCommand;
     ///
     /// # async fn example() -> anyhow::Result<()> {
     /// let output = GitCommand::fetch()
@@ -437,7 +437,7 @@ impl GitCommand {
                                 .cloned()
                                 .unwrap_or_else(|| "unknown".to_string())
                         };
-                    return Err(CcpmError::GitCommandError {
+                    return Err(AgpmError::GitCommandError {
                         operation: git_operation,
                         stderr: format!(
                             "Git command timed out after {} seconds. This may indicate:\n\
@@ -488,19 +488,19 @@ impl GitCommand {
 
             let error = if effective_args.first().is_some_and(|arg| arg == "clone") {
                 let url = effective_args.get(2).cloned().unwrap_or_default();
-                CcpmError::GitCloneFailed {
+                AgpmError::GitCloneFailed {
                     url,
                     reason: stderr.to_string(),
                 }
             } else if effective_args.first().is_some_and(|arg| arg == "checkout") {
                 let reference = effective_args.get(1).cloned().unwrap_or_default();
-                CcpmError::GitCheckoutFailed {
+                AgpmError::GitCheckoutFailed {
                     reference,
                     reason: stderr.to_string(),
                 }
             } else if effective_args.first().is_some_and(|arg| arg == "worktree") {
                 let subcommand = effective_args.get(1).cloned().unwrap_or_default();
-                CcpmError::GitCommandError {
+                AgpmError::GitCommandError {
                     operation: format!("worktree {}", subcommand),
                     stderr: if stderr.is_empty() {
                         stdout.to_string()
@@ -509,7 +509,7 @@ impl GitCommand {
                     },
                 }
             } else {
-                CcpmError::GitCommandError {
+                AgpmError::GitCommandError {
                     operation: effective_args
                         .first()
                         .cloned()
@@ -724,7 +724,7 @@ impl GitCommand {
     ///
     /// Bare repositories are optimized for use as a source for worktrees,
     /// allowing multiple concurrent checkouts without conflicts. This is
-    /// the preferred method for parallel operations in CCPM.
+    /// the preferred method for parallel operations in AGPM.
     ///
     /// # Arguments
     ///
@@ -738,7 +738,7 @@ impl GitCommand {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::git::command_builder::GitCommand;
+    /// use agpm::git::command_builder::GitCommand;
     ///
     /// # async fn example() -> anyhow::Result<()> {
     /// GitCommand::clone_bare(
@@ -757,7 +757,7 @@ impl GitCommand {
     /// with [`worktree_add`](#method.worktree_add) for parallel operations:
     ///
     /// ```rust,no_run
-    /// use ccpm::git::command_builder::GitCommand;
+    /// use agpm::git::command_builder::GitCommand;
     ///
     /// # async fn worktree_example() -> anyhow::Result<()> {
     /// // Clone bare repository
@@ -829,7 +829,7 @@ impl GitCommand {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::git::command_builder::GitCommand;
+    /// use agpm::git::command_builder::GitCommand;
     ///
     /// # async fn example() -> anyhow::Result<()> {
     /// // Create worktree with specific version
@@ -849,7 +849,7 @@ impl GitCommand {
     ///
     /// # Concurrency Control
     ///
-    /// CCPM uses a global semaphore to limit concurrent Git operations and
+    /// AGPM uses a global semaphore to limit concurrent Git operations and
     /// prevent resource exhaustion. This is handled automatically by the
     /// cache layer when using worktrees for parallel installations.
     ///
@@ -893,7 +893,7 @@ impl GitCommand {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::git::command_builder::GitCommand;
+    /// use agpm::git::command_builder::GitCommand;
     ///
     /// # async fn example() -> anyhow::Result<()> {
     /// // Remove a worktree
@@ -912,7 +912,7 @@ impl GitCommand {
     /// - Files are locked or in use
     /// - The worktree directory structure has been modified
     ///
-    /// This is appropriate for CCPM's use case where worktrees are temporary
+    /// This is appropriate for AGPM's use case where worktrees are temporary
     /// and any local changes should be discarded.
     ///
     /// [`worktree_add`]: #method.worktree_add
@@ -951,7 +951,7 @@ impl GitCommand {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::git::command_builder::GitCommand;
+    /// use agpm::git::command_builder::GitCommand;
     ///
     /// # async fn example() -> anyhow::Result<()> {
     /// let output = GitCommand::worktree_list()
@@ -994,7 +994,7 @@ impl GitCommand {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::git::command_builder::GitCommand;
+    /// use agpm::git::command_builder::GitCommand;
     ///
     /// # async fn example() -> anyhow::Result<()> {
     /// // Clean up stale worktree references

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,14 +1,14 @@
-//! Git operations wrapper for CCPM
+//! Git operations wrapper for AGPM
 //!
 //! This module provides a safe, async wrapper around the system `git` command, serving as
-//! the foundation for CCPM's distributed package management capabilities. Unlike libraries
+//! the foundation for AGPM's distributed package management capabilities. Unlike libraries
 //! that use embedded Git implementations (like `libgit2`), this module leverages the system's
 //! installed Git binary to ensure maximum compatibility with existing Git configurations,
 //! authentication methods, and platform-specific optimizations.
 //!
 //! # Design Philosophy: CLI-Based Git Integration
 //!
-//! CCPM follows the same approach as Cargo with `git-fetch-with-cli`, using the system's
+//! AGPM follows the same approach as Cargo with `git-fetch-with-cli`, using the system's
 //! `git` command rather than an embedded Git library. This design choice provides several
 //! critical advantages:
 //!
@@ -89,7 +89,7 @@
 //!
 //! # Error Handling Strategy
 //!
-//! The module provides rich error context through [`CcpmError`] variants:
+//! The module provides rich error context through [`AgpmError`] variants:
 //! - Network failures with retry suggestions
 //! - Authentication errors with configuration guidance
 //! - Repository format errors with recovery steps
@@ -99,7 +99,7 @@
 //!
 //! ## Basic Repository Operations
 //! ```rust,no_run
-//! use ccpm::git::GitRepo;
+//! use agpm::git::GitRepo;
 //! use std::env;
 //!
 //! # async fn example() -> anyhow::Result<()> {
@@ -128,7 +128,7 @@
 //!
 //! ## Authentication with URLs
 //! ```rust,no_run
-//! use ccpm::git::GitRepo;
+//! use agpm::git::GitRepo;
 //! use std::env;
 //!
 //! # async fn auth_example() -> anyhow::Result<()> {
@@ -151,7 +151,7 @@
 //!
 //! ## Repository Validation
 //! ```rust,no_run
-//! use ccpm::git::{GitRepo, ensure_git_available, is_valid_git_repo};
+//! use agpm::git::{GitRepo, ensure_git_available, is_valid_git_repo};
 //! use std::env;
 //!
 //! # async fn validation_example() -> anyhow::Result<()> {
@@ -175,7 +175,7 @@
 //!
 //! ## Worktree-based Parallel Operations
 //! ```rust,no_run
-//! use ccpm::git::GitRepo;
+//! use agpm::git::GitRepo;
 //! use std::env;
 //!
 //! # async fn worktree_example() -> anyhow::Result<()> {
@@ -230,22 +230,22 @@
 //! - Supports various credential helpers
 //! - Handles different filesystem permissions
 //!
-//! # Integration with CCPM
+//! # Integration with AGPM
 //!
-//! This module integrates with other CCPM components:
+//! This module integrates with other AGPM components:
 //! - [`crate::source`] - Repository source management
 //! - [`crate::manifest`] - Manifest-based dependency resolution
 //! - [`crate::lockfile`] - Lockfile generation with commit hashes
 //! - [`crate::utils::progress`] - User progress feedback
-//! - [`crate::core::CcpmError`] - Centralized error handling
+//! - [`crate::core::AgpmError`] - Centralized error handling
 //!
-//! [`CcpmError`]: crate::core::CcpmError
+//! [`AgpmError`]: crate::core::AgpmError
 
 pub mod command_builder;
 #[cfg(test)]
 mod tests;
 
-use crate::core::CcpmError;
+use crate::core::AgpmError;
 use crate::git::command_builder::GitCommand;
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
@@ -274,7 +274,7 @@ use std::path::{Path, PathBuf};
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::git::GitRepo;
+/// use agpm::git::GitRepo;
 /// use std::path::Path;
 ///
 /// # async fn example() -> anyhow::Result<()> {
@@ -318,7 +318,7 @@ impl GitRepo {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::git::GitRepo;
+    /// use agpm::git::GitRepo;
     /// use std::path::Path;
     ///
     /// // Create repository handle
@@ -369,7 +369,7 @@ impl GitRepo {
     /// # Examples
     ///
     /// ```ignore
-    /// use ccpm::git::GitRepo;
+    /// use agpm::git::GitRepo;
     /// use std::env;
     ///
     /// # async fn example() -> anyhow::Result<()> {
@@ -392,7 +392,7 @@ impl GitRepo {
     ///
     /// # Errors
     ///
-    /// Returns [`CcpmError::GitCloneFailed`] if:
+    /// Returns [`AgpmError::GitCloneFailed`] if:
     /// - The URL is invalid or unreachable
     /// - Authentication fails
     /// - The target directory already exists and is not empty
@@ -404,7 +404,7 @@ impl GitRepo {
     /// URLs are validated and sanitized before passing to Git. Authentication
     /// tokens in URLs are never logged or exposed in error messages.
     ///
-    /// [`CcpmError::GitCloneFailed`]: crate::core::CcpmError::GitCloneFailed
+    /// [`AgpmError::GitCloneFailed`]: crate::core::AgpmError::GitCloneFailed
     pub async fn clone(url: &str, target: impl AsRef<Path>) -> Result<Self> {
         let target_path = target.as_ref();
 
@@ -457,7 +457,7 @@ impl GitRepo {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::git::GitRepo;
+    /// use agpm::git::GitRepo;
     /// use std::env;
     ///
     /// # async fn example() -> anyhow::Result<()> {
@@ -477,7 +477,7 @@ impl GitRepo {
     ///
     /// # Errors
     ///
-    /// Returns [`CcpmError::GitCommandError`] if:
+    /// Returns [`AgpmError::GitCommandError`] if:
     /// - Network connectivity fails
     /// - Authentication is rejected
     /// - The remote repository is unavailable
@@ -490,7 +490,7 @@ impl GitRepo {
     /// - Provide progress feedback for large transfers
     /// - Use efficient Git transfer protocols
     ///
-    /// [`CcpmError::GitCommandError`]: crate::core::CcpmError::GitCommandError
+    /// [`AgpmError::GitCommandError`]: crate::core::AgpmError::GitCommandError
     pub async fn fetch(&self, auth_url: Option<&str>) -> Result<()> {
         // Note: file:// URLs are local repositories, but we still need to fetch
         // from them to get updates from the source repository
@@ -547,7 +547,7 @@ impl GitRepo {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::git::GitRepo;
+    /// use agpm::git::GitRepo;
     ///
     /// # async fn example() -> anyhow::Result<()> {
     /// let repo = GitRepo::new("/path/to/repo");
@@ -571,12 +571,12 @@ impl GitRepo {
     ///
     /// **This operation discards uncommitted changes.** The hard reset before
     /// checkout ensures a clean state but will permanently lose any local
-    /// modifications. This behavior is intentional for CCPM's package management
+    /// modifications. This behavior is intentional for AGPM's package management
     /// use case where clean, reproducible states are required.
     ///
     /// # Errors
     ///
-    /// Returns [`CcpmError::GitCheckoutFailed`] if:
+    /// Returns [`AgpmError::GitCheckoutFailed`] if:
     /// - The reference doesn't exist in the repository
     /// - The repository is in an invalid state
     /// - File system permissions prevent checkout
@@ -589,7 +589,7 @@ impl GitRepo {
     /// - Minimal file system operations
     /// - Efficient handling of large repositories
     ///
-    /// [`CcpmError::GitCheckoutFailed`]: crate::core::CcpmError::GitCheckoutFailed
+    /// [`AgpmError::GitCheckoutFailed`]: crate::core::AgpmError::GitCheckoutFailed
     pub async fn checkout(&self, ref_name: &str) -> Result<()> {
         // Reset to clean state before checkout
         let reset_result = GitCommand::reset_hard()
@@ -633,12 +633,12 @@ impl GitRepo {
             .map_err(|e| {
                 // If it's already a GitCheckoutFailed error, return as-is
                 // Otherwise wrap it
-                if let Some(ccpm_err) = e.downcast_ref::<CcpmError>()
-                    && matches!(ccpm_err, CcpmError::GitCheckoutFailed { .. })
+                if let Some(ccpm_err) = e.downcast_ref::<AgpmError>()
+                    && matches!(ccpm_err, AgpmError::GitCheckoutFailed { .. })
                 {
                     return e;
                 }
-                CcpmError::GitCheckoutFailed {
+                AgpmError::GitCheckoutFailed {
                     reference: ref_name.to_string(),
                     reason: e.to_string(),
                 }
@@ -667,7 +667,7 @@ impl GitRepo {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::git::GitRepo;
+    /// use agpm::git::GitRepo;
     ///
     /// # async fn example() -> anyhow::Result<()> {
     /// let repo = GitRepo::new("/path/to/repo");
@@ -694,7 +694,7 @@ impl GitRepo {
     /// ```rust,no_run
     /// # use anyhow::Result;
     /// use semver::Version;
-    /// use ccpm::git::GitRepo;
+    /// use agpm::git::GitRepo;
     ///
     /// # async fn version_example() -> Result<()> {
     /// let repo = GitRepo::new("/path/to/repo");
@@ -713,7 +713,7 @@ impl GitRepo {
     ///
     /// # Errors
     ///
-    /// Returns [`CcpmError::GitCommandError`] if:
+    /// Returns [`AgpmError::GitCommandError`] if:
     /// - The repository path doesn't exist
     /// - The directory is not a valid Git repository
     /// - Git command execution fails
@@ -725,7 +725,7 @@ impl GitRepo {
     /// without network access. For repositories with thousands of tags,
     /// consider filtering or pagination if memory usage is a concern.
     ///
-    /// [`CcpmError::GitCommandError`]: crate::core::CcpmError::GitCommandError
+    /// [`AgpmError::GitCommandError`]: crate::core::AgpmError::GitCommandError
     pub async fn list_tags(&self) -> Result<Vec<String>> {
         // Check if the directory exists and is a git repo
         if !self.path.exists() {
@@ -777,7 +777,7 @@ impl GitRepo {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::git::GitRepo;
+    /// use agpm::git::GitRepo;
     ///
     /// # async fn example() -> anyhow::Result<()> {
     /// let repo = GitRepo::new("/path/to/repo");
@@ -799,7 +799,7 @@ impl GitRepo {
     /// For processing the URL further, consider using [`parse_git_url`]:
     ///
     /// ```rust,no_run
-    /// use ccpm::git::{GitRepo, parse_git_url};
+    /// use agpm::git::{GitRepo, parse_git_url};
     ///
     /// # async fn parse_example() -> anyhow::Result<()> {
     /// let repo = GitRepo::new("/path/to/repo");
@@ -814,7 +814,7 @@ impl GitRepo {
     ///
     /// # Errors
     ///
-    /// Returns [`CcpmError::GitCommandError`] if:
+    /// Returns [`AgpmError::GitCommandError`] if:
     /// - No 'origin' remote is configured
     /// - The repository is not a valid Git repository
     /// - Git command execution fails
@@ -827,7 +827,7 @@ impl GitRepo {
     /// that might contain sensitive tokens or credentials.
     ///
     /// [`parse_git_url`]: fn.parse_git_url.html
-    /// [`CcpmError::GitCommandError`]: crate::core::CcpmError::GitCommandError
+    /// [`AgpmError::GitCommandError`]: crate::core::AgpmError::GitCommandError
     pub async fn get_remote_url(&self) -> Result<String> {
         GitCommand::remote_url()
             .current_dir(&self.path)
@@ -844,7 +844,7 @@ impl GitRepo {
     /// This method is intentionally synchronous and lightweight for efficiency.\n    /// It performs at most two filesystem checks without spawning async tasks or\n    /// executing Git commands.\n    ///
     /// # Examples\n    ///
     /// ```rust,no_run
-    /// use ccpm::git::GitRepo;
+    /// use agpm::git::GitRepo;
     ///
     /// // Regular repository
     /// let repo = GitRepo::new("/path/to/regular/repo");
@@ -884,7 +884,7 @@ impl GitRepo {
     /// For error-based validation with detailed context, use [`ensure_valid_git_repo`]:
     ///
     /// ```rust,no_run
-    /// use ccpm::git::ensure_valid_git_repo;
+    /// use agpm::git::ensure_valid_git_repo;
     /// use std::path::Path;
     ///
     /// # fn example() -> anyhow::Result<()> {
@@ -913,7 +913,7 @@ impl GitRepo {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::git::GitRepo;
+    /// use agpm::git::GitRepo;
     /// use std::path::Path;
     ///
     /// let repo = GitRepo::new("/home/user/my-project");
@@ -934,7 +934,7 @@ impl GitRepo {
     /// The returned path can be used for various filesystem operations:
     ///
     /// ```rust,no_run
-    /// use ccpm::git::GitRepo;
+    /// use agpm::git::GitRepo;
     ///
     /// # fn example() -> std::io::Result<()> {
     /// let repo = GitRepo::new("/path/to/repo");
@@ -993,7 +993,7 @@ impl GitRepo {
     /// # Examples
     ///
     /// ```ignore
-    /// use ccpm::git::GitRepo;
+    /// use agpm::git::GitRepo;
     ///
     /// # async fn example() -> anyhow::Result<()> {
     /// // Verify public repository
@@ -1123,7 +1123,7 @@ impl GitRepo {
     /// # Examples
     ///
     /// ```ignore
-    /// use ccpm::git::GitRepo;
+    /// use agpm::git::GitRepo;
     /// use std::env;
     ///
     /// # async fn example() -> anyhow::Result<()> {
@@ -1209,7 +1209,7 @@ impl GitRepo {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::git::GitRepo;
+    /// use agpm::git::GitRepo;
     ///
     /// # async fn example() -> anyhow::Result<()> {
     /// let bare_repo = GitRepo::new("/path/to/bare.git");
@@ -1515,7 +1515,7 @@ impl GitRepo {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::git::GitRepo;
+    /// use agpm::git::GitRepo;
     ///
     /// # async fn example() -> anyhow::Result<()> {
     /// let bare_repo = GitRepo::new("/path/to/bare.git");
@@ -1547,7 +1547,7 @@ impl GitRepo {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::git::GitRepo;
+    /// use agpm::git::GitRepo;
     ///
     /// # async fn example() -> anyhow::Result<()> {
     /// let bare_repo = GitRepo::new("/path/to/bare.git");
@@ -1599,7 +1599,7 @@ impl GitRepo {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::git::GitRepo;
+    /// use agpm::git::GitRepo;
     ///
     /// # async fn example() -> anyhow::Result<()> {
     /// let bare_repo = GitRepo::new("/path/to/bare.git");
@@ -1625,7 +1625,7 @@ impl GitRepo {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::git::GitRepo;
+    /// use agpm::git::GitRepo;
     ///
     /// # async fn example() -> anyhow::Result<()> {
     /// let repo = GitRepo::new("/path/to/repo.git");
@@ -1664,7 +1664,7 @@ impl GitRepo {
     /// # Examples
     ///
     /// ```no_run
-    /// # use ccpm::git::GitRepo;
+    /// # use agpm::git::GitRepo;
     /// # async fn example() -> anyhow::Result<()> {
     /// let repo = GitRepo::new("/path/to/repo");
     /// let commit = repo.get_current_commit().await?;
@@ -1682,7 +1682,7 @@ impl GitRepo {
 
     /// Resolves a Git reference (tag, branch, commit) to its full SHA-1 hash.
     ///
-    /// This method is central to CCPM's optimization strategy - by resolving all
+    /// This method is central to AGPM's optimization strategy - by resolving all
     /// version specifications to SHAs upfront, we can:
     /// - Create worktrees keyed by SHA for maximum reuse
     /// - Avoid redundant checkouts for the same commit
@@ -1709,7 +1709,7 @@ impl GitRepo {
     /// # Examples
     ///
     /// ```no_run
-    /// # use ccpm::git::GitRepo;
+    /// # use agpm::git::GitRepo;
     /// # async fn example() -> anyhow::Result<()> {
     /// let repo = GitRepo::new("/path/to/repo");
     ///
@@ -1842,7 +1842,7 @@ impl GitRepo {
 ///
 /// This function verifies that the system's `git` command is available in the PATH
 /// and responds to version queries. It's a prerequisite check for all Git operations
-/// in CCPM.
+/// in AGPM.
 ///
 /// # Return Value
 ///
@@ -1863,7 +1863,7 @@ impl GitRepo {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::git::is_git_installed;
+/// use agpm::git::is_git_installed;
 ///
 /// if is_git_installed() {
 ///     println!("Git is available - proceeding with repository operations");
@@ -1873,7 +1873,7 @@ impl GitRepo {
 /// }
 /// ```
 ///
-/// # Usage in CCPM
+/// # Usage in AGPM
 ///
 /// This function is typically called during:
 /// - Application startup to validate prerequisites
@@ -1885,10 +1885,10 @@ impl GitRepo {
 /// For error-based validation with detailed context, use [`ensure_git_available()`]:
 ///
 /// ```rust,no_run
-/// use ccpm::git::ensure_git_available;
+/// use agpm::git::ensure_git_available;
 ///
 /// # fn example() -> anyhow::Result<()> {
-/// ensure_git_available()?; // Throws CcpmError::GitNotFound if not available
+/// ensure_git_available()?; // Throws AgpmError::GitNotFound if not available
 /// # Ok(())
 /// # }
 /// ```
@@ -1908,13 +1908,13 @@ pub fn is_git_installed() -> bool {
 /// Ensures Git is available on the system or returns a detailed error.
 ///
 /// This function validates that Git is installed and accessible, providing a
-/// [`CcpmError::GitNotFound`] with actionable guidance if Git is unavailable.
+/// [`AgpmError::GitNotFound`] with actionable guidance if Git is unavailable.
 /// It's the error-throwing equivalent of [`is_git_installed()`].
 ///
 /// # Return Value
 ///
 /// - `Ok(())` if Git is properly installed and accessible
-/// - `Err(CcpmError::GitNotFound)` if Git is not available
+/// - `Err(AgpmError::GitNotFound)` if Git is not available
 ///
 /// # Error Context
 ///
@@ -1926,7 +1926,7 @@ pub fn is_git_installed() -> bool {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::git::ensure_git_available;
+/// use agpm::git::ensure_git_available;
 ///
 /// # fn example() -> anyhow::Result<()> {
 /// // Validate Git before starting operations
@@ -1941,13 +1941,13 @@ pub fn is_git_installed() -> bool {
 /// # Error Handling
 ///
 /// ```rust,no_run
-/// use ccpm::git::ensure_git_available;
-/// use ccpm::core::CcpmError;
+/// use agpm::git::ensure_git_available;
+/// use agpm::core::AgpmError;
 ///
 /// match ensure_git_available() {
 ///     Ok(_) => println!("Git is ready"),
 ///     Err(e) => {
-///         if let Some(CcpmError::GitNotFound) = e.downcast_ref::<CcpmError>() {
+///         if let Some(AgpmError::GitNotFound) = e.downcast_ref::<AgpmError>() {
 ///             eprintln!("Please install Git to continue");
 ///             // Show platform-specific installation instructions
 ///         }
@@ -1960,7 +1960,7 @@ pub fn is_git_installed() -> bool {
 /// Typically called at the start of Git-dependent operations:
 ///
 /// ```rust,no_run
-/// use ccpm::git::{ensure_git_available, GitRepo};
+/// use agpm::git::{ensure_git_available, GitRepo};
 /// use std::env;
 ///
 /// # async fn git_operation() -> anyhow::Result<()> {
@@ -1977,11 +1977,11 @@ pub fn is_git_installed() -> bool {
 /// # }
 /// ```
 ///
-/// [`CcpmError::GitNotFound`]: crate::core::CcpmError::GitNotFound
+/// [`AgpmError::GitNotFound`]: crate::core::AgpmError::GitNotFound
 /// [`is_git_installed()`]: fn.is_git_installed.html
 pub fn ensure_git_available() -> Result<()> {
     if !is_git_installed() {
-        return Err(CcpmError::GitNotFound.into());
+        return Err(AgpmError::GitNotFound.into());
     }
     Ok(())
 }
@@ -2005,7 +2005,7 @@ pub fn ensure_git_available() -> Result<()> {
 ///
 /// ```rust,no_run
 /// use std::path::Path;
-/// use ccpm::git::is_git_repository;
+/// use agpm::git::is_git_repository;
 ///
 /// // Check a regular repository
 /// let repo_path = Path::new("/path/to/repo");
@@ -2048,7 +2048,7 @@ pub fn is_git_repository(path: &Path) -> bool {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::git::is_valid_git_repo;
+/// use agpm::git::is_valid_git_repo;
 /// use std::path::Path;
 ///
 /// let path = Path::new("/home/user/my-project");
@@ -2070,7 +2070,7 @@ pub fn is_git_repository(path: &Path) -> bool {
 /// # Batch Processing Example
 ///
 /// ```rust,no_run
-/// use ccpm::git::is_valid_git_repo;
+/// use agpm::git::is_valid_git_repo;
 /// use std::fs;
 /// use std::path::Path;
 ///
@@ -2110,7 +2110,7 @@ pub fn is_valid_git_repo(path: &Path) -> bool {
 /// Ensures a directory contains a valid Git repository or returns a detailed error.
 ///
 /// This function validates that the specified path contains a Git repository,
-/// providing a [`CcpmError::GitRepoInvalid`] with actionable guidance if the
+/// providing a [`AgpmError::GitRepoInvalid`] with actionable guidance if the
 /// validation fails. It's the error-throwing equivalent of [`is_valid_git_repo()`].
 ///
 /// # Arguments
@@ -2120,7 +2120,7 @@ pub fn is_valid_git_repo(path: &Path) -> bool {
 /// # Return Value
 ///
 /// - `Ok(())` if the path contains a valid `.git` directory
-/// - `Err(CcpmError::GitRepoInvalid)` if the path is not a Git repository
+/// - `Err(AgpmError::GitRepoInvalid)` if the path is not a Git repository
 ///
 /// # Error Context
 ///
@@ -2132,7 +2132,7 @@ pub fn is_valid_git_repo(path: &Path) -> bool {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::git::ensure_valid_git_repo;
+/// use agpm::git::ensure_valid_git_repo;
 /// use std::path::Path;
 ///
 /// # fn example() -> anyhow::Result<()> {
@@ -2150,8 +2150,8 @@ pub fn is_valid_git_repo(path: &Path) -> bool {
 /// # Error Handling Pattern
 ///
 /// ```rust,no_run
-/// use ccpm::git::ensure_valid_git_repo;
-/// use ccpm::core::CcpmError;
+/// use agpm::git::ensure_valid_git_repo;
+/// use agpm::core::AgpmError;
 /// use std::path::Path;
 ///
 /// let path = Path::new("/some/directory");
@@ -2159,7 +2159,7 @@ pub fn is_valid_git_repo(path: &Path) -> bool {
 /// match ensure_valid_git_repo(path) {
 ///     Ok(_) => println!("Valid repository found"),
 ///     Err(e) => {
-///         if let Some(CcpmError::GitRepoInvalid { path }) = e.downcast_ref::<CcpmError>() {
+///         if let Some(AgpmError::GitRepoInvalid { path }) = e.downcast_ref::<AgpmError>() {
 ///             eprintln!("Directory {} is not a Git repository", path);
 ///             eprintln!("Try: git clone <url> {} or git init {}", path, path);
 ///         }
@@ -2172,7 +2172,7 @@ pub fn is_valid_git_repo(path: &Path) -> bool {
 /// This function provides validation before creating `GitRepo` instances:
 ///
 /// ```rust,no_run
-/// use ccpm::git::{ensure_valid_git_repo, GitRepo};
+/// use agpm::git::{ensure_valid_git_repo, GitRepo};
 /// use std::path::Path;
 ///
 /// # async fn validated_repo_operations() -> anyhow::Result<()> {
@@ -2195,11 +2195,11 @@ pub fn is_valid_git_repo(path: &Path) -> bool {
 /// - **Pipeline validation**: Fail fast in processing pipelines
 /// - **User feedback**: Give actionable error messages with suggestions
 ///
-/// [`CcpmError::GitRepoInvalid`]: crate::core::CcpmError::GitRepoInvalid
+/// [`AgpmError::GitRepoInvalid`]: crate::core::AgpmError::GitRepoInvalid
 /// [`is_valid_git_repo()`]: fn.is_valid_git_repo.html
 pub fn ensure_valid_git_repo(path: &Path) -> Result<()> {
     if !is_valid_git_repo(path) {
-        return Err(CcpmError::GitRepoInvalid {
+        return Err(AgpmError::GitRepoInvalid {
             path: path.display().to_string(),
         }
         .into());
@@ -2243,7 +2243,7 @@ pub fn ensure_valid_git_repo(path: &Path) -> Result<()> {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::git::parse_git_url;
+/// use agpm::git::parse_git_url;
 ///
 /// # fn example() -> anyhow::Result<()> {
 /// // Parse GitHub URL
@@ -2274,7 +2274,7 @@ pub fn ensure_valid_git_repo(path: &Path) -> Result<()> {
 /// # Cache Integration Example
 ///
 /// ```rust,no_run
-/// use ccpm::git::parse_git_url;
+/// use agpm::git::parse_git_url;
 /// use std::path::PathBuf;
 ///
 /// # fn cache_example() -> anyhow::Result<()> {
@@ -2282,12 +2282,12 @@ pub fn ensure_valid_git_repo(path: &Path) -> Result<()> {
 /// let (owner, repo) = parse_git_url(url)?;
 ///
 /// // Create cache directory path
-/// let cache_path = PathBuf::from("/home/user/.ccpm/cache")
+/// let cache_path = PathBuf::from("/home/user/.agpm/cache")
 ///     .join(&owner)
 ///     .join(&repo);
 ///     
 /// println!("Cache location: {}", cache_path.display());
-/// // Output: Cache location: /home/user/.ccpm/cache/rust-lang/cargo
+/// // Output: Cache location: /home/user/.agpm/cache/rust-lang/cargo
 /// # Ok(())
 /// # }
 /// ```
@@ -2298,7 +2298,7 @@ pub fn ensure_valid_git_repo(path: &Path) -> Result<()> {
 /// the repository components:
 ///
 /// ```rust,no_run
-/// use ccpm::git::parse_git_url;
+/// use agpm::git::parse_git_url;
 ///
 /// # fn auth_example() -> anyhow::Result<()> {
 /// // Authentication is ignored in parsing
@@ -2416,7 +2416,7 @@ pub fn parse_git_url(url: &str) -> Result<(String, String)> {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::git::strip_auth_from_url;
+/// use agpm::git::strip_auth_from_url;
 ///
 /// # fn example() -> anyhow::Result<()> {
 /// // Strip token from HTTPS URL
@@ -2437,7 +2437,7 @@ pub fn parse_git_url(url: &str) -> Result<(String, String)> {
 /// # Safe Logging Pattern
 ///
 /// ```rust,no_run
-/// use ccpm::git::strip_auth_from_url;
+/// use agpm::git::strip_auth_from_url;
 /// use anyhow::Result;
 ///
 /// fn log_repository_operation(url: &str, operation: &str) -> Result<()> {
@@ -2452,8 +2452,8 @@ pub fn parse_git_url(url: &str) -> Result<(String, String)> {
 /// # Error Context Integration
 ///
 /// ```rust,no_run
-/// use ccpm::git::strip_auth_from_url;
-/// use ccpm::core::CcpmError;
+/// use agpm::git::strip_auth_from_url;
+/// use agpm::core::AgpmError;
 ///
 /// # async fn operation_example(url: &str) -> anyhow::Result<()> {
 /// match some_git_operation(url).await {

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -633,8 +633,8 @@ impl GitRepo {
             .map_err(|e| {
                 // If it's already a GitCheckoutFailed error, return as-is
                 // Otherwise wrap it
-                if let Some(ccpm_err) = e.downcast_ref::<AgpmError>()
-                    && matches!(ccpm_err, AgpmError::GitCheckoutFailed { .. })
+                if let Some(agpm_err) = e.downcast_ref::<AgpmError>()
+                    && matches!(agpm_err, AgpmError::GitCheckoutFailed { .. })
                 {
                     return e;
                 }

--- a/src/git/tests.rs
+++ b/src/git/tests.rs
@@ -533,7 +533,7 @@ mod tests {
             .unwrap();
 
         Command::new("git")
-            .args(["config", "user.name", "CCPM Test"])
+            .args(["config", "user.name", "AGPM Test"])
             .current_dir(repo_path)
             .output()
             .unwrap();
@@ -684,7 +684,7 @@ mod tests {
             .unwrap();
 
         Command::new("git")
-            .args(["config", "user.name", "CCPM Test"])
+            .args(["config", "user.name", "AGPM Test"])
             .current_dir(repo_path)
             .output()
             .unwrap();
@@ -727,7 +727,7 @@ mod tests {
             .unwrap();
 
         Command::new("git")
-            .args(["config", "user.name", "CCPM Test"])
+            .args(["config", "user.name", "AGPM Test"])
             .current_dir(repo_path)
             .output()
             .unwrap();
@@ -1010,7 +1010,7 @@ mod tests {
             .unwrap();
 
         Command::new("git")
-            .args(["config", "user.name", "CCPM Test"])
+            .args(["config", "user.name", "AGPM Test"])
             .current_dir(repo_path)
             .output()
             .unwrap();

--- a/src/git/tests.rs
+++ b/src/git/tests.rs
@@ -527,7 +527,7 @@ mod tests {
             .unwrap();
 
         Command::new("git")
-            .args(["config", "user.email", "test@ccpm.test"])
+            .args(["config", "user.email", "test@agpm.test"])
             .current_dir(repo_path)
             .output()
             .unwrap();
@@ -611,7 +611,7 @@ mod tests {
             .unwrap();
 
         Command::new("git")
-            .args(["config", "user.email", "test@ccpm.test"])
+            .args(["config", "user.email", "test@agpm.test"])
             .current_dir(repo_path)
             .output()
             .unwrap();
@@ -678,7 +678,7 @@ mod tests {
             .unwrap();
 
         Command::new("git")
-            .args(["config", "user.email", "test@ccpm.test"])
+            .args(["config", "user.email", "test@agpm.test"])
             .current_dir(repo_path)
             .output()
             .unwrap();
@@ -721,7 +721,7 @@ mod tests {
             .unwrap();
 
         Command::new("git")
-            .args(["config", "user.email", "test@ccpm.test"])
+            .args(["config", "user.email", "test@agpm.test"])
             .current_dir(repo_path)
             .output()
             .unwrap();
@@ -775,7 +775,7 @@ mod tests {
             .unwrap();
 
         Command::new("git")
-            .args(["config", "user.email", "test@ccpm.test"])
+            .args(["config", "user.email", "test@agpm.test"])
             .current_dir(repo_path)
             .output()
             .unwrap();
@@ -946,7 +946,7 @@ mod tests {
             .unwrap();
 
         Command::new("git")
-            .args(["config", "user.email", "test@ccpm.test"])
+            .args(["config", "user.email", "test@agpm.test"])
             .current_dir(&repo_path)
             .output()
             .unwrap();
@@ -1004,7 +1004,7 @@ mod tests {
             .unwrap();
 
         Command::new("git")
-            .args(["config", "user.email", "test@ccpm.test"])
+            .args(["config", "user.email", "test@agpm.test"])
             .current_dir(repo_path)
             .output()
             .unwrap();

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -1962,35 +1962,35 @@ pub fn update_gitignore(lockfile: &LockFile, project_dir: &Path, enabled: bool) 
     add_resource_paths(&lockfile.mcp_servers);
 
     // Read existing gitignore if it exists
-    let mut before_ccpm_section = Vec::new();
-    let mut after_ccpm_section = Vec::new();
+    let mut before_agpm_section = Vec::new();
+    let mut after_agpm_section = Vec::new();
 
     if gitignore_path.exists() {
         let content = fs::read_to_string(&gitignore_path)
             .with_context(|| format!("Failed to read {}", gitignore_path.display()))?;
 
-        let mut in_ccpm_section = false;
-        let mut past_ccpm_section = false;
+        let mut in_agpm_section = false;
+        let mut past_agpm_section = false;
 
         for line in content.lines() {
             if line == "# AGPM managed entries - do not edit below this line" {
-                in_ccpm_section = true;
+                in_agpm_section = true;
                 continue;
             } else if line == "# End of AGPM managed entries" {
-                in_ccpm_section = false;
-                past_ccpm_section = true;
+                in_agpm_section = false;
+                past_agpm_section = true;
                 continue;
             }
 
-            if !in_ccpm_section && !past_ccpm_section {
+            if !in_agpm_section && !past_agpm_section {
                 // Preserve everything before AGPM section exactly as-is
-                before_ccpm_section.push(line.to_string());
-            } else if in_ccpm_section {
+                before_agpm_section.push(line.to_string());
+            } else if in_agpm_section {
                 // Skip existing AGPM entries (they'll be replaced)
                 continue;
             } else {
                 // Preserve everything after AGPM section exactly as-is
-                after_ccpm_section.push(line.to_string());
+                after_agpm_section.push(line.to_string());
             }
         }
     }
@@ -1999,13 +1999,13 @@ pub fn update_gitignore(lockfile: &LockFile, project_dir: &Path, enabled: bool) 
     let mut new_content = String::new();
 
     // Add everything before AGPM section exactly as it was
-    if !before_ccpm_section.is_empty() {
-        for line in &before_ccpm_section {
+    if !before_agpm_section.is_empty() {
+        for line in &before_agpm_section {
             new_content.push_str(line);
             new_content.push('\n');
         }
         // Add blank line before AGPM section if the previous content doesn't end with one
-        if !before_ccpm_section.is_empty() && !before_ccpm_section.last().unwrap().trim().is_empty()
+        if !before_agpm_section.is_empty() && !before_agpm_section.last().unwrap().trim().is_empty()
         {
             new_content.push('\n');
         }
@@ -2035,16 +2035,16 @@ pub fn update_gitignore(lockfile: &LockFile, project_dir: &Path, enabled: bool) 
     new_content.push_str("# End of AGPM managed entries\n");
 
     // Add everything after AGPM section exactly as it was
-    if !after_ccpm_section.is_empty() {
+    if !after_agpm_section.is_empty() {
         new_content.push('\n');
-        for line in &after_ccpm_section {
+        for line in &after_agpm_section {
             new_content.push_str(line);
             new_content.push('\n');
         }
     }
 
     // If this is a new file, add a basic header
-    if before_ccpm_section.is_empty() && after_ccpm_section.is_empty() {
+    if before_agpm_section.is_empty() && after_agpm_section.is_empty() {
         let mut default_content = String::new();
         default_content.push_str("# .gitignore - AGPM managed entries\n");
         default_content.push_str("# AGPM entries are automatically generated\n");

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -1,4 +1,4 @@
-//! Shared installation utilities for CCPM resources.
+//! Shared installation utilities for AGPM resources.
 //!
 //! This module provides common functionality for installing resources from
 //! lockfile entries to the project directory. It's shared between the install
@@ -59,7 +59,7 @@ use std::path::PathBuf;
 ///
 /// This type alias simplifies the return type of parallel installation functions
 /// that need to return either success information or error details with context.
-/// It was introduced in CCPM v0.3.0 to resolve clippy::type_complexity warnings
+/// It was introduced in AGPM v0.3.0 to resolve clippy::type_complexity warnings
 /// while maintaining clear semantics for installation results.
 ///
 /// # Success Variant: `Ok((String, bool, String))`
@@ -81,7 +81,7 @@ use std::path::PathBuf;
 /// individual resource results need to be collected and processed:
 ///
 /// ```rust,ignore
-/// use ccpm::installer::InstallResult;
+/// use agpm::installer::InstallResult;
 /// use futures::stream::{self, StreamExt};
 ///
 /// # async fn example() -> anyhow::Result<()> {
@@ -175,10 +175,10 @@ use std::fs;
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::installer::install_resource;
-/// use ccpm::lockfile::LockedResource;
-/// use ccpm::cache::Cache;
-/// use ccpm::core::ResourceType;
+/// use agpm::installer::install_resource;
+/// use agpm::lockfile::LockedResource;
+/// use agpm::cache::Cache;
+/// use agpm::core::ResourceType;
 /// use std::path::Path;
 ///
 /// # async fn example() -> anyhow::Result<()> {
@@ -264,7 +264,7 @@ pub async fn install_resource(
                 .as_deref()
                 .ok_or_else(|| {
                     anyhow::anyhow!(
-                        "Resource {} missing resolved commit SHA. Run 'ccpm update' to regenerate lockfile.",
+                        "Resource {} missing resolved commit SHA. Run 'agpm update' to regenerate lockfile.",
                         entry.name
                     )
                 })?;
@@ -386,11 +386,11 @@ pub async fn install_resource(
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::installer::install_resource_with_progress;
-/// use ccpm::lockfile::LockedResource;
-/// use ccpm::cache::Cache;
-/// use ccpm::core::ResourceType;
-/// use ccpm::utils::progress::ProgressBar;
+/// use agpm::installer::install_resource_with_progress;
+/// use agpm::lockfile::LockedResource;
+/// use agpm::cache::Cache;
+/// use agpm::core::ResourceType;
+/// use agpm::utils::progress::ProgressBar;
 /// use std::path::Path;
 ///
 /// # async fn example() -> anyhow::Result<()> {
@@ -489,16 +489,16 @@ pub async fn install_resource_with_progress(
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::installer::install_resources_parallel;
-/// use ccpm::lockfile::LockFile;
-/// use ccpm::manifest::Manifest;
-/// use ccpm::cache::Cache;
-/// use ccpm::utils::progress::ProgressBar;
+/// use agpm::installer::install_resources_parallel;
+/// use agpm::lockfile::LockFile;
+/// use agpm::manifest::Manifest;
+/// use agpm::cache::Cache;
+/// use agpm::utils::progress::ProgressBar;
 /// use std::path::Path;
 ///
 /// # async fn example() -> anyhow::Result<()> {
-/// let lockfile = LockFile::load(Path::new("ccpm.lock"))?;
-/// let manifest = Manifest::load(Path::new("ccpm.toml"))?;
+/// let lockfile = LockFile::load(Path::new("agpm.lock"))?;
+/// let manifest = Manifest::load(Path::new("agpm.toml"))?;
 /// let cache = Cache::new()?;
 ///
 /// // Count total resources for progress bar
@@ -699,9 +699,9 @@ pub async fn install_resources_parallel(
 ///
 /// ```rust,ignore
 /// use futures::stream::{self, StreamExt};
-/// use ccpm::installer::install_resource_for_parallel;
-/// # use ccpm::lockfile::LockedResource;
-/// # use ccpm::cache::Cache;
+/// use agpm::installer::install_resource_for_parallel;
+/// # use agpm::lockfile::LockedResource;
+/// # use agpm::cache::Cache;
 /// # use std::path::Path;
 ///
 /// # async fn example(entries: Vec<LockedResource>, cache: Cache) -> anyhow::Result<()> {
@@ -761,7 +761,7 @@ async fn install_resource_for_parallel(
 /// progress updates to user interface components:
 ///
 /// ```rust,no_run
-/// use ccpm::installer::InstallProgress;
+/// use agpm::installer::InstallProgress;
 /// use tokio::sync::mpsc;
 ///
 /// # async fn example() -> anyhow::Result<()> {
@@ -854,17 +854,17 @@ pub struct InstallProgress {
 /// # Channel-Based Architecture
 ///
 /// ```rust,ignore
-/// use ccpm::installer::{install_resources_parallel_with_progress, InstallProgress};
-/// use ccpm::lockfile::LockFile;
-/// use ccpm::manifest::Manifest;
-/// use ccpm::cache::Cache;
+/// use agpm::installer::{install_resources_parallel_with_progress, InstallProgress};
+/// use agpm::lockfile::LockFile;
+/// use agpm::manifest::Manifest;
+/// use agpm::cache::Cache;
 /// use tokio::sync::mpsc;
 /// use std::path::Path;
 ///
 /// # async fn example() -> anyhow::Result<()> {
 /// let (tx, mut rx) = mpsc::unbounded_channel::<InstallProgress>();
-/// let lockfile = LockFile::load(Path::new("ccpm.lock"))?;
-/// let manifest = Manifest::load(Path::new("ccpm.toml"))?;
+/// let lockfile = LockFile::load(Path::new("agpm.lock"))?;
+/// let manifest = Manifest::load(Path::new("agpm.toml"))?;
 /// let cache = Cache::new()?;
 ///
 /// // Spawn installation task
@@ -1108,7 +1108,7 @@ pub async fn install_resources_parallel_with_progress(
 ///
 /// Install all resources:
 /// ```rust,no_run
-/// use ccpm::installer::ResourceFilter;
+/// use agpm::installer::ResourceFilter;
 ///
 /// let filter = ResourceFilter::All;
 /// // This will install every resource in the lockfile
@@ -1116,7 +1116,7 @@ pub async fn install_resources_parallel_with_progress(
 ///
 /// Install only updated resources:
 /// ```rust,no_run
-/// use ccpm::installer::ResourceFilter;
+/// use agpm::installer::ResourceFilter;
 ///
 /// let updates = vec![
 ///     ("agent1".to_string(), None, "v1.0.0".to_string(), "v1.1.0".to_string()),
@@ -1159,7 +1159,7 @@ pub enum ResourceFilter {
 /// This function consolidates all resource installation patterns into a single, flexible
 /// interface that can handle both full installations and selective updates with different
 /// progress reporting mechanisms. It represents the modernized installation architecture
-/// introduced in CCPM v0.3.0.
+/// introduced in AGPM v0.3.0.
 ///
 /// # Architecture Benefits
 ///
@@ -1218,11 +1218,11 @@ pub enum ResourceFilter {
 ///
 /// Install all resources with progress tracking:
 /// ```rust,no_run
-/// use ccpm::installer::{install_resources, ResourceFilter};
-/// use ccpm::utils::progress::MultiPhaseProgress;
-/// use ccpm::lockfile::LockFile;
-/// use ccpm::manifest::Manifest;
-/// use ccpm::cache::Cache;
+/// use agpm::installer::{install_resources, ResourceFilter};
+/// use agpm::utils::progress::MultiPhaseProgress;
+/// use agpm::lockfile::LockFile;
+/// use agpm::manifest::Manifest;
+/// use agpm::cache::Cache;
 /// use std::sync::Arc;
 /// use std::path::Path;
 ///
@@ -1251,10 +1251,10 @@ pub enum ResourceFilter {
 ///
 /// Install resources quietly (for automation):
 /// ```rust,no_run
-/// use ccpm::installer::{install_resources, ResourceFilter};
-/// use ccpm::lockfile::LockFile;
-/// use ccpm::manifest::Manifest;
-/// use ccpm::cache::Cache;
+/// use agpm::installer::{install_resources, ResourceFilter};
+/// use agpm::lockfile::LockFile;
+/// use agpm::manifest::Manifest;
+/// use agpm::cache::Cache;
 /// use std::path::Path;
 ///
 /// # async fn example() -> anyhow::Result<()> {
@@ -1509,17 +1509,17 @@ pub async fn install_resources(
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::installer::install_resources_with_dynamic_progress;
-/// use ccpm::utils::progress::ProgressBar;
-/// use ccpm::lockfile::LockFile;
-/// use ccpm::manifest::Manifest;
-/// use ccpm::cache::Cache;
+/// use agpm::installer::install_resources_with_dynamic_progress;
+/// use agpm::utils::progress::ProgressBar;
+/// use agpm::lockfile::LockFile;
+/// use agpm::manifest::Manifest;
+/// use agpm::cache::Cache;
 /// use std::sync::Arc;
 /// use std::path::Path;
 ///
 /// # async fn example() -> anyhow::Result<()> {
-/// let lockfile = LockFile::load(Path::new("ccpm.lock"))?;
-/// let manifest = Manifest::load(Path::new("ccpm.toml"))?;
+/// let lockfile = LockFile::load(Path::new("agpm.lock"))?;
+/// let manifest = Manifest::load(Path::new("agpm.toml"))?;
 /// let cache = Cache::new()?;
 ///
 /// // Create dynamic progress manager
@@ -1743,16 +1743,16 @@ pub async fn install_resources_with_dynamic_progress(
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::installer::install_updated_resources;
-/// use ccpm::lockfile::LockFile;
-/// use ccpm::manifest::Manifest;
-/// use ccpm::cache::Cache;
-/// use ccpm::utils::progress::ProgressBar;
+/// use agpm::installer::install_updated_resources;
+/// use agpm::lockfile::LockFile;
+/// use agpm::manifest::Manifest;
+/// use agpm::cache::Cache;
+/// use agpm::utils::progress::ProgressBar;
 /// use std::path::Path;
 ///
 /// # async fn example() -> anyhow::Result<()> {
-/// let lockfile = LockFile::load(Path::new("ccpm.lock"))?;
-/// let manifest = Manifest::load(Path::new("ccpm.toml"))?;
+/// let lockfile = LockFile::load(Path::new("agpm.lock"))?;
+/// let manifest = Manifest::load(Path::new("agpm.toml"))?;
 /// let cache = Cache::new()?;
 /// let pb = ProgressBar::new(3);
 ///
@@ -1788,7 +1788,7 @@ pub async fn install_resources_with_dynamic_progress(
 ///
 /// # Integration with Update Command
 ///
-/// This function is typically used by the `ccpm update` command after dependency
+/// This function is typically used by the `agpm update` command after dependency
 /// resolution determines which resources have new versions available:
 ///
 /// ```text
@@ -1982,23 +1982,23 @@ pub fn update_gitignore(lockfile: &LockFile, project_dir: &Path, enabled: bool) 
         let mut past_ccpm_section = false;
 
         for line in content.lines() {
-            if line == "# CCPM managed entries - do not edit below this line" {
+            if line == "# AGPM managed entries - do not edit below this line" {
                 in_ccpm_section = true;
                 continue;
-            } else if line == "# End of CCPM managed entries" {
+            } else if line == "# End of AGPM managed entries" {
                 in_ccpm_section = false;
                 past_ccpm_section = true;
                 continue;
             }
 
             if !in_ccpm_section && !past_ccpm_section {
-                // Preserve everything before CCPM section exactly as-is
+                // Preserve everything before AGPM section exactly as-is
                 before_ccpm_section.push(line.to_string());
             } else if in_ccpm_section {
-                // Skip existing CCPM entries (they'll be replaced)
+                // Skip existing AGPM entries (they'll be replaced)
                 continue;
             } else {
-                // Preserve everything after CCPM section exactly as-is
+                // Preserve everything after AGPM section exactly as-is
                 after_ccpm_section.push(line.to_string());
             }
         }
@@ -2007,21 +2007,21 @@ pub fn update_gitignore(lockfile: &LockFile, project_dir: &Path, enabled: bool) 
     // Build the new content
     let mut new_content = String::new();
 
-    // Add everything before CCPM section exactly as it was
+    // Add everything before AGPM section exactly as it was
     if !before_ccpm_section.is_empty() {
         for line in &before_ccpm_section {
             new_content.push_str(line);
             new_content.push('\n');
         }
-        // Add blank line before CCPM section if the previous content doesn't end with one
+        // Add blank line before AGPM section if the previous content doesn't end with one
         if !before_ccpm_section.is_empty() && !before_ccpm_section.last().unwrap().trim().is_empty()
         {
             new_content.push('\n');
         }
     }
 
-    // Add CCPM managed section
-    new_content.push_str("# CCPM managed entries - do not edit below this line\n");
+    // Add AGPM managed section
+    new_content.push_str("# AGPM managed entries - do not edit below this line\n");
 
     // Convert paths to gitignore format (relative to project root)
     // Sort paths for consistent output
@@ -2041,9 +2041,9 @@ pub fn update_gitignore(lockfile: &LockFile, project_dir: &Path, enabled: bool) 
         new_content.push('\n');
     }
 
-    new_content.push_str("# End of CCPM managed entries\n");
+    new_content.push_str("# End of AGPM managed entries\n");
 
-    // Add everything after CCPM section exactly as it was
+    // Add everything after AGPM section exactly as it was
     if !after_ccpm_section.is_empty() {
         new_content.push('\n');
         for line in &after_ccpm_section {
@@ -2055,12 +2055,12 @@ pub fn update_gitignore(lockfile: &LockFile, project_dir: &Path, enabled: bool) 
     // If this is a new file, add a basic header
     if before_ccpm_section.is_empty() && after_ccpm_section.is_empty() {
         let mut default_content = String::new();
-        default_content.push_str("# .gitignore - CCPM managed entries\n");
-        default_content.push_str("# CCPM entries are automatically generated\n");
+        default_content.push_str("# .gitignore - AGPM managed entries\n");
+        default_content.push_str("# AGPM entries are automatically generated\n");
         default_content.push('\n');
-        default_content.push_str("# CCPM managed entries - do not edit below this line\n");
+        default_content.push_str("# AGPM managed entries - do not edit below this line\n");
 
-        // Add the CCPM paths
+        // Add the AGPM paths
         for path in &sorted_paths {
             let ignore_path = if path.starts_with("./") {
                 path.strip_prefix("./").unwrap_or(path).to_string()
@@ -2071,7 +2071,7 @@ pub fn update_gitignore(lockfile: &LockFile, project_dir: &Path, enabled: bool) 
             default_content.push('\n');
         }
 
-        default_content.push_str("# End of CCPM managed entries\n");
+        default_content.push_str("# End of AGPM managed entries\n");
         new_content = default_content;
     }
 
@@ -2086,7 +2086,7 @@ pub fn update_gitignore(lockfile: &LockFile, project_dir: &Path, enabled: bool) 
 ///
 /// This function performs automatic cleanup of obsolete resource files by comparing
 /// the old and new lockfiles. It identifies and removes artifacts that have been:
-/// - **Removed from manifest**: Dependencies deleted from `ccpm.toml`
+/// - **Removed from manifest**: Dependencies deleted from `agpm.toml`
 /// - **Relocated**: Files with changed `installed_at` paths due to:
 ///   - Relative path preservation (v0.3.18+)
 ///   - Custom target changes
@@ -2129,12 +2129,12 @@ pub fn update_gitignore(lockfile: &LockFile, project_dir: &Path, enabled: bool) 
 /// ## Basic Cleanup After Update
 ///
 /// ```no_run
-/// use ccpm::installer::cleanup_removed_artifacts;
-/// use ccpm::lockfile::LockFile;
+/// use agpm::installer::cleanup_removed_artifacts;
+/// use agpm::lockfile::LockFile;
 /// use std::path::Path;
 ///
 /// # async fn example() -> anyhow::Result<()> {
-/// let old_lockfile = LockFile::load(Path::new("ccpm.lock"))?;
+/// let old_lockfile = LockFile::load(Path::new("agpm.lock"))?;
 /// let new_lockfile = LockFile::new(); // After resolution
 /// let project_dir = Path::new(".");
 ///
@@ -2166,8 +2166,8 @@ pub fn update_gitignore(lockfile: &LockFile, project_dir: &Path, enabled: bool) 
 /// ## Cleanup After Dependency Removal
 ///
 /// ```no_run
-/// # use ccpm::installer::cleanup_removed_artifacts;
-/// # use ccpm::lockfile::{LockFile, LockedResource};
+/// # use agpm::installer::cleanup_removed_artifacts;
+/// # use agpm::lockfile::{LockFile, LockedResource};
 /// # use std::path::Path;
 /// # async fn removal_example() -> anyhow::Result<()> {
 /// // Old lockfile had 3 agents
@@ -2190,7 +2190,7 @@ pub fn update_gitignore(lockfile: &LockFile, project_dir: &Path, enabled: bool) 
 ///
 /// ## Integration with Install Command
 ///
-/// This function is automatically called during `ccpm install` when both old and
+/// This function is automatically called during `agpm install` when both old and
 /// new lockfiles exist:
 ///
 /// ```rust,ignore
@@ -2258,13 +2258,13 @@ pub fn update_gitignore(lockfile: &LockFile, project_dir: &Path, enabled: bool) 
 ///
 /// ## Manifest Cleanup
 ///
-/// Simply removing dependencies from `ccpm.toml` triggers automatic cleanup:
+/// Simply removing dependencies from `agpm.toml` triggers automatic cleanup:
 /// ```toml
 /// # Remove unwanted dependency
 /// [agents]
 /// # old-agent = { ... }  # Commented out or deleted
 /// ```
-/// The next `ccpm install` removes the old agent file automatically.
+/// The next `agpm install` removes the old agent file automatically.
 ///
 /// # Version History
 ///
@@ -2361,7 +2361,7 @@ pub async fn cleanup_removed_artifacts(
 /// ## Basic Directory Cleanup
 ///
 /// ```ignore
-/// # use ccpm::installer::cleanup_empty_dirs;
+/// # use agpm::installer::cleanup_empty_dirs;
 /// # use std::path::Path;
 /// # use std::fs;
 /// # async fn example() -> anyhow::Result<()> {
@@ -2790,7 +2790,7 @@ mod tests {
         assert!(project_dir.join(".claude/agents/test-agent.md").exists());
         assert!(
             project_dir
-                .join(".claude/ccpm/snippets/test-snippet.md")
+                .join(".claude/agpm/snippets/test-snippet.md")
                 .exists()
         );
         assert!(
@@ -2963,7 +2963,7 @@ mod tests {
 
         // Add snippet with installed path
         let mut snippet = create_test_locked_resource("test-snippet", true);
-        snippet.installed_at = ".claude/ccpm/snippets/test-snippet.md".to_string();
+        snippet.installed_at = ".claude/agpm/snippets/test-snippet.md".to_string();
         lockfile.snippets.push(snippet);
 
         // Call update_gitignore
@@ -2976,9 +2976,9 @@ mod tests {
 
         // Check content
         let content = std::fs::read_to_string(&gitignore_path).unwrap();
-        assert!(content.contains("CCPM managed entries"));
+        assert!(content.contains("AGPM managed entries"));
         assert!(content.contains(".claude/agents/test-agent.md"));
-        assert!(content.contains(".claude/ccpm/snippets/test-snippet.md"));
+        assert!(content.contains(".claude/agpm/snippets/test-snippet.md"));
     }
 
     #[tokio::test]
@@ -3014,9 +3014,9 @@ mod tests {
         let existing_content = "# User comment\n\
                                user-file.txt\n\
                                *.backup\n\
-                               # CCPM managed entries - do not edit below this line\n\
+                               # AGPM managed entries - do not edit below this line\n\
                                .claude/agents/old-entry.md\n\
-                               # End of CCPM managed entries\n";
+                               # End of AGPM managed entries\n";
         std::fs::write(&gitignore_path, existing_content).unwrap();
 
         // Create lockfile with new resources

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! CCPM - Claude Code Package Manager
+//! AGPM - Claude Code Package Manager
 //!
 //! A Git-based package manager for Claude Code resources (agents, snippets, commands,
 //! scripts, hooks, and MCP servers) that enables reproducible installations using
@@ -6,9 +6,9 @@
 //!
 //! # Architecture Overview
 //!
-//! CCPM follows a manifest/lockfile model where:
-//! - `ccpm.toml` defines desired dependencies and their version constraints
-//! - `ccpm.lock` records exact resolved versions for reproducible builds
+//! AGPM follows a manifest/lockfile model where:
+//! - `agpm.toml` defines desired dependencies and their version constraints
+//! - `agpm.lock` records exact resolved versions for reproducible builds
 //! - Resources are fetched directly from Git repositories (no central registry)
 //! - Pattern-based dependencies enable bulk installation of related resources
 //!
@@ -27,7 +27,7 @@
 //! ## Core Functionality
 //! - [`cache`] - Git repository caching and management for performance
 //! - [`cli`] - Command-line interface with comprehensive subcommands
-//! - [`config`] - Global (~/.ccpm/config.toml) and project configuration
+//! - [`config`] - Global (~/.agpm/config.toml) and project configuration
 //! - [`core`] - Core types, error handling, and resource abstractions
 //! - [`resolver`] - Dependency resolution, conflict detection, and version matching
 //!
@@ -36,8 +36,8 @@
 //! - [`source`] - Source repository operations and management
 //!
 //! ## Resource Management
-//! - [`lockfile`] - Lockfile generation, parsing, and validation (ccpm.lock)
-//! - [`manifest`] - Manifest parsing and validation (ccpm.toml)
+//! - [`lockfile`] - Lockfile generation, parsing, and validation (agpm.lock)
+//! - [`manifest`] - Manifest parsing and validation (agpm.toml)
 //! - [`markdown`] - Markdown file operations and frontmatter extraction
 //! - [`metadata`] - Extraction of transitive dependencies from resource files
 //! - [`pattern`] - Pattern-based dependency resolution using glob patterns
@@ -51,7 +51,7 @@
 //! - [`utils`] - Cross-platform utilities, file operations, and path validation
 //! - [`version`] - Version constraint parsing, comparison, and resolution
 //!
-//! # Manifest Format (ccpm.toml)
+//! # Manifest Format (agpm.toml)
 //!
 //! ## Basic Example
 //! ```toml
@@ -87,44 +87,44 @@
 //!
 //! ## Installation and Management
 //! ```bash
-//! # Initialize new CCPM project
-//! ccpm init
+//! # Initialize new AGPM project
+//! agpm init
 //!
-//! # Install all dependencies from ccpm.toml
-//! ccpm install
+//! # Install all dependencies from agpm.toml
+//! agpm install
 //!
 //! # Install with frozen lockfile (CI/production)
-//! ccpm install --frozen
+//! agpm install --frozen
 //!
 //! # Update dependencies within version constraints
-//! ccpm update
+//! agpm update
 //!
 //! # Update specific dependencies only
-//! ccpm update code-reviewer utils
+//! agpm update code-reviewer utils
 //! ```
 //!
 //! ## Resource Discovery
 //! ```bash
 //! # List installed resources
-//! ccpm list
+//! agpm list
 //!
 //! # List with details and source information
-//! ccpm list --details
+//! agpm list --details
 //!
 //! # List specific resource types
-//! ccpm list --agents --format json
+//! agpm list --agents --format json
 //! ```
 //!
 //! ## Project Management
 //! ```bash
 //! # Validate project configuration
-//! ccpm validate --resolve --sources
+//! agpm validate --resolve --sources
 //!
 //! # Add new dependencies
-//! ccpm add dep agent official:agents/helper.md@v1.0.0
+//! agpm add dep agent official:agents/helper.md@v1.0.0
 //!
 //! # Manage cache
-//! ccpm cache clean
+//! agpm cache clean
 //! ```
 
 // Core functionality modules

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,8 +57,8 @@
 //! ```toml
 //! # Define source repositories
 //! [sources]
-//! community = "https://github.com/aig787/ccpm-community.git"
-//! official = "https://github.com/example-org/ccpm-official.git"
+//! community = "https://github.com/aig787/agpm-community.git"
+//! official = "https://github.com/example-org/agpm-official.git"
 //!
 //! # Install individual resources
 //! [agents]

--- a/src/lockfile/tests.rs
+++ b/src/lockfile/tests.rs
@@ -44,7 +44,7 @@ dependencies: vec![],
     #[test]
     fn test_save_and_load() {
         let temp_dir = TempDir::new().unwrap();
-        let lockfile_path = temp_dir.path().join("ccpm.lock");
+        let lockfile_path = temp_dir.path().join("agpm.lock");
 
         let mut lockfile = LockFile::new();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,11 @@
-//! CCPM CLI entry point
+//! AGPM CLI entry point
 //!
-//! This is the main executable for the Claude Code Package Manager.
+//! This is the main executable for the AGent Package Manager.
 //! It handles command-line argument parsing, error display, and command execution.
 //!
 //! The CLI supports various commands for managing Claude Code resources:
-//! - `init` - Initialize a new ccpm.toml manifest
-//! - `install` - Install dependencies from ccpm.toml
+//! - `init` - Initialize a new agpm.toml manifest
+//! - `install` - Install dependencies from agpm.toml
 //! - `update` - Update dependencies within version constraints
 //! - `list` - List installed resources
 //! - `validate` - Validate manifest and lockfile
@@ -14,9 +14,9 @@
 //! - `add` - Add sources or dependencies to manifest
 //! - `remove` - Remove sources or dependencies from manifest
 
+use agpm::cli;
+use agpm::core::error::user_friendly_error;
 use anyhow::Result;
-use ccpm::cli;
-use ccpm::core::error::user_friendly_error;
 use clap::Parser;
 use tracing_subscriber::EnvFilter;
 

--- a/src/manifest/dependency_spec.rs
+++ b/src/manifest/dependency_spec.rs
@@ -62,22 +62,20 @@ impl DependencyMetadata {
     pub fn has_dependencies(&self) -> bool {
         self.dependencies
             .as_ref()
-            .map(|deps| !deps.is_empty() && deps.values().any(|v| !v.is_empty()))
-            .unwrap_or(false)
+            .is_some_and(|deps| !deps.is_empty() && deps.values().any(|v| !v.is_empty()))
     }
 
     /// Get the total count of dependencies.
     pub fn dependency_count(&self) -> usize {
         self.dependencies
             .as_ref()
-            .map(|deps| deps.values().map(|v| v.len()).sum())
-            .unwrap_or(0)
+            .map_or(0, |deps| deps.values().map(std::vec::Vec::len).sum())
     }
 
     /// Merge another metadata into this one.
     ///
     /// Used when combining dependencies from multiple sources.
-    pub fn merge(&mut self, other: DependencyMetadata) {
+    pub fn merge(&mut self, other: Self) {
         if let Some(other_deps) = other.dependencies {
             let deps = self.dependencies.get_or_insert_with(HashMap::new);
             for (resource_type, specs) in other_deps {

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -1,6 +1,6 @@
-//! Manifest file parsing and validation for CCPM projects.
+//! Manifest file parsing and validation for AGPM projects.
 //!
-//! This module handles the `ccpm.toml` manifest file that defines project
+//! This module handles the `agpm.toml` manifest file that defines project
 //! dependencies and configuration. The manifest uses TOML format and follows
 //! a structure similar to Cargo.toml, providing a lockfile-based dependency
 //! management system for Claude Code resources.
@@ -8,7 +8,7 @@
 //! # Overview
 //!
 //! The manifest system enables:
-//! - Declarative dependency management through `ccpm.toml`
+//! - Declarative dependency management through `agpm.toml`
 //! - Reproducible installations via lockfile generation
 //! - Support for multiple Git-based source repositories
 //! - Local and remote dependency resolution
@@ -22,7 +22,7 @@
 //!
 //! ## Basic Structure
 //!
-//! A `ccpm.toml` manifest file consists of four main sections:
+//! A `agpm.toml` manifest file consists of four main sections:
 //!
 //! ```toml
 //! # Named source repositories (optional)
@@ -36,8 +36,8 @@
 //! [target]
 //! # Where agents should be installed (default: ".claude/agents")
 //! agents = ".claude/agents"
-//! # Where snippets should be installed (default: ".claude/ccpm/snippets")
-//! snippets = ".claude/ccpm/snippets"
+//! # Where snippets should be installed (default: ".claude/agpm/snippets")
+//! snippets = ".claude/agpm/snippets"
 //! # Where commands should be installed (default: ".claude/commands")
 //! commands = ".claude/commands"
 //!
@@ -97,7 +97,7 @@
 //! [target]
 //! # Default values shown - these can be customized
 //! agents = ".claude/agents"      # Where agent .md files are copied
-//! snippets = ".claude/ccpm/snippets"  # Where snippet .md files are copied
+//! snippets = ".claude/agpm/snippets"  # Where snippet .md files are copied
 //! commands = ".claude/commands"  # Where command .md files are copied
 //!
 //! # Alternative configurations
@@ -244,7 +244,7 @@
 //!
 //! ## Version Constraint Syntax
 //!
-//! CCPM supports flexible version constraints:
+//! AGPM supports flexible version constraints:
 //!
 //! - `"v1.0.0"` - Exact semantic version
 //! - `"1.0.0"` - Exact version (v prefix optional)
@@ -292,40 +292,40 @@
 //!
 //! ## Security Considerations
 //!
-//! **CRITICAL**: Never include authentication credentials in `ccpm.toml`:
+//! **CRITICAL**: Never include authentication credentials in `agpm.toml`:
 //!
 //! ```toml
 //! # ❌ NEVER DO THIS - credentials will be committed to git
 //! [sources]
 //! private = "https://token:ghp_xxxx@github.com/company/repo.git"
 //!
-//! # ✅ Instead, use global configuration in ~/.ccpm/config.toml
+//! # ✅ Instead, use global configuration in ~/.agpm/config.toml
 //! # Or use SSH keys with git@ URLs
 //! [sources]
 //! private = "git@github.com:company/repo.git"
 //! ```
 //!
-//! Authentication should be configured globally in `~/.ccpm/config.toml` or
+//! Authentication should be configured globally in `~/.agpm/config.toml` or
 //! through SSH keys for `git@` URLs. See [`crate::config`] for details.
 //!
 //! ## Relationship to Lockfile
 //!
-//! The manifest works together with the lockfile (`ccpm.lock`):
+//! The manifest works together with the lockfile (`agpm.lock`):
 //!
-//! - **Manifest (`ccpm.toml`)**: Declares dependencies and constraints
-//! - **Lockfile (`ccpm.lock`)**: Records exact resolved versions and checksums
+//! - **Manifest (`agpm.toml`)**: Declares dependencies and constraints
+//! - **Lockfile (`agpm.lock`)**: Records exact resolved versions and checksums
 //!
-//! When you run `ccpm install`:
-//! 1. Reads dependencies from `ccpm.toml`
+//! When you run `agpm install`:
+//! 1. Reads dependencies from `agpm.toml`
 //! 2. Resolves versions within constraints  
-//! 3. Generates/updates `ccpm.lock` with exact commits
+//! 3. Generates/updates `agpm.lock` with exact commits
 //! 4. Installs resources to target directories
 //!
 //! See [`crate::lockfile`] for lockfile format details.
 //!
 //! ## Cross-Platform Compatibility
 //!
-//! CCPM handles platform differences automatically:
+//! AGPM handles platform differences automatically:
 //! - Path separators (/ vs \\) are normalized
 //! - Home directory expansion (~) is supported
 //! - Environment variable expansion is available
@@ -342,9 +342,9 @@
 //! 5. **Keep manifests simple**: Avoid overly complex dependency trees
 //! 6. **Use SSH for private repos**: More secure than HTTPS tokens
 //! 7. **Test across platforms**: Verify paths work on all target systems
-//! 8. **Version control manifests**: Always commit `ccpm.toml` to git
-//! 9. **Validate regularly**: Run `ccpm validate` before commits
-//! 10. **Use lockfiles**: Commit `ccpm.lock` for reproducible builds
+//! 8. **Version control manifests**: Always commit `agpm.toml` to git
+//! 9. **Validate regularly**: Run `agpm validate` before commits
+//! 10. **Use lockfiles**: Commit `agpm.lock` for reproducible builds
 //!
 //! ## Transitive Dependencies
 //!
@@ -376,7 +376,7 @@
 //! {
 //!   "events": ["UserPromptSubmit"],
 //!   "type": "command",
-//!   "command": ".claude/ccpm/scripts/test.js",
+//!   "command": ".claude/agpm/scripts/test.js",
 //!   "dependencies": {
 //!     "scripts": [
 //!       { "path": "scripts/test-runner.sh", "version": "v1.0.0" },
@@ -438,15 +438,15 @@
 //!
 //! ## Integration with Other Modules
 //!
-//! The manifest module works closely with other CCPM modules:
+//! The manifest module works closely with other AGPM modules:
 //!
 //! ### With [`crate::resolver`]
 //!
 //! ```rust,ignore
-//! use ccpm::manifest::Manifest;
-//! use ccpm::resolver::DependencyResolver;
+//! use agpm::manifest::Manifest;
+//! use agpm::resolver::DependencyResolver;
 //!
-//! let manifest = Manifest::load(&project_path.join("ccpm.toml"))?;
+//! let manifest = Manifest::load(&project_path.join("agpm.toml"))?;
 //! let resolver = DependencyResolver::new(&manifest);
 //! let resolved = resolver.resolve_all().await?;
 //! ```
@@ -454,21 +454,21 @@
 //! ### With [`crate::lockfile`]
 //!
 //! ```rust,ignore  
-//! use ccpm::manifest::Manifest;
-//! use ccpm::lockfile::LockFile;
+//! use agpm::manifest::Manifest;
+//! use agpm::lockfile::LockFile;
 //!
-//! let manifest = Manifest::load(&project_path.join("ccpm.toml"))?;
+//! let manifest = Manifest::load(&project_path.join("agpm.toml"))?;
 //! let lockfile = LockFile::generate_from_manifest(&manifest).await?;
-//! lockfile.save(&project_path.join("ccpm.lock"))?;
+//! lockfile.save(&project_path.join("agpm.lock"))?;
 //! ```
 //!
 //! ### With [`crate::git`] for Source Management
 //!
 //! ```rust,ignore
-//! use ccpm::manifest::Manifest;
-//! use ccpm::git::GitManager;
+//! use agpm::manifest::Manifest;
+//! use agpm::git::GitManager;
 //!
-//! let manifest = Manifest::load(&project_path.join("ccpm.toml"))?;
+//! let manifest = Manifest::load(&project_path.join("agpm.toml"))?;
 //! let git = GitManager::new(&cache_dir);
 //!
 //! for (name, url) in &manifest.sources {
@@ -485,9 +485,9 @@ use std::path::{Path, PathBuf};
 
 pub use dependency_spec::{DependencyMetadata, DependencySpec};
 
-/// The main manifest file structure representing a complete `ccpm.toml` file.
+/// The main manifest file structure representing a complete `agpm.toml` file.
 ///
-/// This struct encapsulates all configuration for a CCPM project, including
+/// This struct encapsulates all configuration for a AGPM project, including
 /// source repositories, installation targets, and resource dependencies.
 /// It provides the foundation for declarative dependency management similar
 /// to Cargo's `Cargo.toml`.
@@ -514,7 +514,7 @@ pub use dependency_spec::{DependencyMetadata, DependencySpec};
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::manifest::{Manifest, ResourceDependency};
+/// use agpm::manifest::{Manifest, ResourceDependency};
 ///
 /// // Create a new empty manifest
 /// let mut manifest = Manifest::new();
@@ -597,7 +597,7 @@ pub struct Manifest {
     /// MCP servers provide integrations with external systems and services,
     /// allowing Claude Code to connect to databases, APIs, and other tools.
     /// MCP servers are JSON configuration files that get installed to
-    /// `.claude/ccpm/mcp-servers/` and configured in `.mcp.json`.
+    /// `.claude/agpm/mcp-servers/` and configured in `.mcp.json`.
     ///
     /// See [`ResourceDependency`] for specification format details.
     #[serde(
@@ -610,7 +610,7 @@ pub struct Manifest {
     /// Script dependencies mapping names to their specifications.
     ///
     /// Scripts are executable files (.sh, .js, .py, etc.) that can be run by hooks
-    /// or independently. They are installed to `.claude/ccpm/scripts/` and can be
+    /// or independently. They are installed to `.claude/agpm/scripts/` and can be
     /// referenced by hook configurations.
     ///
     /// See [`ResourceDependency`] for specification format details.
@@ -632,13 +632,13 @@ pub struct Manifest {
 /// Target directories configuration specifying where resources are installed.
 ///
 /// This struct defines the installation destinations for different resource types
-/// within a CCPM project. All paths are relative to the project root (where
-/// `ccpm.toml` is located) unless they are absolute paths.
+/// within a AGPM project. All paths are relative to the project root (where
+/// `agpm.toml` is located) unless they are absolute paths.
 ///
 /// # Default Values
 ///
 /// - **Agents**: `.claude/agents` - Following Claude Code conventions
-/// - **Snippets**: `.claude/ccpm/snippets` - Following Claude Code conventions
+/// - **Snippets**: `.claude/agpm/snippets` - Following Claude Code conventions
 /// - **Commands**: `.claude/commands` - Following Claude Code conventions
 ///
 /// # Path Resolution
@@ -654,7 +654,7 @@ pub struct Manifest {
 /// # Default configuration (can be omitted)
 /// [target]
 /// agents = ".claude/agents"
-/// snippets = ".claude/ccpm/snippets"
+/// snippets = ".claude/agpm/snippets"
 /// commands = ".claude/commands"
 ///
 /// # Custom configuration
@@ -672,7 +672,7 @@ pub struct Manifest {
 ///
 /// # Cross-Platform Considerations
 ///
-/// CCPM automatically handles platform differences:
+/// AGPM automatically handles platform differences:
 /// - Forward slashes work on all platforms (Windows, macOS, Linux)
 /// - Path separators are normalized during installation
 /// - Long path support on Windows is handled automatically
@@ -692,7 +692,7 @@ pub struct TargetConfig {
     /// Snippets are reusable code templates, examples, or documentation.
     /// This directory will contain copies of snippet files from dependencies.
     ///
-    /// **Default**: `.claude/ccpm/snippets` (following Claude Code conventions)
+    /// **Default**: `.claude/agpm/snippets` (following Claude Code conventions)
     #[serde(default = "default_snippets_dir")]
     pub snippets: String,
 
@@ -711,7 +711,7 @@ pub struct TargetConfig {
     /// not installed to this directory. This directory is used for tracking
     /// metadata about installed servers.
     ///
-    /// **Default**: `.claude/ccpm/mcp-servers` (following Claude Code conventions)
+    /// **Default**: `.claude/agpm/mcp-servers` (following Claude Code conventions)
     #[serde(default = "default_mcp_servers_dir", rename = "mcp-servers")]
     pub mcp_servers: String,
 
@@ -720,7 +720,7 @@ pub struct TargetConfig {
     /// Scripts are executable files (.sh, .js, .py, etc.) that can be referenced
     /// by hooks or run independently.
     ///
-    /// **Default**: `.claude/ccpm/scripts` (following Claude Code conventions)
+    /// **Default**: `.claude/agpm/scripts` (following Claude Code conventions)
     #[serde(default = "default_scripts_dir")]
     pub scripts: String,
 
@@ -729,13 +729,13 @@ pub struct TargetConfig {
     /// Hooks are JSON configuration files that define event-based automation
     /// in Claude Code.
     ///
-    /// **Default**: `.claude/ccpm/hooks` (following Claude Code conventions)
+    /// **Default**: `.claude/agpm/hooks` (following Claude Code conventions)
     #[serde(default = "default_hooks_dir")]
     pub hooks: String,
 
     /// Whether to automatically add installed files to `.gitignore`.
     ///
-    /// When enabled (default), CCPM will create or update `.gitignore`
+    /// When enabled (default), AGPM will create or update `.gitignore`
     /// to exclude all installed files from version control. This prevents
     /// installed dependencies from being committed to your repository.
     ///
@@ -765,7 +765,7 @@ fn default_agents_dir() -> String {
 }
 
 fn default_snippets_dir() -> String {
-    ".claude/ccpm/snippets".to_string()
+    ".claude/agpm/snippets".to_string()
 }
 
 fn default_commands_dir() -> String {
@@ -773,15 +773,15 @@ fn default_commands_dir() -> String {
 }
 
 fn default_mcp_servers_dir() -> String {
-    ".claude/ccpm/mcp-servers".to_string()
+    ".claude/agpm/mcp-servers".to_string()
 }
 
 fn default_scripts_dir() -> String {
-    ".claude/ccpm/scripts".to_string()
+    ".claude/agpm/scripts".to_string()
 }
 
 fn default_hooks_dir() -> String {
-    ".claude/ccpm/hooks".to_string()
+    ".claude/agpm/hooks".to_string()
 }
 
 fn default_gitignore() -> bool {
@@ -991,7 +991,7 @@ pub struct DetailedDependency {
     /// - Pattern matching: `"agents/*.md"`, `"**/*.md"`, `"agents/[a-z]*.md"`
     ///
     /// Pattern dependencies are detected by the presence of glob characters
-    /// (`*`, `?`, `[`) in the path. When a pattern is detected, CCPM will
+    /// (`*`, `?`, `[`) in the path. When a pattern is detected, AGPM will
     /// expand it to match all resources in the source repository.
     ///
     /// # Examples
@@ -1192,7 +1192,7 @@ pub struct DetailedDependency {
     ///
     /// Example:
     /// ```toml
-    /// # This would be extracted from the file's frontmatter/JSON, not specified in ccpm.toml
+    /// # This would be extracted from the file's frontmatter/JSON, not specified in agpm.toml
     /// # { "agents": [{"path": "agents/helper.md", "version": "v1.0.0"}] }
     /// ```
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1204,7 +1204,7 @@ impl Manifest {
     ///
     /// The new manifest will have:
     /// - No sources defined
-    /// - Default target directories (`.claude/agents` and `.claude/ccpm/snippets`)
+    /// - Default target directories (`.claude/agents` and `.claude/agpm/snippets`)
     /// - No dependencies
     ///
     /// This is typically used when programmatically building a manifest or
@@ -1213,7 +1213,7 @@ impl Manifest {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::manifest::Manifest;
+    /// use agpm::manifest::Manifest;
     ///
     /// let manifest = Manifest::new();
     /// assert!(manifest.sources.is_empty());
@@ -1266,11 +1266,11 @@ impl Manifest {
     /// # Examples
     ///
     /// ```rust,no_run,ignore
-    /// use ccpm::manifest::Manifest;
+    /// use agpm::manifest::Manifest;
     /// use std::path::Path;
     ///
     /// // Load a manifest file
-    /// let manifest = Manifest::load(Path::new("ccpm.toml"))?;
+    /// let manifest = Manifest::load(Path::new("agpm.toml"))?;
     ///
     /// // Access parsed data
     /// println!("Found {} sources", manifest.sources.len());
@@ -1281,7 +1281,7 @@ impl Manifest {
     ///
     /// # File Format
     ///
-    /// Expects a valid TOML file following the CCPM manifest format.
+    /// Expects a valid TOML file following the AGPM manifest format.
     /// See the module-level documentation for complete format specification.
     pub fn load(path: &Path) -> Result<Self> {
         let content = std::fs::read_to_string(path).with_context(|| {
@@ -1296,7 +1296,7 @@ impl Manifest {
         })?;
 
         let manifest: Self = toml::from_str(&content)
-            .map_err(|e| crate::core::CcpmError::ManifestParseError {
+            .map_err(|e| crate::core::AgpmError::ManifestParseError {
                 file: path.display().to_string(),
                 reason: e.to_string(),
             })
@@ -1348,7 +1348,7 @@ impl Manifest {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::manifest::Manifest;
+    /// use agpm::manifest::Manifest;
     /// use std::path::Path;
     ///
     /// let mut manifest = Manifest::new();
@@ -1360,7 +1360,7 @@ impl Manifest {
     /// // Save to file
     /// # use tempfile::tempdir;
     /// # let temp_dir = tempdir()?;
-    /// # let manifest_path = temp_dir.path().join("ccpm.toml");
+    /// # let manifest_path = temp_dir.path().join("agpm.toml");
     /// manifest.save(&manifest_path)?;
     /// # Ok::<(), anyhow::Error>(())
     /// ```
@@ -1375,7 +1375,7 @@ impl Manifest {
     ///
     /// [target]
     /// agents = ".claude/agents"
-    /// snippets = ".claude/ccpm/snippets"
+    /// snippets = ".claude/agpm/snippets"
     ///
     /// [agents]
     /// helper = { source = "official", path = "agents/helper.md", version = "v1.0.0" }
@@ -1432,14 +1432,14 @@ impl Manifest {
     /// # Error Types
     ///
     /// Returns specific error types for different validation failures:
-    /// - [`crate::core::CcpmError::SourceNotFound`]: Referenced source doesn't exist
-    /// - [`crate::core::CcpmError::ManifestValidationError`]: General validation failures
+    /// - [`crate::core::AgpmError::SourceNotFound`]: Referenced source doesn't exist
+    /// - [`crate::core::AgpmError::ManifestValidationError`]: General validation failures
     /// - Context errors for specific issues with actionable suggestions
     ///
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::manifest::{Manifest, ResourceDependency, DetailedDependency};
+    /// use agpm::manifest::{Manifest, ResourceDependency, DetailedDependency};
     ///
     /// let mut manifest = Manifest::new();
     ///
@@ -1489,7 +1489,7 @@ impl Manifest {
         for (name, dep) in self.all_dependencies() {
             // Check for empty path
             if dep.get_path().is_empty() {
-                return Err(crate::core::CcpmError::ManifestValidationError {
+                return Err(crate::core::AgpmError::ManifestValidationError {
                     reason: format!("Missing required field 'path' for dependency '{name}'"),
                 }
                 .into());
@@ -1498,7 +1498,7 @@ impl Manifest {
             // Validate pattern safety if it's a pattern dependency
             if dep.is_pattern() {
                 crate::pattern::validate_pattern_safety(dep.get_path()).map_err(|e| {
-                    crate::core::CcpmError::ManifestValidationError {
+                    crate::core::AgpmError::ManifestValidationError {
                         reason: format!("Invalid pattern in dependency '{}': {}", name, e),
                     }
                 })?;
@@ -1507,7 +1507,7 @@ impl Manifest {
             // Check for version when source is specified (non-local dependencies)
             if let Some(source) = dep.get_source() {
                 if !self.sources.contains_key(source) {
-                    return Err(crate::core::CcpmError::SourceNotFound {
+                    return Err(crate::core::AgpmError::SourceNotFound {
                         name: source.to_string(),
                     }
                     .into());
@@ -1531,7 +1531,7 @@ impl Manifest {
                         path.starts_with('/') || path.starts_with("./") || path.starts_with("../");
 
                     if is_plain_dir && dep.get_version().is_some() {
-                        return Err(crate::core::CcpmError::ManifestValidationError {
+                        return Err(crate::core::AgpmError::ManifestValidationError {
                             reason: format!(
                                 "Version specified for plain directory dependency '{name}' with path '{path}'. \n\
                                 Plain directory dependencies do not support versions. \n\
@@ -1551,7 +1551,7 @@ impl Manifest {
             if let Some(version) = dep.get_version() {
                 if let Some(existing_version) = seen_deps.get(name) {
                     if existing_version != version {
-                        return Err(crate::core::CcpmError::ManifestValidationError {
+                        return Err(crate::core::AgpmError::ManifestValidationError {
                             reason: format!("Version conflict for dependency '{name}': found versions '{existing_version}' and '{version}'"),
                         }
                         .into());
@@ -1576,7 +1576,7 @@ impl Manifest {
             && !expanded_url.starts_with("./")
             && !expanded_url.starts_with("../")
             {
-                return Err(crate::core::CcpmError::ManifestValidationError {
+                return Err(crate::core::AgpmError::ManifestValidationError {
                     reason: format!(
                         "Source '{name}' has invalid URL: '{url}'. Must be HTTP(S), SSH (git@...), or file:// URL"
                     ),
@@ -1589,7 +1589,7 @@ impl Manifest {
                 || expanded_url.starts_with("./")
                 || expanded_url.starts_with("../")
             {
-                return Err(crate::core::CcpmError::ManifestValidationError {
+                return Err(crate::core::AgpmError::ManifestValidationError {
                     reason: format!(
                         "Plain directory path '{url}' cannot be used as source '{name}'. \n\
                         Sources must be git repositories. Use one of:\n\
@@ -1615,7 +1615,7 @@ impl Manifest {
                 // Find the original conflicting name
                 for (other_name, _) in self.all_dependencies() {
                     if other_name != name && other_name.to_lowercase() == normalized {
-                        return Err(crate::core::CcpmError::ManifestValidationError {
+                        return Err(crate::core::AgpmError::ManifestValidationError {
                             reason: format!(
                                 "Case conflict: '{}' and '{}' would map to the same file on case-insensitive filesystems. To ensure portability across platforms, resource names must be case-insensitively unique.",
                                 name, other_name
@@ -1645,7 +1645,7 @@ impl Manifest {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::manifest::Manifest;
+    /// use agpm::manifest::Manifest;
     ///
     /// let manifest = Manifest::new();
     /// // ... add some dependencies
@@ -1716,7 +1716,7 @@ impl Manifest {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// # use ccpm::manifest::Manifest;
+    /// # use agpm::manifest::Manifest;
     /// # let manifest = Manifest::new();
     /// for (name, dep) in manifest.all_dependencies() {
     ///     println!("Dependency: {} -> {}", name, dep.get_path());
@@ -1771,7 +1771,7 @@ impl Manifest {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::manifest::{Manifest, ResourceDependency};
+    /// use agpm::manifest::{Manifest, ResourceDependency};
     ///
     /// let mut manifest = Manifest::new();
     /// manifest.add_dependency(
@@ -1803,7 +1803,7 @@ impl Manifest {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::manifest::{Manifest, ResourceDependency};
+    /// use agpm::manifest::{Manifest, ResourceDependency};
     ///
     /// let mut manifest = Manifest::new();
     /// manifest.add_dependency(
@@ -1841,7 +1841,7 @@ impl Manifest {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::manifest::{Manifest, ResourceDependency};
+    /// use agpm::manifest::{Manifest, ResourceDependency};
     ///
     /// let mut manifest = Manifest::new();
     /// manifest.add_dependency(
@@ -1881,7 +1881,7 @@ impl Manifest {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::manifest::Manifest;
+    /// use agpm::manifest::Manifest;
     ///
     /// let mut manifest = Manifest::new();
     ///
@@ -1907,7 +1907,7 @@ impl Manifest {
     /// # Security Note
     ///
     /// Never include authentication tokens in the URL. Use SSH keys or
-    /// configure authentication globally in `~/.ccpm/config.toml`.
+    /// configure authentication globally in `~/.agpm/config.toml`.
     pub fn add_source(&mut self, name: String, url: String) {
         self.sources.insert(name, url);
     }
@@ -1937,7 +1937,7 @@ impl Manifest {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::manifest::{Manifest, ResourceDependency, DetailedDependency};
+    /// use agpm::manifest::{Manifest, ResourceDependency, DetailedDependency};
     ///
     /// let mut manifest = Manifest::new();
     ///
@@ -1989,8 +1989,8 @@ impl Manifest {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::manifest::{Manifest, ResourceDependency};
-    /// use ccpm::core::ResourceType;
+    /// use agpm::manifest::{Manifest, ResourceDependency};
+    /// use agpm::core::ResourceType;
     ///
     /// let mut manifest = Manifest::new();
     ///
@@ -2039,7 +2039,7 @@ impl Manifest {
     /// # Examples
     ///
     /// ```rust,no_run,ignore
-    /// use ccpm::manifest::{Manifest, ResourceDependency};
+    /// use agpm::manifest::{Manifest, ResourceDependency};
     ///
     /// let mut manifest = Manifest::new();
     ///
@@ -2064,7 +2064,7 @@ impl ResourceDependency {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::manifest::{ResourceDependency, DetailedDependency};
+    /// use agpm::manifest::{ResourceDependency, DetailedDependency};
     ///
     /// // Local dependency - no source
     /// let local = ResourceDependency::Simple("../local/file.md".to_string());
@@ -2109,7 +2109,7 @@ impl ResourceDependency {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::manifest::{ResourceDependency, DetailedDependency};
+    /// use agpm::manifest::{ResourceDependency, DetailedDependency};
     ///
     /// // Dependency with custom target
     /// let custom = ResourceDependency::Detailed(Box::new(DetailedDependency {
@@ -2146,7 +2146,7 @@ impl ResourceDependency {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::manifest::{ResourceDependency, DetailedDependency};
+    /// use agpm::manifest::{ResourceDependency, DetailedDependency};
     ///
     /// // Dependency with custom filename
     /// let custom = ResourceDependency::Detailed(Box::new(DetailedDependency {
@@ -2186,7 +2186,7 @@ impl ResourceDependency {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::manifest::{ResourceDependency, DetailedDependency};
+    /// use agpm::manifest::{ResourceDependency, DetailedDependency};
     ///
     /// // Local dependency - filesystem path
     /// let local = ResourceDependency::Simple("../shared/helper.md".to_string());
@@ -2246,7 +2246,7 @@ impl ResourceDependency {
     /// the `git` field takes precedence:
     ///
     /// ```rust,no_run
-    /// use ccpm::manifest::{ResourceDependency, DetailedDependency};
+    /// use agpm::manifest::{ResourceDependency, DetailedDependency};
     ///
     /// let dep = ResourceDependency::Detailed(Box::new(DetailedDependency {
     ///     source: Some("repo".to_string()),
@@ -2267,7 +2267,7 @@ impl ResourceDependency {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::manifest::{ResourceDependency, DetailedDependency};
+    /// use agpm::manifest::{ResourceDependency, DetailedDependency};
     ///
     /// // Local dependency - no version
     /// let local = ResourceDependency::Simple("../local/file.md".to_string());
@@ -2337,7 +2337,7 @@ impl ResourceDependency {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::manifest::{ResourceDependency, DetailedDependency};
+    /// use agpm::manifest::{ResourceDependency, DetailedDependency};
     ///
     /// // Local dependency
     /// let local = ResourceDependency::Simple("../local/file.md".to_string());
@@ -2418,7 +2418,7 @@ impl Default for Manifest {
 /// # Examples
 ///
 /// ```rust,no_run,ignore
-/// # use ccpm::manifest::expand_url;
+/// # use agpm::manifest::expand_url;
 /// # fn example() -> anyhow::Result<()> {
 /// // Standard URLs remain unchanged
 /// assert_eq!(expand_url("https://github.com/user/repo.git")?,
@@ -2505,7 +2505,7 @@ fn expand_url(url: &str) -> Result<String> {
 
 /// Find the manifest file by searching up the directory tree from the current directory.
 ///
-/// This function implements the standard CCPM behavior of searching for a `ccpm.toml`
+/// This function implements the standard AGPM behavior of searching for a `agpm.toml`
 /// file starting from the current working directory and walking up the directory
 /// tree until one is found or the filesystem root is reached.
 ///
@@ -2515,7 +2515,7 @@ fn expand_url(url: &str) -> Result<String> {
 /// # Search Algorithm
 ///
 /// 1. Start from the current working directory
-/// 2. Look for `ccpm.toml` in the current directory
+/// 2. Look for `agpm.toml` in the current directory
 /// 3. If not found, move to the parent directory
 /// 4. Repeat until found or reach the filesystem root
 /// 5. Return error if no manifest is found
@@ -2523,7 +2523,7 @@ fn expand_url(url: &str) -> Result<String> {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::manifest::find_manifest;
+/// use agpm::manifest::find_manifest;
 ///
 /// // Find manifest from current directory
 /// match find_manifest() {
@@ -2536,25 +2536,25 @@ fn expand_url(url: &str) -> Result<String> {
 ///
 /// ```text
 /// /home/user/project/
-/// ├── ccpm.toml          ← Found here
+/// ├── agpm.toml          ← Found here
 /// └── subdir/
 ///     └── deep/
 ///         └── nested/     ← Search started here, walks up
 /// ```
 ///
 /// If called from `/home/user/project/subdir/deep/nested/`, this function
-/// will find and return `/home/user/project/ccpm.toml`.
+/// will find and return `/home/user/project/agpm.toml`.
 ///
 /// # Error Conditions
 ///
-/// - **No manifest found**: Searched to filesystem root without finding `ccpm.toml`
+/// - **No manifest found**: Searched to filesystem root without finding `agpm.toml`
 /// - **Permission denied**: Cannot read current directory or traverse up
 /// - **Filesystem corruption**: Cannot determine current working directory
 ///
 /// # Use Cases
 ///
 /// This function is typically called by CLI commands that need to locate the
-/// project configuration, allowing users to run CCPM commands from any
+/// project configuration, allowing users to run AGPM commands from any
 /// subdirectory within their project.
 pub fn find_manifest() -> Result<PathBuf> {
     let current = std::env::current_dir()
@@ -2586,12 +2586,12 @@ pub fn find_manifest() -> Result<PathBuf> {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::manifest::find_manifest_with_optional;
+/// use agpm::manifest::find_manifest_with_optional;
 /// use std::path::PathBuf;
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// // Use explicit path
-/// let explicit = Some(PathBuf::from("/path/to/ccpm.toml"));
+/// let explicit = Some(PathBuf::from("/path/to/agpm.toml"));
 /// let manifest = find_manifest_with_optional(explicit)?;
 ///
 /// // Search from current directory
@@ -2605,7 +2605,7 @@ pub fn find_manifest_with_optional(explicit_path: Option<PathBuf>) -> Result<Pat
             if path.exists() {
                 Ok(path)
             } else {
-                Err(crate::core::CcpmError::ManifestNotFound.into())
+                Err(crate::core::AgpmError::ManifestNotFound.into())
             }
         }
         None => find_manifest(),
@@ -2621,11 +2621,11 @@ pub fn find_manifest_with_optional(explicit_path: Option<PathBuf>) -> Result<Pat
 ///
 /// # Algorithm
 ///
-/// 1. Check if `ccpm.toml` exists in the starting directory
+/// 1. Check if `agpm.toml` exists in the starting directory
 /// 2. If found, return the full path to the manifest
 /// 3. If not found, move to the parent directory
 /// 4. Repeat until manifest is found or filesystem root is reached
-/// 5. Return [`crate::core::CcpmError::ManifestNotFound`] if no manifest is found
+/// 5. Return [`crate::core::AgpmError::ManifestNotFound`] if no manifest is found
 ///
 /// # Parameters
 ///
@@ -2634,7 +2634,7 @@ pub fn find_manifest_with_optional(explicit_path: Option<PathBuf>) -> Result<Pat
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::manifest::find_manifest_from;
+/// use agpm::manifest::find_manifest_from;
 /// use std::path::PathBuf;
 ///
 /// // Search from a specific directory
@@ -2665,17 +2665,17 @@ pub fn find_manifest_with_optional(explicit_path: Option<PathBuf>) -> Result<Pat
 ///
 /// # Error Handling
 ///
-/// Returns [`crate::core::CcpmError::ManifestNotFound`] wrapped in an [`anyhow::Error`]
+/// Returns [`crate::core::AgpmError::ManifestNotFound`] wrapped in an [`anyhow::Error`]
 /// if no manifest file is found after searching to the filesystem root.
 pub fn find_manifest_from(mut current: PathBuf) -> Result<PathBuf> {
     loop {
-        let manifest_path = current.join("ccpm.toml");
+        let manifest_path = current.join("agpm.toml");
         if manifest_path.exists() {
             return Ok(manifest_path);
         }
 
         if !current.pop() {
-            return Err(crate::core::CcpmError::ManifestNotFound.into());
+            return Err(crate::core::AgpmError::ManifestNotFound.into());
         }
     }
 }
@@ -2698,7 +2698,7 @@ mod tests {
     #[test]
     fn test_manifest_load_save() {
         let temp = tempdir().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         let mut manifest = Manifest::new();
         manifest.add_source(
@@ -2893,7 +2893,7 @@ mod tests {
     #[test]
     fn test_manifest_save_load_commands() {
         let temp = tempdir().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         let mut manifest = Manifest::new();
         manifest.add_source(
@@ -2974,7 +2974,7 @@ mod tests {
     #[test]
     fn test_manifest_save_load_mcp_servers() {
         let temp = tempdir().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         let mut manifest = Manifest::new();
         manifest.add_source("npm".to_string(), "https://registry.npmjs.org".to_string());
@@ -2997,7 +2997,7 @@ mod tests {
     #[test]
     fn test_target_config_mcp_servers_dir() {
         let config = TargetConfig::default();
-        assert_eq!(config.mcp_servers, ".claude/ccpm/mcp-servers");
+        assert_eq!(config.mcp_servers, ".claude/agpm/mcp-servers");
 
         // Test custom config
         let mut manifest = Manifest::new();
@@ -3052,7 +3052,7 @@ mod tests {
     #[test]
     fn test_save_load_dependency_with_custom_target() {
         let temp = tempdir().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         let mut manifest = Manifest::new();
         manifest.add_source(
@@ -3137,7 +3137,7 @@ mod tests {
     #[test]
     fn test_save_load_dependency_with_custom_filename() {
         let temp = tempdir().unwrap();
-        let manifest_path = temp.path().join("ccpm.toml");
+        let manifest_path = temp.path().join("agpm.toml");
 
         let mut manifest = Manifest::new();
         manifest.add_source(

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -664,15 +664,13 @@ impl MarkdownDocument {
                     // Parsing failed - emit warning and treat entire document as content
                     if let Some(ctx) = context {
                         eprintln!(
-                            "⚠️  Warning: Unable to parse YAML frontmatter in '{}'. \
-                            The document will be processed without metadata. Error: {}",
-                            ctx, err
+                            "⚠️  Warning: Unable to parse YAML frontmatter in '{ctx}'. \
+                            The document will be processed without metadata. Error: {err}"
                         );
                     } else {
                         eprintln!(
                             "⚠️  Warning: Unable to parse YAML frontmatter. \
-                            The document will be processed without metadata. Error: {}",
-                            err
+                            The document will be processed without metadata. Error: {err}"
                         );
                     }
 
@@ -707,15 +705,13 @@ impl MarkdownDocument {
                     // TOML parsing failed - emit warning and treat entire document as content
                     if let Some(ctx) = context {
                         eprintln!(
-                            "⚠️  Warning: Unable to parse TOML frontmatter in '{}'. \
-                            The document will be processed without metadata. Error: {}",
-                            ctx, err
+                            "⚠️  Warning: Unable to parse TOML frontmatter in '{ctx}'. \
+                            The document will be processed without metadata. Error: {err}"
                         );
                     } else {
                         eprintln!(
                             "⚠️  Warning: Unable to parse TOML frontmatter. \
-                            The document will be processed without metadata. Error: {}",
-                            err
+                            The document will be processed without metadata. Error: {err}"
                         );
                     }
 

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -6,7 +6,7 @@
 //!
 //! # Overview
 //!
-//! The markdown module is a core component of CCPM that:
+//! The markdown module is a core component of AGPM that:
 //! - Parses Markdown files with optional YAML or TOML frontmatter
 //! - Extracts structured metadata for dependency resolution
 //! - Preserves document structure during read/write operations
@@ -123,7 +123,7 @@
 //! ## Basic Reading and Writing
 //!
 //! ```rust,no_run
-//! use ccpm::markdown::MarkdownDocument;
+//! use agpm::markdown::MarkdownDocument;
 //! use std::path::Path;
 //!
 //! # fn example() -> anyhow::Result<()> {
@@ -151,7 +151,7 @@
 //! ## Creating Documents Programmatically
 //!
 //! ```rust,no_run
-//! use ccpm::markdown::{MarkdownDocument, MarkdownMetadata};
+//! use agpm::markdown::{MarkdownDocument, MarkdownMetadata};
 //!
 //! # fn example() -> anyhow::Result<()> {
 //! // Create metadata
@@ -173,7 +173,7 @@
 //! ## Batch File Processing
 //!
 //! ```rust,no_run
-//! use ccpm::markdown::{list_markdown_files, MarkdownDocument};
+//! use agpm::markdown::{list_markdown_files, MarkdownDocument};
 //! use std::path::Path;
 //!
 //! # fn example() -> anyhow::Result<()> {
@@ -191,9 +191,9 @@
 //! # }
 //! ```
 //!
-//! # Integration with CCPM
+//! # Integration with AGPM
 //!
-//! This module integrates with other CCPM components:
+//! This module integrates with other AGPM components:
 //!
 //! - `crate::manifest`: Uses metadata for dependency resolution
 //! - `crate::lockfile`: Stores checksums and installation paths  
@@ -219,7 +219,7 @@ use crate::manifest::DependencySpec;
 /// # Examples
 ///
 /// ```rust,no_run
-/// # use ccpm::markdown::{MarkdownFile, MarkdownDocument};
+/// # use agpm::markdown::{MarkdownFile, MarkdownDocument};
 /// // These are equivalent
 /// let doc1 = MarkdownDocument::new("content".to_string());
 /// let doc2 = MarkdownFile::new("content".to_string());
@@ -232,11 +232,11 @@ pub type MarkdownFile = MarkdownDocument;
 ///
 /// This struct represents all the metadata that can be parsed from YAML or TOML
 /// frontmatter in Markdown files. It follows a flexible schema that accommodates
-/// both standard CCPM fields and custom extensions.
+/// both standard AGPM fields and custom extensions.
 ///
 /// # Standard Fields
 ///
-/// The following fields have special meaning in CCPM:
+/// The following fields have special meaning in AGPM:
 /// - `title`: Human-readable name for the resource
 /// - `description`: Brief explanation of what the resource does
 /// - `version`: Version identifier (semantic versioning recommended)
@@ -259,7 +259,7 @@ pub type MarkdownFile = MarkdownDocument;
 /// # Example
 ///
 /// ```rust,no_run
-/// # use ccpm::markdown::MarkdownMetadata;
+/// # use agpm::markdown::MarkdownMetadata;
 /// # use std::collections::HashMap;
 /// let mut metadata = MarkdownMetadata::default();
 /// metadata.title = Some("Python Linter".to_string());
@@ -347,7 +347,7 @@ pub struct MarkdownMetadata {
     ///
     /// Any frontmatter fields not recognized by the standard schema are
     /// preserved here. This allows resource authors to include custom
-    /// metadata without breaking compatibility with CCPM.
+    /// metadata without breaking compatibility with AGPM.
     ///
     /// Values are stored as `serde_json::Value` to handle mixed types
     /// (strings, numbers, arrays, objects).
@@ -357,7 +357,7 @@ pub struct MarkdownMetadata {
 
 /// A parsed Markdown document representing a Claude Code resource.
 ///
-/// This is the core structure for handling Markdown files in CCPM. It provides
+/// This is the core structure for handling Markdown files in AGPM. It provides
 /// a clean separation between structured metadata (from frontmatter) and the
 /// actual content, while preserving the original document format for roundtrip
 /// compatibility.
@@ -390,7 +390,7 @@ pub struct MarkdownMetadata {
 /// ## Reading from File
 ///
 /// ```rust,no_run
-/// # use ccpm::markdown::MarkdownDocument;
+/// # use agpm::markdown::MarkdownDocument;
 /// # use std::path::Path;
 /// # fn example() -> anyhow::Result<()> {
 /// let doc = MarkdownDocument::read(Path::new("agent.md"))?;
@@ -407,7 +407,7 @@ pub struct MarkdownMetadata {
 /// ## Creating Programmatically
 ///
 /// ```rust,no_run
-/// # use ccpm::markdown::{MarkdownDocument, MarkdownMetadata};
+/// # use agpm::markdown::{MarkdownDocument, MarkdownMetadata};
 /// let metadata = MarkdownMetadata {
 ///     title: Some("Test Agent".to_string()),
 ///     version: Some("1.0.0".to_string()),
@@ -425,7 +425,7 @@ pub struct MarkdownMetadata {
 /// ## Modifying Content
 ///
 /// ```rust,no_run
-/// # use ccpm::markdown::MarkdownDocument;
+/// # use agpm::markdown::MarkdownDocument;
 /// let mut doc = MarkdownDocument::new("# Original".to_string());
 ///
 /// // Update content - raw is automatically regenerated
@@ -443,7 +443,7 @@ pub struct MarkdownDocument {
     ///
     /// This will be `Some` if the document contained valid YAML or TOML
     /// frontmatter, and `None` for plain Markdown files. The metadata
-    /// is used by CCPM for dependency resolution and resource management.
+    /// is used by AGPM for dependency resolution and resource management.
     pub metadata: Option<MarkdownMetadata>,
 
     /// The main Markdown content without frontmatter delimiters.
@@ -476,7 +476,7 @@ impl MarkdownDocument {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// # use ccpm::markdown::MarkdownDocument;
+    /// # use agpm::markdown::MarkdownDocument;
     /// let doc = MarkdownDocument::new("# Hello\n\nWorld!".to_string());
     ///
     /// assert!(doc.metadata.is_none());
@@ -506,7 +506,7 @@ impl MarkdownDocument {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// # use ccpm::markdown::{MarkdownDocument, MarkdownMetadata};
+    /// # use agpm::markdown::{MarkdownDocument, MarkdownMetadata};
     /// let metadata = MarkdownMetadata {
     ///     title: Some("Example".to_string()),
     ///     version: Some("1.0.0".to_string()),
@@ -557,7 +557,7 @@ impl MarkdownDocument {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// # use ccpm::markdown::MarkdownDocument;
+    /// # use agpm::markdown::MarkdownDocument;
     /// # use std::path::Path;
     /// # fn example() -> anyhow::Result<()> {
     /// let doc = MarkdownDocument::read(Path::new("resources/agent.md"))?;
@@ -604,7 +604,7 @@ impl MarkdownDocument {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// # use ccpm::markdown::MarkdownDocument;
+    /// # use agpm::markdown::MarkdownDocument;
     /// # use std::path::Path;
     /// # fn example() -> anyhow::Result<()> {
     /// let doc = MarkdownDocument::new("# Test\n\nContent".to_string());
@@ -782,7 +782,7 @@ impl MarkdownDocument {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// # use ccpm::markdown::MarkdownDocument;
+    /// # use agpm::markdown::MarkdownDocument;
     /// // Parse document with YAML frontmatter
     /// let input = "---\ntitle: Test\n---\n# Content";
     /// let doc = MarkdownDocument::parse(input).unwrap();
@@ -822,7 +822,7 @@ impl MarkdownDocument {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// # use ccpm::markdown::{MarkdownDocument, MarkdownMetadata};
+    /// # use agpm::markdown::{MarkdownDocument, MarkdownMetadata};
     /// let mut doc = MarkdownDocument::new("# Test\n\nContent".to_string());
     /// assert!(doc.metadata.is_none());
     ///
@@ -864,7 +864,7 @@ impl MarkdownDocument {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// # use ccpm::markdown::{MarkdownDocument, MarkdownMetadata};
+    /// # use agpm::markdown::{MarkdownDocument, MarkdownMetadata};
     /// // Document with metadata
     /// let metadata = MarkdownMetadata {
     ///     title: Some("Test".to_string()),
@@ -913,7 +913,7 @@ impl MarkdownDocument {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// # use ccpm::markdown::{MarkdownDocument, MarkdownMetadata};
+    /// # use agpm::markdown::{MarkdownDocument, MarkdownMetadata};
     /// // From metadata
     /// let metadata = MarkdownMetadata {
     ///     title: Some("Metadata Title".to_string()),
@@ -976,7 +976,7 @@ impl MarkdownDocument {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// # use ccpm::markdown::{MarkdownDocument, MarkdownMetadata};
+    /// # use agpm::markdown::{MarkdownDocument, MarkdownMetadata};
     /// // From metadata
     /// let metadata = MarkdownMetadata {
     ///     description: Some("Metadata description".to_string()),
@@ -1146,7 +1146,7 @@ fn find_toml_frontmatter_end(input: &str) -> Option<usize> {
 /// # Examples
 ///
 /// ```rust,no_run
-/// # use ccpm::markdown::is_markdown_file;
+/// # use agpm::markdown::is_markdown_file;
 /// # use std::path::Path;
 /// assert!(is_markdown_file(Path::new("agent.md")));
 /// assert!(is_markdown_file(Path::new("README.MD")));
@@ -1194,7 +1194,7 @@ pub fn is_markdown_file(path: &Path) -> bool {
 /// # Examples
 ///
 /// ```rust,no_run
-/// # use ccpm::markdown::list_markdown_files;
+/// # use agpm::markdown::list_markdown_files;
 /// # use std::path::Path;
 /// # fn example() -> anyhow::Result<()> {
 /// let files = list_markdown_files(Path::new("resources/"))?;

--- a/src/metadata/extractor.rs
+++ b/src/metadata/extractor.rs
@@ -169,7 +169,7 @@ This is a command without frontmatter."#;
         let content = r#"{
   "events": ["UserPromptSubmit"],
   "type": "command",
-  "command": ".claude/ccpm/scripts/test.js",
+  "command": ".claude/agpm/scripts/test.js",
   "dependencies": {
     "scripts": [
       { "path": "scripts/test-runner.sh", "version": "v1.0.0" },

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,4 +1,4 @@
-//! Shared data models for CCPM operations
+//! Shared data models for AGPM operations
 //!
 //! This module provides reusable data structures that are used across
 //! different CLI commands and core operations, ensuring consistency

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -104,27 +104,27 @@ pub enum DependencyType {
 impl DependencyType {
     /// Get the common dependency specification
     #[must_use]
-    pub fn common(&self) -> &DependencySpec {
+    pub const fn common(&self) -> &DependencySpec {
         match self {
-            DependencyType::Agent(dep) => &dep.common,
-            DependencyType::Snippet(dep) => &dep.common,
-            DependencyType::Command(dep) => &dep.common,
-            DependencyType::Script(dep) => &dep.common,
-            DependencyType::Hook(dep) => &dep.common,
-            DependencyType::McpServer(dep) => &dep.common,
+            Self::Agent(dep) => &dep.common,
+            Self::Snippet(dep) => &dep.common,
+            Self::Command(dep) => &dep.common,
+            Self::Script(dep) => &dep.common,
+            Self::Hook(dep) => &dep.common,
+            Self::McpServer(dep) => &dep.common,
         }
     }
 
     /// Get the resource type as a string
     #[must_use]
-    pub fn resource_type(&self) -> &'static str {
+    pub const fn resource_type(&self) -> &'static str {
         match self {
-            DependencyType::Agent(_) => "agent",
-            DependencyType::Snippet(_) => "snippet",
-            DependencyType::Command(_) => "command",
-            DependencyType::Script(_) => "script",
-            DependencyType::Hook(_) => "hook",
-            DependencyType::McpServer(_) => "mcp-server",
+            Self::Agent(_) => "agent",
+            Self::Snippet(_) => "snippet",
+            Self::Command(_) => "command",
+            Self::Script(_) => "script",
+            Self::Hook(_) => "hook",
+            Self::McpServer(_) => "mcp-server",
         }
     }
 }

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -129,7 +129,7 @@ impl PatternMatcher {
     /// ```
     pub fn new(pattern_str: &str) -> Result<Self> {
         let pattern = Pattern::new(pattern_str)
-            .with_context(|| format!("Invalid glob pattern: {}", pattern_str))?;
+            .with_context(|| format!("Invalid glob pattern: {pattern_str}"))?;
 
         Ok(Self {
             pattern,
@@ -192,12 +192,12 @@ impl PatternMatcher {
         let mut matches = Vec::new();
         let base_path = base_path
             .canonicalize()
-            .with_context(|| format!("Failed to canonicalize path: {:?}", base_path))?;
+            .with_context(|| format!("Failed to canonicalize path: {base_path:?}"))?;
 
         for entry in WalkDir::new(&base_path)
             .follow_links(false) // Security: don't follow symlinks
             .into_iter()
-            .filter_map(|e| e.ok())
+            .filter_map(std::result::Result::ok)
         {
             let path = entry.path();
 
@@ -336,7 +336,7 @@ impl PatternResolver {
     /// ```
     ///
     /// [`exclude`]: PatternResolver::exclude
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             exclude_patterns: Vec::new(),
         }
@@ -380,7 +380,7 @@ impl PatternResolver {
     /// ```
     pub fn exclude(&mut self, pattern: &str) -> Result<()> {
         let pattern = Pattern::new(pattern)
-            .with_context(|| format!("Invalid exclusion pattern: {}", pattern))?;
+            .with_context(|| format!("Invalid exclusion pattern: {pattern}"))?;
         self.exclude_patterns.push(pattern);
         Ok(())
     }
@@ -593,17 +593,17 @@ pub fn extract_resource_name(path: &Path) -> String {
 pub fn validate_pattern_safety(pattern: &str) -> Result<()> {
     // Check for path traversal attempts
     if pattern.contains("..") {
-        anyhow::bail!("Pattern contains path traversal (..): {}", pattern);
+        anyhow::bail!("Pattern contains path traversal (..): {pattern}");
     }
 
     // Check for absolute paths on Unix
     if cfg!(unix) && pattern.starts_with('/') {
-        anyhow::bail!("Pattern contains absolute path: {}", pattern);
+        anyhow::bail!("Pattern contains absolute path: {pattern}");
     }
 
     // Check for absolute paths on Windows
     if cfg!(windows) && (pattern.contains(':') || pattern.starts_with('\\')) {
-        anyhow::bail!("Pattern contains absolute path: {}", pattern);
+        anyhow::bail!("Pattern contains absolute path: {pattern}");
     }
 
     Ok(())

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -1,13 +1,13 @@
-//! Pattern-based dependency resolution for CCPM.
+//! Pattern-based dependency resolution for AGPM.
 //!
 //! This module provides glob pattern matching functionality to support
-//! pattern-based dependencies in CCPM manifests. Pattern dependencies
+//! pattern-based dependencies in AGPM manifests. Pattern dependencies
 //! allow installation of multiple resources matching a glob pattern,
 //! enabling bulk operations on related resources.
 //!
 //! # Pattern Syntax
 //!
-//! CCPM uses standard glob patterns with the following support:
+//! AGPM uses standard glob patterns with the following support:
 //!
 //! - `*` matches any sequence of characters within a single path component
 //! - `**` matches any sequence of path components (recursive matching)
@@ -70,7 +70,7 @@ use walkdir::WalkDir;
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::pattern::PatternMatcher;
+/// use agpm::pattern::PatternMatcher;
 /// use std::path::Path;
 ///
 /// # fn example() -> anyhow::Result<()> {
@@ -115,7 +115,7 @@ impl PatternMatcher {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::pattern::PatternMatcher;
+    /// use agpm::pattern::PatternMatcher;
     ///
     /// // Simple wildcard
     /// let matcher = PatternMatcher::new("*.md")?;
@@ -170,7 +170,7 @@ impl PatternMatcher {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::pattern::PatternMatcher;
+    /// use agpm::pattern::PatternMatcher;
     /// use std::path::Path;
     ///
     /// # async fn example() -> anyhow::Result<()> {
@@ -239,7 +239,7 @@ impl PatternMatcher {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::pattern::PatternMatcher;
+    /// use agpm::pattern::PatternMatcher;
     /// use std::path::Path;
     ///
     /// # fn example() -> anyhow::Result<()> {
@@ -268,7 +268,7 @@ impl PatternMatcher {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::pattern::PatternMatcher;
+    /// use agpm::pattern::PatternMatcher;
     ///
     /// # fn example() -> anyhow::Result<()> {
     /// let pattern_str = "**/*.md";
@@ -287,7 +287,7 @@ impl PatternMatcher {
 ///
 /// The `PatternResolver` provides advanced pattern matching with exclusion
 /// support and deterministic ordering. It's designed for resolving
-/// pattern-based dependencies in CCPM manifests to concrete resource files.
+/// pattern-based dependencies in AGPM manifests to concrete resource files.
 ///
 /// # Features
 ///
@@ -299,7 +299,7 @@ impl PatternMatcher {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::pattern::PatternResolver;
+/// use agpm::pattern::PatternResolver;
 /// use std::path::Path;
 ///
 /// # fn example() -> anyhow::Result<()> {
@@ -329,7 +329,7 @@ impl PatternResolver {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::pattern::PatternResolver;
+    /// use agpm::pattern::PatternResolver;
     ///
     /// let resolver = PatternResolver::new();
     /// // PatternResolver starts with no exclusions
@@ -360,7 +360,7 @@ impl PatternResolver {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::pattern::PatternResolver;
+    /// use agpm::pattern::PatternResolver;
     ///
     /// # fn example() -> anyhow::Result<()> {
     /// let mut resolver = PatternResolver::new();
@@ -418,7 +418,7 @@ impl PatternResolver {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::pattern::PatternResolver;
+    /// use agpm::pattern::PatternResolver;
     /// use std::path::Path;
     ///
     /// # fn example() -> anyhow::Result<()> {
@@ -476,7 +476,7 @@ impl PatternResolver {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::pattern::PatternResolver;
+    /// use agpm::pattern::PatternResolver;
     /// use std::path::Path;
     ///
     /// # fn example() -> anyhow::Result<()> {
@@ -530,7 +530,7 @@ impl Default for PatternResolver {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::pattern::extract_resource_name;
+/// use agpm::pattern::extract_resource_name;
 /// use std::path::Path;
 ///
 /// assert_eq!(extract_resource_name(Path::new("agents/helper.md")), "helper");
@@ -576,7 +576,7 @@ pub fn extract_resource_name(path: &Path) -> String {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::pattern::validate_pattern_safety;
+/// use agpm::pattern::validate_pattern_safety;
 ///
 /// // Safe patterns
 /// assert!(validate_pattern_safety("*.md").is_ok());

--- a/src/resolver/dependency_graph.rs
+++ b/src/resolver/dependency_graph.rs
@@ -140,10 +140,10 @@ impl DependencyGraph {
             {
                 let cycle_str = cycle
                     .iter()
-                    .map(|n| n.display_name())
+                    .map(DependencyNode::display_name)
                     .collect::<Vec<_>>()
                     .join(" → ");
-                return Err(anyhow!("Circular dependency detected: {}", cycle_str));
+                return Err(anyhow!("Circular dependency detected: {cycle_str}"));
             }
         }
 
@@ -152,7 +152,7 @@ impl DependencyGraph {
 
     /// DFS visit for cycle detection.
     ///
-    /// Returns Some(cycle_path) if a cycle is detected, None otherwise.
+    /// Returns `Some(cycle_path)` if a cycle is detected, None otherwise.
     fn dfs_visit(
         &self,
         node: NodeIndex,
@@ -302,19 +302,19 @@ impl DependencyGraph {
         if !visited.insert(node.clone()) {
             // Already visited - indicate circular reference
             let child_prefix = if is_last {
-                format!("{}    ", prefix)
+                format!("{prefix}    ")
             } else {
-                format!("{}│   ", prefix)
+                format!("{prefix}│   ")
             };
-            result.push_str(&format!("{}└── (circular reference)\n", child_prefix));
+            result.push_str(&format!("{child_prefix}└── (circular reference)\n"));
             return;
         }
 
         let deps = self.get_direct_deps(node);
         let child_prefix = if is_last {
-            format!("{}    ", prefix)
+            format!("{prefix}    ")
         } else {
-            format!("{}│   ", prefix)
+            format!("{prefix}│   ")
         };
 
         for (i, dep) in deps.iter().enumerate() {

--- a/src/resolver/redundancy.rs
+++ b/src/resolver/redundancy.rs
@@ -1,0 +1,1058 @@
+//! Redundancy detection and analysis for AGPM dependencies.
+//!
+//! This module provides sophisticated analysis of dependency redundancy patterns
+//! to help users optimize their manifest files and understand resource usage.
+//! Redundancy detection is designed to be advisory rather than blocking,
+//! enabling legitimate use cases while highlighting optimization opportunities.
+//!
+//! # Types of Redundancy
+//!
+//! ## Version Redundancy
+//! Multiple resources referencing the same source file with different versions:
+//! ```toml
+//! [agents]
+//! app-helper = { source = "community", path = "agents/helper.md", version = "v1.0.0" }
+//! tool-helper = { source = "community", path = "agents/helper.md", version = "v2.0.0" }
+//! ```
+//!
+//! ## Mixed Constraint Redundancy  
+//! Some dependencies use specific versions while others use latest:
+//! ```toml
+//! [agents]
+//! main-agent = { source = "community", path = "agents/helper.md" } # latest
+//! backup-agent = { source = "community", path = "agents/helper.md", version = "v1.0.0" }
+//! ```
+//!
+//! ## Cross-Source Redundancy (Future)
+//! Same resource available from multiple sources (not yet implemented):
+//! ```toml
+//! [sources]
+//! official = "https://github.com/org/agpm-official.git"
+//! mirror = "https://github.com/org/agpm-mirror.git"
+//!
+//! [agents]
+//! helper1 = { source = "official", path = "agents/helper.md" }
+//! helper2 = { source = "mirror", path = "agents/helper.md" }
+//! ```
+//!
+//! # Algorithm Design
+//!
+//! The redundancy detection algorithm operates in O(n) time complexity:
+//! 1. **Collection Phase**: Build usage map of source files → resources (O(n))
+//! 2. **Analysis Phase**: Identify files with multiple version usages (O(n))
+//! 3. **Classification Phase**: Categorize redundancy types (O(k) where k = redundancies)
+//!
+//! ## Data Structures
+//!
+//! The detector uses a hash map for efficient lookup:
+//! ```text
+//! usages: HashMap<String, Vec<ResourceUsage>>
+//!         ↑                ↑
+//!         source:path      list of resources using this file
+//! ```
+//!
+//! # Design Principles
+//!
+//! ## Non-Blocking Detection
+//! Redundancy analysis never prevents installation because:
+//! - **A/B Testing**: Users may intentionally install multiple versions
+//! - **Gradual Migration**: Transitioning between versions may require temporary redundancy
+//! - **Testing Environments**: Different test scenarios may need different versions
+//! - **Rollback Capability**: Keeping previous versions enables quick rollbacks
+//!
+//! ## Helpful Suggestions
+//! Instead of blocking, the detector provides:
+//! - **Version Alignment**: Suggest using consistent versions across resources
+//! - **Consolidation Opportunities**: Identify resources that could share versions
+//! - **Best Practices**: Guide users toward maintainable dependency patterns
+//!
+//! # Performance Considerations
+//!
+//! - **Lazy Evaluation**: Analysis only runs when explicitly requested
+//! - **Memory Efficient**: Uses references where possible to avoid cloning
+//! - **Early Termination**: Stops processing once redundancies are found (for boolean checks)
+//! - **Batched Operations**: Groups related analysis operations together
+//!
+//! # Future Extensions
+//!
+//! Planned enhancements for redundancy detection:
+//!
+//! ## Transitive Analysis
+//! When dependencies-of-dependencies are supported:
+//! ```text
+//! impl RedundancyDetector {
+//!     pub fn check_transitive_redundancies(&self) -> Vec<Redundancy> {
+//!         // Analyze entire dependency tree for redundant patterns
+//!     }
+//! }
+//! ```
+//!
+//! ## Content-Based Detection
+//! Hash-based redundancy detection for identical files:
+//! ```rust,no_run
+//! # use agpm::resolver::redundancy::ResourceUsage;
+//! pub struct ContentRedundancy {
+//!     content_hash: String,
+//!     identical_resources: Vec<ResourceUsage>,
+//! }
+//! ```
+//!
+//! ## Semantic Analysis
+//! ML-based detection of functionally similar resources:
+//! ```rust,no_run
+//! # use agpm::resolver::redundancy::ResourceUsage;
+//! pub struct SemanticRedundancy {
+//!     similarity_score: f64,
+//!     similar_resources: Vec<ResourceUsage>,
+//! }
+//! ```
+
+use crate::manifest::{Manifest, ResourceDependency};
+use colored::Colorize;
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+
+/// Represents a specific usage of a source file by a resource dependency.
+///
+/// This struct captures how a particular resource (agent or snippet) uses
+/// a source file, including version constraints and naming information.
+/// It's the fundamental unit of redundancy analysis.
+///
+/// # Fields
+///
+/// - `resource_name`: The name given to this resource in the manifest
+/// - `source_file`: Composite identifier in format "source:path"
+/// - `version`: Version constraint (None means latest/default branch)
+///
+/// # Example
+///
+/// For this manifest entry:
+/// ```toml
+/// [agents]
+/// my-helper = { source = "community", path = "agents/helper.md", version = "v1.2.3" }
+/// ```
+///
+/// The corresponding `ResourceUsage` would be:
+/// ```rust,no_run
+/// # use agpm::resolver::redundancy::ResourceUsage;
+/// ResourceUsage {
+///     resource_name: "my-helper".to_string(),
+///     source_file: "community:agents/helper.md".to_string(),
+///     version: Some("v1.2.3".to_string()),
+/// }
+/// # ;
+/// ```
+#[derive(Debug, Clone)]
+pub struct ResourceUsage {
+    /// The resource name that uses this source file
+    pub resource_name: String,
+    /// The source file being used (source:path)
+    pub source_file: String,
+    /// The version being used
+    pub version: Option<String>,
+}
+
+impl fmt::Display for ResourceUsage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "'{}' uses version {}",
+            self.resource_name,
+            self.version.as_deref().unwrap_or("latest")
+        )
+    }
+}
+
+/// Represents a detected redundancy pattern where multiple resources use the same source file.
+///
+/// A [`Redundancy`] is created when the analysis detects that multiple resources
+/// reference the same source file (identified by source:path) but with different
+/// version constraints or names.
+///
+/// # Redundancy Criteria
+///
+/// A redundancy is detected when:
+/// 1. **Multiple Usages**: More than one resource uses the same source file
+/// 2. **Version Differences**: The usages specify different version constraints
+///
+/// Note: Multiple resources using the same source file with identical versions
+/// are NOT considered redundant, as this is a valid use case.
+///
+/// # Use Cases for Legitimate Redundancy
+///
+/// - **A/B Testing**: Installing multiple versions for comparison
+/// - **Migration Periods**: Gradually transitioning between versions
+/// - **Rollback Preparation**: Keeping previous versions for quick rollback
+/// - **Environment Differences**: Different versions for dev/staging/prod
+///
+/// # Display Format
+///
+/// When displayed, redundancies show:
+/// ```text
+/// ⚠ Multiple versions of 'community:agents/helper.md' will be installed:
+///   - 'app-helper' uses version v1.0.0
+///   - 'tool-helper' uses version v2.0.0
+/// ```
+#[derive(Debug)]
+pub struct Redundancy {
+    /// The source file that is used multiple times
+    pub source_file: String,
+    /// All usages of this source file
+    pub usages: Vec<ResourceUsage>,
+}
+
+impl fmt::Display for Redundancy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(
+            f,
+            "{} Multiple versions of '{}' will be installed:",
+            "⚠".yellow(),
+            self.source_file
+        )?;
+        for usage in &self.usages {
+            writeln!(f, "  - {usage}")?;
+        }
+        Ok(())
+    }
+}
+
+/// Analyzes dependency patterns to detect and categorize redundancies.
+///
+/// The [`RedundancyDetector`] is the main analysis engine for identifying
+/// optimization opportunities in dependency manifests. It builds a comprehensive
+/// view of how resources use source files and identifies patterns that might
+/// indicate redundancy.
+///
+/// # Analysis Process
+///
+/// 1. **Collection**: Gather all resource usages via [`add_usage()`] or [`analyze_manifest()`]
+/// 2. **Detection**: Run [`detect_redundancies()`] to find redundant patterns
+/// 3. **Reporting**: Generate warnings or suggestions using helper methods
+///
+/// # Thread Safety
+///
+/// The detector is not thread-safe due to mutable state during analysis.
+/// Create separate instances for concurrent analysis operations.
+///
+/// # Memory Usage
+///
+/// The detector maintains an in-memory map of all resource usages. For large
+/// manifests with hundreds of dependencies, memory usage scales linearly:
+/// - Each resource usage: ~100 bytes (strings + metadata)
+/// - `HashMap` overhead: ~25% of total usage data
+///
+/// [`add_usage()`]: RedundancyDetector::add_usage
+/// [`analyze_manifest()`]: RedundancyDetector::analyze_manifest
+/// [`detect_redundancies()`]: RedundancyDetector::detect_redundancies
+pub struct RedundancyDetector {
+    /// Map of source file identifiers to their usages
+    usages: HashMap<String, Vec<ResourceUsage>>,
+}
+
+impl Default for RedundancyDetector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RedundancyDetector {
+    /// Creates a new redundancy detector with empty state.
+    ///
+    /// The detector starts with no resource usage data. Use [`add_usage()`]
+    /// for individual dependencies or [`analyze_manifest()`] for complete
+    /// manifest analysis.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use agpm::resolver::redundancy::RedundancyDetector;
+    ///
+    /// let mut detector = RedundancyDetector::new();
+    /// // Add usages or analyze manifest...
+    /// let redundancies = detector.detect_redundancies();
+    /// ```
+    ///
+    /// [`add_usage()`]: RedundancyDetector::add_usage
+    /// [`analyze_manifest()`]: RedundancyDetector::analyze_manifest
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            usages: HashMap::new(),
+        }
+    }
+
+    /// Records a resource usage for redundancy analysis.
+    ///
+    /// This method adds a single resource dependency to the analysis dataset.
+    /// Local dependencies are automatically filtered out since they don't
+    /// have redundancy concerns (each local path is unique).
+    ///
+    /// # Filtering Logic
+    ///
+    /// - **Remote Dependencies**: Added to analysis (have source + path)
+    /// - **Local Dependencies**: Skipped (path-only, no redundancy issues)
+    /// - **Invalid Dependencies**: Skipped (missing source information)
+    ///
+    /// # Source File Identification
+    ///
+    /// Remote dependencies are identified by their composite key:
+    /// ```text
+    /// source_file = "{source_name}:{resource_path}"
+    /// ```
+    ///
+    /// This ensures that the same file from different sources is treated
+    /// as separate resources (no cross-source redundancy detection yet).
+    ///
+    /// # Parameters
+    ///
+    /// - `resource_name`: Name assigned to this resource in the manifest
+    /// - `dep`: Resource dependency specification from manifest
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use agpm::resolver::redundancy::RedundancyDetector;
+    /// use agpm::manifest::{ResourceDependency, DetailedDependency};
+    ///
+    /// let mut detector = RedundancyDetector::new();
+    ///
+    /// // This will be recorded
+    /// let remote_dep = ResourceDependency::Detailed(Box::new(DetailedDependency {
+    ///     source: Some("community".to_string()),
+    ///     path: "agents/helper.md".to_string(),
+    ///     version: Some("v1.0.0".to_string()),
+    ///     branch: None,
+    ///     rev: None,
+    ///     command: None,
+    ///     args: None,
+    ///     target: None,
+    ///     filename: None,
+    ///     dependencies: None,
+    /// }));
+    /// detector.add_usage("my-helper".to_string(), &remote_dep);
+    ///
+    /// // This will be ignored (local dependency)
+    /// let local_dep = ResourceDependency::Simple("../local/helper.md".to_string());
+    /// detector.add_usage("local-helper".to_string(), &local_dep);
+    /// ```
+    pub fn add_usage(&mut self, resource_name: String, dep: &ResourceDependency) {
+        // Only track remote dependencies (local ones don't have redundancy issues)
+        if dep.is_local() {
+            return;
+        }
+
+        if let Some(source) = dep.get_source() {
+            let source_file = format!("{}:{}", source, dep.get_path());
+
+            let usage = ResourceUsage {
+                resource_name,
+                source_file: source_file.clone(),
+                version: dep.get_version().map(std::string::ToString::to_string),
+            };
+
+            self.usages.entry(source_file).or_default().push(usage);
+        }
+    }
+
+    /// Analyzes all dependencies from a manifest for redundancy patterns.
+    ///
+    /// This is a convenience method that processes all dependencies from
+    /// a manifest file in a single operation. It's equivalent to calling
+    /// [`add_usage()`] for each dependency individually.
+    ///
+    /// # Processing Scope
+    ///
+    /// The method analyzes:
+    /// - **Agent Dependencies**: From `[agents]` section
+    /// - **Snippet Dependencies**: From `[snippets]` section
+    /// - **Remote Dependencies**: Only those with source specifications
+    ///
+    /// Local dependencies are automatically filtered out during analysis.
+    ///
+    /// # Usage Pattern
+    ///
+    /// This method is typically used in the main resolution workflow:
+    /// ```rust,no_run
+    /// use agpm::resolver::redundancy::RedundancyDetector;
+    /// use agpm::manifest::Manifest;
+    /// use std::path::Path;
+    ///
+    /// # fn example() -> anyhow::Result<()> {
+    /// let manifest = Manifest::load(Path::new("agpm.toml"))?;
+    /// let mut detector = RedundancyDetector::new();
+    /// detector.analyze_manifest(&manifest);
+    ///
+    /// let redundancies = detector.detect_redundancies();
+    /// let warning = detector.generate_redundancy_warning(&redundancies);
+    /// if !warning.is_empty() {
+    ///     eprintln!("{}", warning);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Performance
+    ///
+    /// - **Time Complexity**: O(n) where n = total dependencies
+    /// - **Space Complexity**: O(r) where r = remote dependencies
+    /// - **Memory Usage**: Linear with number of remote dependencies
+    ///
+    /// [`add_usage()`]: RedundancyDetector::add_usage
+    pub fn analyze_manifest(&mut self, manifest: &Manifest) {
+        for (name, dep) in manifest.all_dependencies() {
+            self.add_usage(name.to_string(), dep);
+        }
+    }
+
+    /// Detects redundancy patterns in the collected resource usages.
+    ///
+    /// This method analyzes all collected resource usages and identifies
+    /// patterns where multiple resources use the same source file with
+    /// different version constraints.
+    ///
+    /// # Detection Algorithm
+    ///
+    /// For each source file in the usage map:
+    /// 1. **Skip Single Usage**: Files used by only one resource are not redundant
+    /// 2. **Version Analysis**: Collect all unique version constraints for the file
+    /// 3. **Redundancy Check**: If multiple different versions exist, mark as redundant
+    ///
+    /// # Redundancy Criteria
+    ///
+    /// A source file is considered redundant when:
+    /// - **Multiple Resources**: More than one resource uses the file
+    /// - **Different Versions**: Resources specify different version constraints
+    ///
+    /// # Non-Redundant Cases
+    ///
+    /// These cases are NOT considered redundant:
+    /// - Single resource using a source file
+    /// - Multiple resources using identical version constraints
+    /// - Multiple resources all using "latest" (no version specified)
+    ///
+    /// # Algorithm Complexity
+    ///
+    /// - **Time**: O(n + k·m) where:
+    ///   - n = total resource usages
+    ///   - k = unique source files
+    ///   - m = average usages per file
+    /// - **Space**: O(r) where r = detected redundancies
+    ///
+    /// # Returns
+    ///
+    /// A vector of [`Redundancy`] objects, each representing a source file
+    /// with redundant usage patterns. The vector is empty if no redundancies
+    /// are detected.
+    ///
+    /// # Example Output
+    ///
+    /// For a manifest with redundant dependencies, this method might return:
+    /// ```text
+    /// [
+    ///     Redundancy {
+    ///         source_file: "community:agents/helper.md",
+    ///         usages: [
+    ///             ResourceUsage { resource_name: "app-helper", version: Some("v1.0.0") },
+    ///             ResourceUsage { resource_name: "tool-helper", version: Some("v2.0.0") },
+    ///         ]
+    ///     }
+    /// ]
+    /// ```
+    ///
+    /// [`Redundancy`]: Redundancy
+    #[must_use]
+    pub fn detect_redundancies(&self) -> Vec<Redundancy> {
+        let mut redundancies = Vec::new();
+
+        for (source_file, uses) in &self.usages {
+            // Skip if only one resource uses this source file
+            if uses.len() <= 1 {
+                continue;
+            }
+
+            // Collect unique versions
+            let versions: HashSet<Option<String>> =
+                uses.iter().map(|u| u.version.clone()).collect();
+
+            // If there are different versions, it's a redundancy worth noting
+            if versions.len() > 1 {
+                redundancies.push(Redundancy {
+                    source_file: source_file.clone(),
+                    usages: uses.clone(),
+                });
+            }
+        }
+
+        redundancies
+    }
+
+    /// Determines if a redundancy could be consolidated to use a single version.
+    ///
+    /// This method analyzes a detected redundancy to determine if all resources
+    /// using the source file could reasonably be updated to use the same version.
+    /// This is a heuristic for suggesting consolidation opportunities.
+    ///
+    /// # Consolidation Logic
+    ///
+    /// A redundancy can be consolidated if:
+    /// - All resources use the same version constraint (already consolidated)
+    /// - All resources use "latest" (no specific versions)
+    ///
+    /// A redundancy cannot be easily consolidated if:
+    /// - Resources use different specific versions (may have compatibility reasons)
+    /// - Mixed latest and specific versions (may indicate intentional pinning)
+    ///
+    /// # Use Cases
+    ///
+    /// This method helps identify:
+    /// - **Easy Wins**: Redundancies that could be quickly resolved
+    /// - **Complex Cases**: Redundancies that may require careful consideration
+    /// - **Intentional Patterns**: Cases where redundancy might be deliberate
+    ///
+    /// # Parameters
+    ///
+    /// - `redundancy`: The redundancy pattern to analyze
+    ///
+    /// # Returns
+    ///
+    /// - `true`: All usages could likely be consolidated to a single version
+    /// - `false`: Consolidation would require careful analysis of compatibility
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use agpm::resolver::redundancy::{RedundancyDetector, Redundancy, ResourceUsage};
+    ///
+    /// let detector = RedundancyDetector::new();
+    ///
+    /// // Easy to consolidate (all use latest)
+    /// let easy_redundancy = Redundancy {
+    ///     source_file: "community:agents/helper.md".to_string(),
+    ///     usages: vec![
+    ///         ResourceUsage { resource_name: "helper1".to_string(), source_file: "community:agents/helper.md".to_string(), version: None },
+    ///         ResourceUsage { resource_name: "helper2".to_string(), source_file: "community:agents/helper.md".to_string(), version: None },
+    ///     ]
+    /// };
+    /// assert!(detector.can_consolidate(&easy_redundancy));
+    ///
+    /// // Hard to consolidate (different versions)
+    /// let hard_redundancy = Redundancy {
+    ///     source_file: "community:agents/helper.md".to_string(),
+    ///     usages: vec![
+    ///         ResourceUsage { resource_name: "helper1".to_string(), source_file: "community:agents/helper.md".to_string(), version: Some("v1.0.0".to_string()) },
+    ///         ResourceUsage { resource_name: "helper2".to_string(), source_file: "community:agents/helper.md".to_string(), version: Some("v2.0.0".to_string()) },
+    ///     ]
+    /// };
+    /// assert!(!detector.can_consolidate(&hard_redundancy));
+    /// ```
+    #[must_use]
+    pub fn can_consolidate(&self, redundancy: &Redundancy) -> bool {
+        // If all usages want the same version or latest, they could be consolidated
+        let versions: HashSet<_> = redundancy.usages.iter().map(|u| &u.version).collect();
+        versions.len() == 1
+    }
+
+    /// Generates a comprehensive warning message for detected redundancies.
+    ///
+    /// This method creates a user-friendly warning message that explains detected
+    /// redundancies and provides actionable suggestions for optimization. The
+    /// message is designed to be informative rather than alarming, emphasizing
+    /// that redundancy is not an error.
+    ///
+    /// # Message Structure
+    ///
+    /// The generated warning includes:
+    /// 1. **Header**: Clear indication this is a warning, not an error
+    /// 2. **Redundancy List**: Each detected redundancy with details
+    /// 3. **General Guidance**: Explanation of implications and options
+    /// 4. **Specific Suggestions**: Targeted advice based on detected patterns
+    ///
+    /// # Message Tone
+    ///
+    /// The warning message maintains a helpful, non-blocking tone:
+    /// - Emphasizes that installation will proceed normally
+    /// - Explains that redundancy may be intentional
+    /// - Provides optimization suggestions without mandating changes
+    /// - Uses clear, jargon-free language
+    ///
+    /// # Color Coding
+    ///
+    /// The message uses terminal colors for better readability:
+    /// - **Yellow**: Warning indicators and attention markers
+    /// - **Blue**: Informational notes and suggestions
+    /// - **Default**: Main content and resource names
+    ///
+    /// # Parameters
+    ///
+    /// - `redundancies`: List of detected redundancy patterns
+    ///
+    /// # Returns
+    ///
+    /// - **Non-empty**: Formatted warning message if redundancies exist
+    /// - **Empty string**: If no redundancies provided
+    ///
+    /// # Example Output
+    ///
+    /// ```text
+    /// Warning: Redundant dependencies detected
+    ///
+    /// ⚠ Multiple versions of 'community:agents/helper.md' will be installed:
+    ///   - 'app-helper' uses version v1.0.0
+    ///   - 'tool-helper' uses version latest
+    ///
+    /// Note: This is not an error, but you may want to consider:
+    ///   • Using the same version for consistency
+    ///   • These resources will be installed to different files
+    ///   • Each will work independently
+    ///   • Consider aligning versions for 'community:agents/helper.md' across all resources
+    /// ```
+    #[must_use]
+    pub fn generate_redundancy_warning(&self, redundancies: &[Redundancy]) -> String {
+        if redundancies.is_empty() {
+            return String::new();
+        }
+
+        let mut message = format!(
+            "\n{} Redundant dependencies detected\n\n",
+            "Warning:".yellow().bold()
+        );
+
+        for redundancy in redundancies {
+            message.push_str(&format!("{redundancy}\n"));
+        }
+
+        message.push_str(&format!(
+            "\n{} This is not an error, but you may want to consider:\n",
+            "Note:".blue()
+        ));
+        message.push_str("  • Using the same version for consistency\n");
+        message.push_str("  • These resources will be installed to different files\n");
+        message.push_str("  • Each will work independently\n");
+
+        // Add specific suggestions based on redundancy patterns
+        for redundancy in redundancies {
+            let has_latest = redundancy.usages.iter().any(|u| u.version.is_none());
+            let has_specific = redundancy.usages.iter().any(|u| u.version.is_some());
+
+            if has_latest && has_specific {
+                message.push_str(&format!(
+                    "  • Consider aligning versions for '{}' across all resources\n",
+                    redundancy.source_file
+                ));
+            }
+        }
+
+        message
+    }
+
+    /// Placeholder for future transitive redundancy detection.
+    ///
+    /// This method is reserved for future implementation when AGPM supports
+    /// dependencies-of-dependencies (transitive dependencies). Currently returns
+    /// an empty vector as transitive analysis is not yet implemented.
+    ///
+    /// # Planned Functionality
+    ///
+    /// When implemented, this method will:
+    /// 1. **Build Dependency Tree**: Map entire transitive dependency graph
+    /// 2. **Detect Deep Redundancy**: Find redundant patterns across dependency levels
+    /// 3. **Analyze Impact**: Calculate storage and maintenance implications
+    /// 4. **Suggest Optimizations**: Recommend dependency tree restructuring
+    ///
+    /// # Example Future Analysis
+    ///
+    /// ```text
+    /// Direct:     app-agent → community:agents/helper.md v1.0.0
+    /// Transitive: app-agent → tool-lib → community:agents/helper.md v2.0.0
+    ///
+    /// Result: Transitive redundancy detected - app-agent indirectly depends
+    ///         on two versions of the same resource.
+    /// ```
+    ///
+    /// # Implementation Challenges
+    ///
+    /// - **Circular Dependencies**: Detection and handling of cycles
+    /// - **Version Compatibility**: Analyzing semantic version compatibility
+    /// - **Performance**: Efficient analysis of large dependency trees
+    /// - **Cache Management**: Handling cached vs. fresh transitive data
+    ///
+    /// # Returns
+    ///
+    /// Currently returns an empty vector. Future implementation will return
+    /// detected transitive redundancies.
+    #[must_use]
+    pub fn check_transitive_redundancies(&self) -> Vec<Redundancy> {
+        // TODO: When we add support for dependencies having their own dependencies,
+        // we'll need to check for redundancies across the entire dependency tree
+        Vec::new()
+    }
+
+    /// Generates actionable consolidation strategies for a specific redundancy.
+    ///
+    /// This method analyzes a detected redundancy pattern and provides specific,
+    /// actionable suggestions for resolving or managing the redundancy. The
+    /// suggestions are tailored to the specific pattern of version usage.
+    ///
+    /// # Strategy Categories
+    ///
+    /// ## Version Alignment
+    /// For redundancies with multiple specific versions:
+    /// - Suggest adopting a single version across all resources
+    /// - Recommend the most recent or most commonly used version
+    ///
+    /// ## Constraint Standardization
+    /// For mixed latest/specific version patterns:
+    /// - Suggest using specific versions for reproducibility
+    /// - Explain benefits of version pinning
+    ///
+    /// ## Impact Assessment
+    /// For all redundancies:
+    /// - Clarify that resources will be installed independently
+    /// - Explain that each resource will function correctly
+    /// - List all affected resource names
+    ///
+    /// # Suggestion Algorithm
+    ///
+    /// 1. **Analyze Version Pattern**: Identify specific vs. latest usage
+    /// 2. **Generate Alignment Suggestions**: Recommend version standardization
+    /// 3. **Provide Context**: Explain implications and benefits
+    /// 4. **List Affected Resources**: Show impact scope
+    ///
+    /// # Parameters
+    ///
+    /// - `redundancy`: The redundancy pattern to analyze
+    ///
+    /// # Returns
+    ///
+    /// A vector of suggestion strings, ordered by priority:
+    /// 1. Primary suggestions (version alignment)
+    /// 2. Best practice recommendations (reproducibility)
+    /// 3. Impact clarification (what will actually happen)
+    ///
+    /// # Example Output
+    ///
+    /// For a redundancy with mixed version constraints:
+    /// ```text
+    /// "Consider using version v2.0.0 for all resources using 'community:agents/helper.md'"
+    /// "Consider using specific versions for all resources for reproducibility"
+    /// "Note: Each resource (app-helper, tool-helper) will be installed independently"
+    /// ```
+    ///
+    /// # Use Cases
+    ///
+    /// - **CLI Tools**: Generate help text for redundancy warnings
+    /// - **IDE Extensions**: Provide quick-fix suggestions
+    /// - **Automated Tools**: Implement dependency optimization utilities
+    /// - **Documentation**: Generate project-specific optimization guides
+    #[must_use]
+    pub fn suggest_consolidation(&self, redundancy: &Redundancy) -> Vec<String> {
+        let mut suggestions = Vec::new();
+
+        // Collect all versions being used
+        let versions: Vec<_> = redundancy
+            .usages
+            .iter()
+            .filter_map(|u| u.version.as_ref())
+            .collect();
+
+        if !versions.is_empty() {
+            // Suggest using the same version for consistency
+            if let Some(version) = versions.first() {
+                suggestions.push(format!(
+                    "Consider using version {} for all resources using '{}'",
+                    version, redundancy.source_file
+                ));
+            }
+        }
+
+        // If mixing latest and specific versions
+        let has_latest = redundancy.usages.iter().any(|u| u.version.is_none());
+        let has_specific = redundancy.usages.iter().any(|u| u.version.is_some());
+
+        if has_latest && has_specific {
+            suggestions.push(
+                "Consider using specific versions for all resources for reproducibility"
+                    .to_string(),
+            );
+        }
+
+        // Explain that this isn't breaking
+        suggestions.push(format!(
+            "Note: Each resource ({}) will be installed independently",
+            redundancy
+                .usages
+                .iter()
+                .map(|u| &u.resource_name)
+                .cloned()
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+
+        suggestions
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manifest::DetailedDependency;
+
+    /// Tests basic redundancy detection with different versions of the same resource.
+    ///
+    /// This test verifies that the detector correctly identifies when multiple
+    /// resources reference the same source file with different version constraints.
+    #[test]
+    fn test_detect_simple_redundancy() {
+        let mut detector = RedundancyDetector::new();
+
+        // Add resources using different versions of the same source file
+        detector.add_usage(
+            "app-agent".to_string(),
+            &ResourceDependency::Detailed(Box::new(DetailedDependency {
+                source: Some("community".to_string()),
+                path: "agents/shared.md".to_string(),
+                version: Some("v1.0.0".to_string()),
+                branch: None,
+                rev: None,
+                command: None,
+                args: None,
+                target: None,
+                filename: None,
+                dependencies: None,
+            })),
+        );
+
+        detector.add_usage(
+            "tool-agent".to_string(),
+            &ResourceDependency::Detailed(Box::new(DetailedDependency {
+                source: Some("community".to_string()),
+                path: "agents/shared.md".to_string(),
+                version: Some("v2.0.0".to_string()),
+                branch: None,
+                rev: None,
+                command: None,
+                args: None,
+                target: None,
+                filename: None,
+                dependencies: None,
+            })),
+        );
+
+        let redundancies = detector.detect_redundancies();
+        assert_eq!(redundancies.len(), 1);
+
+        let redundancy = &redundancies[0];
+        assert_eq!(redundancy.source_file, "community:agents/shared.md");
+        assert_eq!(redundancy.usages.len(), 2);
+    }
+
+    /// Tests that resources using the same version are not flagged as redundant.
+    ///
+    /// This test ensures the detector doesn't generate false positives when
+    /// multiple resources legitimately use the same source file and version.
+    #[test]
+    fn test_no_redundancy_same_version() {
+        let mut detector = RedundancyDetector::new();
+
+        // Add resources using the same version - not considered redundant
+        detector.add_usage(
+            "agent1".to_string(),
+            &ResourceDependency::Detailed(Box::new(DetailedDependency {
+                source: Some("community".to_string()),
+                path: "agents/shared.md".to_string(),
+                version: Some("v1.0.0".to_string()),
+                branch: None,
+                rev: None,
+                command: None,
+                args: None,
+                target: None,
+                filename: None,
+                dependencies: None,
+            })),
+        );
+
+        detector.add_usage(
+            "agent2".to_string(),
+            &ResourceDependency::Detailed(Box::new(DetailedDependency {
+                source: Some("community".to_string()),
+                path: "agents/shared.md".to_string(),
+                version: Some("v1.0.0".to_string()),
+                branch: None,
+                rev: None,
+                command: None,
+                args: None,
+                target: None,
+                filename: None,
+                dependencies: None,
+            })),
+        );
+
+        let redundancies = detector.detect_redundancies();
+        assert_eq!(redundancies.len(), 0);
+    }
+
+    /// Tests detection of mixed latest/specific version redundancy patterns.
+    ///
+    /// This test verifies that the detector identifies redundancy when some
+    /// resources use latest (no version) while others specify explicit versions.
+    #[test]
+    fn test_redundancy_latest_vs_specific() {
+        let mut detector = RedundancyDetector::new();
+
+        // One wants latest, another wants specific version - this is redundant
+        detector.add_usage(
+            "agent1".to_string(),
+            &ResourceDependency::Detailed(Box::new(DetailedDependency {
+                source: Some("community".to_string()),
+                path: "agents/shared.md".to_string(),
+                version: None, // latest
+                branch: None,
+                rev: None,
+                command: None,
+                args: None,
+                target: None,
+                filename: None,
+                dependencies: None,
+            })),
+        );
+
+        detector.add_usage(
+            "agent2".to_string(),
+            &ResourceDependency::Detailed(Box::new(DetailedDependency {
+                source: Some("community".to_string()),
+                path: "agents/shared.md".to_string(),
+                version: Some("v1.0.0".to_string()),
+                branch: None,
+                rev: None,
+                command: None,
+                args: None,
+                target: None,
+                filename: None,
+                dependencies: None,
+            })),
+        );
+
+        let redundancies = detector.detect_redundancies();
+        assert_eq!(redundancies.len(), 1);
+    }
+
+    /// Tests that local dependencies are properly filtered out of redundancy analysis.
+    ///
+    /// This test ensures that local file dependencies don't participate in
+    /// redundancy detection since they don't have the source/version complexity.
+    #[test]
+    fn test_local_dependencies_ignored() {
+        let mut detector = RedundancyDetector::new();
+
+        // Local dependencies are not tracked for redundancy
+        detector.add_usage(
+            "local1".to_string(),
+            &ResourceDependency::Simple("../agents/agent1.md".to_string()),
+        );
+
+        detector.add_usage(
+            "local2".to_string(),
+            &ResourceDependency::Simple("../agents/agent2.md".to_string()),
+        );
+
+        let redundancies = detector.detect_redundancies();
+        assert_eq!(redundancies.len(), 0);
+    }
+
+    /// Tests the generation of comprehensive warning messages for redundancies.
+    ///
+    /// This test verifies that the warning message generator produces appropriate
+    /// content including resource names, versions, and helpful guidance.
+    #[test]
+    fn test_generate_redundancy_warning() {
+        let mut detector = RedundancyDetector::new();
+
+        detector.add_usage(
+            "app".to_string(),
+            &ResourceDependency::Detailed(Box::new(DetailedDependency {
+                source: Some("community".to_string()),
+                path: "agents/shared.md".to_string(),
+                version: Some("v1.0.0".to_string()),
+                branch: None,
+                rev: None,
+                command: None,
+                args: None,
+                target: None,
+                filename: None,
+                dependencies: None,
+            })),
+        );
+
+        detector.add_usage(
+            "tool".to_string(),
+            &ResourceDependency::Detailed(Box::new(DetailedDependency {
+                source: Some("community".to_string()),
+                path: "agents/shared.md".to_string(),
+                version: Some("v2.0.0".to_string()),
+                branch: None,
+                rev: None,
+                command: None,
+                args: None,
+                target: None,
+                filename: None,
+                dependencies: None,
+            })),
+        );
+
+        let redundancies = detector.detect_redundancies();
+        let warning = detector.generate_redundancy_warning(&redundancies);
+
+        assert!(warning.contains("Redundant dependencies detected"));
+        assert!(warning.contains("app"));
+        assert!(warning.contains("tool"));
+        assert!(warning.contains("not an error"));
+    }
+
+    /// Tests the generation of consolidation suggestions for redundancy patterns.
+    ///
+    /// This test verifies that the suggestion generator produces actionable
+    /// recommendations for resolving detected redundancy patterns.
+    #[test]
+    fn test_suggest_consolidation() {
+        let mut detector = RedundancyDetector::new();
+
+        detector.add_usage(
+            "app".to_string(),
+            &ResourceDependency::Detailed(Box::new(DetailedDependency {
+                source: Some("community".to_string()),
+                path: "agents/shared.md".to_string(),
+                version: None, // latest
+                branch: None,
+                rev: None,
+                command: None,
+                args: None,
+                target: None,
+                filename: None,
+                dependencies: None,
+            })),
+        );
+
+        detector.add_usage(
+            "tool".to_string(),
+            &ResourceDependency::Detailed(Box::new(DetailedDependency {
+                source: Some("community".to_string()),
+                path: "agents/shared.md".to_string(),
+                version: Some("v2.0.0".to_string()),
+                branch: None,
+                rev: None,
+                command: None,
+                args: None,
+                target: None,
+                filename: None,
+                dependencies: None,
+            })),
+        );
+
+        let redundancies = detector.detect_redundancies();
+        let suggestions = detector.suggest_consolidation(&redundancies[0]);
+
+        assert!(!suggestions.is_empty());
+        assert!(suggestions.iter().any(|s| s.contains("v2.0.0")));
+        assert!(suggestions.iter().any(|s| s.contains("independently")));
+    }
+}

--- a/src/resolver/redundancy.rs
+++ b/src/resolver/redundancy.rs
@@ -681,7 +681,7 @@ impl RedundancyDetector {
     /// Currently returns an empty vector. Future implementation will return
     /// detected transitive redundancies.
     #[must_use]
-    pub fn check_transitive_redundancies(&self) -> Vec<Redundancy> {
+    pub const fn check_transitive_redundancies(&self) -> Vec<Redundancy> {
         // TODO: When we add support for dependencies having their own dependencies,
         // we'll need to check for redundancies across the entire dependency tree
         Vec::new()

--- a/src/resolver/version_resolution.rs
+++ b/src/resolver/version_resolution.rs
@@ -149,8 +149,7 @@ pub fn find_best_matching_tag(constraint_str: &str, tags: Vec<String>) -> Result
     }
 
     Err(anyhow::anyhow!(
-        "No tag found matching constraint: {}",
-        constraint_str
+        "No tag found matching constraint: {constraint_str}"
     ))
 }
 

--- a/src/resolver/version_resolution.rs
+++ b/src/resolver/version_resolution.rs
@@ -25,7 +25,7 @@ use crate::version::constraints::{ConstraintSet, VersionConstraint};
 /// # Examples
 ///
 /// ```
-/// use ccpm::resolver::version_resolution::is_version_constraint;
+/// use agpm::resolver::version_resolution::is_version_constraint;
 /// assert!(is_version_constraint("^1.0.0"));
 /// assert!(is_version_constraint("~1.2.0"));
 /// assert!(is_version_constraint(">=1.0.0"));
@@ -73,7 +73,7 @@ pub fn is_version_constraint(version: &str) -> bool {
 /// # Examples
 ///
 /// ```
-/// use ccpm::resolver::version_resolution::parse_tags_to_versions;
+/// use agpm::resolver::version_resolution::parse_tags_to_versions;
 /// let tags = vec!["v1.0.0".to_string(), "1.2.0".to_string(), "feature-branch".to_string(), "v2.0.0-beta.1".to_string()];
 /// let versions = parse_tags_to_versions(tags);
 /// // Returns: [("v2.0.0-beta.1", Version), ("1.2.0", Version), ("v1.0.0", Version)]
@@ -118,7 +118,7 @@ pub fn parse_tags_to_versions(tags: Vec<String>) -> Vec<(String, Version)> {
 /// ```no_run
 /// # use anyhow::Result;
 /// # fn example() -> Result<()> {
-/// use ccpm::resolver::version_resolution::find_best_matching_tag;
+/// use agpm::resolver::version_resolution::find_best_matching_tag;
 /// let tags = vec!["v1.0.0".to_string(), "v1.2.0".to_string(), "v1.5.0".to_string(), "v2.0.0".to_string()];
 /// let best = find_best_matching_tag("^1.0.0", tags)?;
 /// assert_eq!(best, "v1.5.0"); // Highest 1.x.x version

--- a/src/resolver/version_resolver.rs
+++ b/src/resolver/version_resolver.rs
@@ -1,4 +1,4 @@
-//! Centralized version resolution module for CCPM
+//! Centralized version resolution module for AGPM
 //!
 //! This module implements the core version-to-SHA resolution strategy that ensures
 //! deterministic and efficient dependency management. By resolving all version
@@ -48,8 +48,8 @@ pub struct VersionEntry {
 /// # Example
 ///
 /// ```no_run
-/// # use ccpm::resolver::version_resolver::{VersionResolver, VersionEntry};
-/// # use ccpm::cache::Cache;
+/// # use agpm::resolver::version_resolver::{VersionResolver, VersionEntry};
+/// # use agpm::cache::Cache;
 /// # async fn example() -> anyhow::Result<()> {
 /// let cache = Cache::new()?;
 /// let mut resolver = VersionResolver::new(cache);
@@ -128,7 +128,7 @@ impl VersionResolver {
 
     /// Resolves all collected versions to their commit SHAs using cached repositories.
     ///
-    /// This method implements the second phase of CCPM's two-phase resolution architecture.
+    /// This method implements the second phase of AGPM's two-phase resolution architecture.
     /// It processes all version entries collected via `add_version()` calls and resolves
     /// them to concrete commit SHAs using locally cached Git repositories.
     ///
@@ -166,8 +166,8 @@ impl VersionResolver {
     /// # Example
     ///
     /// ```ignore
-    /// # use ccpm::resolver::version_resolver::VersionResolver;
-    /// # use ccpm::cache::Cache;
+    /// # use agpm::resolver::version_resolver::VersionResolver;
+    /// # use agpm::cache::Cache;
     /// # async fn example() -> anyhow::Result<()> {
     /// let cache = Cache::new()?;
     /// let mut resolver = VersionResolver::new(cache);
@@ -397,7 +397,7 @@ impl VersionResolver {
 
     /// Pre-syncs all unique sources to ensure repositories are cloned/fetched.
     ///
-    /// This method implements the first phase of CCPM's two-phase resolution architecture.
+    /// This method implements the first phase of AGPM's two-phase resolution architecture.
     /// It is designed to be called during the "Syncing sources" phase to perform all
     /// Git network operations upfront, before version resolution occurs.
     ///
@@ -409,7 +409,7 @@ impl VersionResolver {
     /// # Post-Execution State
     ///
     /// After this method completes successfully:
-    /// - All required repositories will be cloned to `~/.ccpm/cache/sources/`
+    /// - All required repositories will be cloned to `~/.agpm/cache/sources/`
     /// - All repositories will have their latest refs fetched from remote
     /// - The internal `bare_repos` map will be populated with repository paths
     /// - `resolve_all()` can proceed without any network operations
@@ -423,8 +423,8 @@ impl VersionResolver {
     /// # Example
     ///
     /// ```ignore
-    /// use ccpm::resolver::version_resolver::VersionResolver;
-    /// use ccpm::cache::Cache;
+    /// use agpm::resolver::version_resolver::VersionResolver;
+    /// use agpm::cache::Cache;
     ///
     /// # async fn example() -> anyhow::Result<()> {
     /// let cache = Cache::new()?;
@@ -433,17 +433,17 @@ impl VersionResolver {
     /// // Add versions to resolve across multiple sources
     /// version_resolver.add_version(
     ///     "community",
-    ///     "https://github.com/org/ccpm-community.git",
+    ///     "https://github.com/org/agpm-community.git",
     ///     Some("v1.0.0"),
     /// );
     /// version_resolver.add_version(
     ///     "community",
-    ///     "https://github.com/org/ccpm-community.git",
+    ///     "https://github.com/org/agpm-community.git",
     ///     Some("v2.0.0"),
     /// );
     /// version_resolver.add_version(
     ///     "private-tools",
-    ///     "https://github.com/company/private-ccpm.git",
+    ///     "https://github.com/company/private-agpm.git",
     ///     Some("main"),
     /// );
     ///
@@ -535,8 +535,8 @@ impl VersionResolver {
     /// # Example
     ///
     /// ```
-    /// # use ccpm::resolver::version_resolver::VersionResolver;
-    /// # use ccpm::cache::Cache;
+    /// # use agpm::resolver::version_resolver::VersionResolver;
+    /// # use agpm::cache::Cache;
     /// # let cache = Cache::new().unwrap();
     /// let mut resolver = VersionResolver::new(cache);
     /// assert!(!resolver.has_entries()); // Initially empty

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -302,7 +302,7 @@ impl Source {
     /// assert!(source.description.is_none());
     /// ```
     #[must_use]
-    pub fn new(name: String, url: String) -> Self {
+    pub const fn new(name: String, url: String) -> Self {
         Self {
             name,
             url,
@@ -1665,14 +1665,14 @@ impl SourceManager {
             if std::path::Path::new(path).exists() {
                 return Ok(());
             }
-            return Err(anyhow::anyhow!("Local path does not exist: {}", path));
+            return Err(anyhow::anyhow!("Local path does not exist: {path}"));
         }
 
         // For other URLs, try to create a GitRepo object and verify it's accessible
         // This is a lightweight check - we don't actually clone the repo
         match crate::git::GitRepo::verify_url(url).await {
             Ok(()) => Ok(()),
-            Err(e) => Err(anyhow::anyhow!("Source not accessible: {}", e)),
+            Err(e) => Err(anyhow::anyhow!("Source not accessible: {e}")),
         }
     }
 }

--- a/src/test_utils/builder.rs
+++ b/src/test_utils/builder.rs
@@ -77,14 +77,14 @@ impl TestEnvironmentBuilder {
         std::fs::create_dir_all(&self.cache_dir)?;
 
         // Write manifest if provided
-        let manifest_path = self.project_dir.join("ccpm.toml");
+        let manifest_path = self.project_dir.join("agpm.toml");
         if let Some(manifest) = &self.manifest {
             let content = toml::to_string_pretty(manifest)?;
             std::fs::write(&manifest_path, content)?;
         }
 
         // Write lockfile if provided
-        let lockfile_path = self.project_dir.join("ccpm.lock");
+        let lockfile_path = self.project_dir.join("agpm.lock");
         if let Some(lockfile) = &self.lockfile {
             lockfile.save(&lockfile_path)?;
         }
@@ -206,7 +206,7 @@ mod tests {
         let manifest = Manifest::default();
         let env = TestEnvironment::with_manifest(manifest).unwrap();
 
-        assert!(env.file_exists("ccpm.toml"));
+        assert!(env.file_exists("agpm.toml"));
         let loaded = env.load_manifest().unwrap();
         assert_eq!(loaded.sources.len(), 0);
     }

--- a/src/test_utils/environment.rs
+++ b/src/test_utils/environment.rs
@@ -69,7 +69,7 @@ utils = {{ source = "official", path = "snippets/utils.md", version = "v1.0.0" }
             env.sources_dir.display()
         );
 
-        fs::write(env.project_dir.join("ccpm.toml"), manifest_content.trim())?;
+        fs::write(env.project_dir.join("agpm.toml"), manifest_content.trim())?;
         Ok(env)
     }
 
@@ -103,7 +103,7 @@ utils = {{ source = "official", path = "snippets/utils.md", version = "v1.0.0" }
             env.sources_dir.display()
         );
 
-        fs::write(env.project_dir.join("ccpm.toml"), manifest_content.trim())?;
+        fs::write(env.project_dir.join("agpm.toml"), manifest_content.trim())?;
 
         // Create a matching lockfile that uses file:// URLs
         let lockfile_content = format!(
@@ -154,7 +154,7 @@ installed_at = "snippets/utils.md"
             env.sources_dir.display()
         );
 
-        fs::write(env.project_dir.join("ccpm.lock"), lockfile_content.trim())?;
+        fs::write(env.project_dir.join("agpm.lock"), lockfile_content.trim())?;
         Ok(env)
     }
 

--- a/src/test_utils/fixtures.rs
+++ b/src/test_utils/fixtures.rs
@@ -299,7 +299,7 @@ pub struct GitRepoFixture {
 impl GitRepoFixture {
     /// Create a new git repository fixture
     #[must_use]
-    pub fn new(path: PathBuf) -> Self {
+    pub const fn new(path: PathBuf) -> Self {
         Self {
             path,
             files: Vec::new(),

--- a/src/test_utils/fixtures.rs
+++ b/src/test_utils/fixtures.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-/// Test fixture for creating sample ccpm.toml files
+/// Test fixture for creating sample agpm.toml files
 #[derive(Clone, Debug)]
 pub struct ManifestFixture {
     pub content: String,
@@ -23,8 +23,8 @@ impl ManifestFixture {
             name: "basic".to_string(),
             content: r#"
 [sources]
-official = "https://github.com/example-org/ccpm-official.git"
-community = "https://github.com/example-org/ccpm-community.git"
+official = "https://github.com/example-org/agpm-official.git"
+community = "https://github.com/example-org/agpm-community.git"
 
 [agents]
 my-agent = { source = "official", path = "agents/my-agent.md", version = "v1.0.0" }
@@ -45,7 +45,7 @@ utils = { source = "official", path = "snippets/utils.md", version = "v1.0.0" }
             name: "with_local".to_string(),
             content: r#"
 [sources]
-official = "https://github.com/example-org/ccpm-official.git"
+official = "https://github.com/example-org/agpm-official.git"
 
 [agents]
 my-agent = { source = "official", path = "agents/my-agent.md", version = "v1.0.0" }
@@ -66,7 +66,7 @@ local-utils = { path = "./snippets/local-utils.md" }
             name: "invalid_syntax".to_string(),
             content: r#"
 [sources
-official = "https://github.com/example-org/ccpm-official.git"
+official = "https://github.com/example-org/agpm-official.git"
 
 [agents]
 my-agent = { source = "official", path = "agents/my-agent.md", version = "v1.0.0"
@@ -83,7 +83,7 @@ my-agent = { source = "official", path = "agents/my-agent.md", version = "v1.0.0
             name: "missing_fields".to_string(),
             content: r#"
 [sources]
-official = "https://github.com/example-org/ccpm-official.git"
+official = "https://github.com/example-org/agpm-official.git"
 
 [agents]
 incomplete-agent = { source = "official", path = "agents/test.md" }  # Missing version
@@ -100,8 +100,8 @@ incomplete-agent = { source = "official", path = "agents/test.md" }  # Missing v
             name: "version_conflicts".to_string(),
             content: r#"
 [sources]
-source1 = "https://github.com/example-org/ccpm-repo1.git"
-source2 = "https://github.com/example-org/ccpm-repo2.git"
+source1 = "https://github.com/example-org/agpm-repo1.git"
+source2 = "https://github.com/example-org/agpm-repo2.git"
 
 [agents]
 agent1 = { source = "source1", path = "shared/lib.md", version = "v1.0.0" }
@@ -118,7 +118,7 @@ agent2 = { source = "source2", path = "shared/lib.md", version = "v2.0.0" }
         Self {
             name: "empty".to_string(),
             content: r"
-# Empty ccpm.toml file
+# Empty agpm.toml file
 # No sources or dependencies defined
 "
             .trim()
@@ -128,13 +128,13 @@ agent2 = { source = "source2", path = "shared/lib.md", version = "v2.0.0" }
 
     /// Write the manifest to a directory
     pub fn write_to(&self, dir: &Path) -> Result<PathBuf> {
-        let manifest_path = dir.join("ccpm.toml");
+        let manifest_path = dir.join("agpm.toml");
         fs::write(&manifest_path, &self.content)?;
         Ok(manifest_path)
     }
 }
 
-/// Test fixture for creating sample ccpm.lock files
+/// Test fixture for creating sample agpm.lock files
 #[derive(Clone, Debug)]
 pub struct LockfileFixture {
     pub content: String,
@@ -153,13 +153,13 @@ version = 1
 
 [[sources]]
 name = "official"
-url = "https://github.com/example-org/ccpm-official.git"
+url = "https://github.com/example-org/agpm-official.git"
 commit = "abc123456789abcdef123456789abcdef12345678"
 fetched_at = "2024-01-01T00:00:00Z"
 
 [[sources]]
 name = "community"
-url = "https://github.com/example-org/ccpm-community.git"
+url = "https://github.com/example-org/agpm-community.git"
 commit = "def456789abcdef123456789abcdef123456789ab"
 fetched_at = "2024-01-01T00:00:00Z"
 
@@ -179,7 +179,7 @@ installed_at = "agents/my-agent.md"
 
     /// Write the lockfile to a directory
     pub fn write_to(&self, dir: &Path) -> Result<PathBuf> {
-        let lockfile_path = dir.join("ccpm.lock");
+        let lockfile_path = dir.join("agpm.lock");
         fs::write(&lockfile_path, &self.content)?;
         Ok(lockfile_path)
     }

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -1,4 +1,4 @@
-//! Test utilities for CCPM
+//! Test utilities for AGPM
 //!
 //! This module provides utilities for writing tests, including helpers for
 //! managing test environments, temporary directories, and test isolation.
@@ -22,7 +22,7 @@
 //!         let env = TestEnvironment::with_basic_manifest().unwrap();
 //!         
 //!         // Use the test environment
-//!         assert!(env.file_exists("ccpm.toml"));
+//!         assert!(env.file_exists("agpm.toml"));
 //!     }
 //! }
 //! ```
@@ -59,10 +59,10 @@ static INIT_LOGGING: Once = Once::new();
 ///
 /// fn my_test() {
 ///     // Use environment variable
-///     ccpm::test_utils::init_test_logging(None);
+///     agpm::test_utils::init_test_logging(None);
 ///     
 ///     // Or set level programmatically
-///     ccpm::test_utils::init_test_logging(Some(Level::DEBUG));
+///     agpm::test_utils::init_test_logging(Some(Level::DEBUG));
 ///     
 ///     // Your test code here - logging will work
 /// }

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -45,12 +45,12 @@ static INIT_LOGGING: Once = Once::new();
 /// Initialize logging for tests.
 ///
 /// This function initializes the tracing subscriber for tests, but only once
-/// regardless of how many times it's called. It respects the RUST_LOG environment
+/// regardless of how many times it's called. It respects the `RUST_LOG` environment
 /// variable if set, or uses the provided log level.
 ///
 /// # Arguments
 ///
-/// * `level` - Optional log level to use. If None, uses RUST_LOG environment variable
+/// * `level` - Optional log level to use. If None, uses `RUST_LOG` environment variable
 ///
 /// # Example
 ///

--- a/src/upgrade/backup.rs
+++ b/src/upgrade/backup.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use tokio::fs;
 use tracing::{debug, info, warn};
 
-/// Manages backup and restoration of CCPM binaries during upgrades.
+/// Manages backup and restoration of AGPM binaries during upgrades.
 ///
 /// `BackupManager` provides comprehensive backup functionality to protect against
 /// failed upgrades and enable rollback capabilities. It creates backups of the
@@ -42,11 +42,11 @@ use tracing::{debug, info, warn};
 ///
 /// ## Basic Backup and Restore
 /// ```rust,no_run
-/// use ccpm::upgrade::backup::BackupManager;
+/// use agpm::upgrade::backup::BackupManager;
 /// use std::path::PathBuf;
 ///
 /// # async fn example() -> anyhow::Result<()> {
-/// let exe_path = PathBuf::from("/usr/local/bin/ccpm");
+/// let exe_path = PathBuf::from("/usr/local/bin/agpm");
 /// let backup_manager = BackupManager::new(exe_path);
 ///
 /// // Create backup before upgrade
@@ -67,10 +67,10 @@ use tracing::{debug, info, warn};
 ///
 /// ## Check for Existing Backup
 /// ```rust,no_run
-/// use ccpm::upgrade::backup::BackupManager;
+/// use agpm::upgrade::backup::BackupManager;
 /// use std::path::PathBuf;
 ///
-/// let backup_manager = BackupManager::new(PathBuf::from("ccpm"));
+/// let backup_manager = BackupManager::new(PathBuf::from("agpm"));
 ///
 /// if backup_manager.backup_exists() {
 ///     println!("Backup found at: {}", backup_manager.backup_path().display());
@@ -110,16 +110,16 @@ impl BackupManager {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::upgrade::backup::BackupManager;
+    /// use agpm::upgrade::backup::BackupManager;
     /// use std::path::PathBuf;
     ///
     /// // Unix-style path
-    /// let manager = BackupManager::new(PathBuf::from("/usr/local/bin/ccpm"));
-    /// // Backup will be at /usr/local/bin/ccpm.backup
+    /// let manager = BackupManager::new(PathBuf::from("/usr/local/bin/agpm"));
+    /// // Backup will be at /usr/local/bin/agpm.backup
     ///
     /// // Windows-style path
-    /// let manager = BackupManager::new(PathBuf::from(r"C:\Program Files\ccpm\ccpm.exe"));
-    /// // Backup will be at C:\Program Files\ccpm\ccpm.exe.backup
+    /// let manager = BackupManager::new(PathBuf::from(r"C:\Program Files\agpm\agpm.exe"));
+    /// // Backup will be at C:\Program Files\agpm\agpm.exe.backup
     /// ```
     pub fn new(executable_path: PathBuf) -> Self {
         let mut backup_path = executable_path.clone();
@@ -165,11 +165,11 @@ impl BackupManager {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::upgrade::backup::BackupManager;
+    /// use agpm::upgrade::backup::BackupManager;
     /// use std::path::PathBuf;
     ///
     /// # async fn example() -> anyhow::Result<()> {
-    /// let manager = BackupManager::new(PathBuf::from("./ccpm"));
+    /// let manager = BackupManager::new(PathBuf::from("./agpm"));
     ///
     /// match manager.create_backup().await {
     ///     Ok(()) => println!("Backup created successfully"),
@@ -255,11 +255,11 @@ impl BackupManager {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::upgrade::backup::BackupManager;
+    /// use agpm::upgrade::backup::BackupManager;
     /// use std::path::PathBuf;
     ///
     /// # async fn example() -> anyhow::Result<()> {
-    /// let manager = BackupManager::new(PathBuf::from("./ccpm"));
+    /// let manager = BackupManager::new(PathBuf::from("./agpm"));
     ///
     /// if manager.backup_exists() {
     ///     match manager.restore_backup().await {
@@ -369,11 +369,11 @@ impl BackupManager {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::upgrade::backup::BackupManager;
+    /// use agpm::upgrade::backup::BackupManager;
     /// use std::path::PathBuf;
     ///
     /// # async fn example() -> anyhow::Result<()> {
-    /// let manager = BackupManager::new(PathBuf::from("./ccpm"));
+    /// let manager = BackupManager::new(PathBuf::from("./agpm"));
     ///
     /// // After successful upgrade
     /// manager.cleanup_backup().await?;
@@ -409,10 +409,10 @@ impl BackupManager {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::upgrade::backup::BackupManager;
+    /// use agpm::upgrade::backup::BackupManager;
     /// use std::path::PathBuf;
     ///
-    /// let manager = BackupManager::new(PathBuf::from("./ccpm"));
+    /// let manager = BackupManager::new(PathBuf::from("./agpm"));
     ///
     /// if manager.backup_exists() {
     ///     println!("Backup available for rollback");
@@ -442,12 +442,12 @@ impl BackupManager {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::upgrade::backup::BackupManager;
+    /// use agpm::upgrade::backup::BackupManager;
     /// use std::path::PathBuf;
     ///
-    /// let manager = BackupManager::new(PathBuf::from("/usr/local/bin/ccpm"));
+    /// let manager = BackupManager::new(PathBuf::from("/usr/local/bin/agpm"));
     /// println!("Backup location: {}", manager.backup_path().display());
-    /// // Output: Backup location: /usr/local/bin/ccpm.backup
+    /// // Output: Backup location: /usr/local/bin/agpm.backup
     /// ```
     ///
     /// # Use Cases

--- a/src/upgrade/backup.rs
+++ b/src/upgrade/backup.rs
@@ -285,7 +285,7 @@ impl BackupManager {
 
         while attempts < MAX_ATTEMPTS {
             match self.attempt_restore().await {
-                Ok(_) => {
+                Ok(()) => {
                     info!("Successfully restored from backup");
                     return Ok(());
                 }
@@ -302,7 +302,7 @@ impl BackupManager {
             }
         }
 
-        bail!("Failed to restore backup after {} attempts", MAX_ATTEMPTS)
+        bail!("Failed to restore backup after {MAX_ATTEMPTS} attempts")
     }
 
     /// Attempt a single restoration operation.

--- a/src/upgrade/config.rs
+++ b/src/upgrade/config.rs
@@ -214,7 +214,7 @@ impl Default for UpgradeConfig {
 ///
 /// Returns `false` to avoid adding network latency to every AGPM invocation.
 /// Users can explicitly enable this or use manual update checking.
-fn default_check_on_startup() -> bool {
+const fn default_check_on_startup() -> bool {
     false // Default to not checking on startup to avoid slowing down the CLI
 }
 
@@ -222,7 +222,7 @@ fn default_check_on_startup() -> bool {
 ///
 /// Returns `86400` (24 hours) to provide daily update notifications while
 /// being respectful of GitHub API rate limits and user attention.
-fn default_check_interval() -> u64 {
+const fn default_check_interval() -> u64 {
     86400 // 24 hours in seconds
 }
 
@@ -230,7 +230,7 @@ fn default_check_interval() -> u64 {
 ///
 /// Returns `true` to maximize safety during upgrades. Backups enable quick
 /// recovery from failed upgrades and add minimal overhead.
-fn default_auto_backup() -> bool {
+const fn default_auto_backup() -> bool {
     true // Always create backups for safety
 }
 
@@ -238,7 +238,7 @@ fn default_auto_backup() -> bool {
 ///
 /// Returns `true` to ensure download integrity and provide security against
 /// corrupted or tampered binaries. Verification adds minimal overhead.
-fn default_verify_checksum() -> bool {
+const fn default_verify_checksum() -> bool {
     true // Always verify checksums for security
 }
 

--- a/src/upgrade/config.rs
+++ b/src/upgrade/config.rs
@@ -1,15 +1,15 @@
 use serde::{Deserialize, Serialize};
 
-/// Configuration settings for CCPM self-update behavior.
+/// Configuration settings for AGPM self-update behavior.
 ///
-/// `UpgradeConfig` defines how CCPM handles automatic update checking,
+/// `UpgradeConfig` defines how AGPM handles automatic update checking,
 /// backup creation, and security verification during upgrades. These settings
 /// can be configured globally or per-project to control update behavior.
 ///
 /// # Configuration Categories
 ///
 /// ## Update Timing
-/// - **Startup Checks**: Whether to check for updates when CCPM starts
+/// - **Startup Checks**: Whether to check for updates when AGPM starts
 /// - **Check Intervals**: How frequently to perform background update checks
 ///
 /// ## Safety Settings
@@ -28,7 +28,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// ## Using Default Configuration
 /// ```rust,no_run
-/// use ccpm::upgrade::config::UpgradeConfig;
+/// use agpm::upgrade::config::UpgradeConfig;
 ///
 /// let config = UpgradeConfig::default();
 /// assert_eq!(config.check_on_startup, false);
@@ -37,7 +37,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// ## Custom Configuration
 /// ```rust,no_run
-/// use ccpm::upgrade::config::UpgradeConfig;
+/// use agpm::upgrade::config::UpgradeConfig;
 ///
 /// let config = UpgradeConfig {
 ///     check_on_startup: true,
@@ -62,20 +62,20 @@ use serde::{Deserialize, Serialize};
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UpgradeConfig {
-    /// Whether to check for updates when CCPM starts.
+    /// Whether to check for updates when AGPM starts.
     ///
-    /// When enabled, CCPM will perform a background check for updates every
+    /// When enabled, AGPM will perform a background check for updates every
     /// time it starts up. This provides the earliest notification of available
     /// updates but may slightly delay startup time.
     ///
     /// # Default: `false`
     ///
     /// Disabled by default to avoid slowing down CLI operations. Users can
-    /// manually check for updates using `ccpm upgrade --check`.
+    /// manually check for updates using `agpm upgrade --check`.
     ///
     /// # Considerations
     ///
-    /// - **Startup Performance**: Adds network delay to every CCPM invocation
+    /// - **Startup Performance**: Adds network delay to every AGPM invocation
     /// - **Network Dependency**: May fail or timeout in poor network conditions
     /// - **Rate Limiting**: Frequent use may hit GitHub API rate limits
     /// - **User Experience**: Can be intrusive for automated scripts
@@ -84,7 +84,7 @@ pub struct UpgradeConfig {
 
     /// Interval between automatic update checks in seconds.
     ///
-    /// Controls how frequently CCPM performs background checks for new versions.
+    /// Controls how frequently AGPM performs background checks for new versions.
     /// This setting balances update notification timeliness with network usage
     /// and API rate limit consumption.
     ///
@@ -109,7 +109,7 @@ pub struct UpgradeConfig {
 
     /// Whether to automatically create backups before upgrades.
     ///
-    /// When enabled, CCPM creates a backup copy of the current binary before
+    /// When enabled, AGPM creates a backup copy of the current binary before
     /// attempting any upgrade. This enables rollback if the upgrade fails or
     /// the new version has issues.
     ///
@@ -123,7 +123,7 @@ pub struct UpgradeConfig {
     /// - Creates a copy with `.backup` suffix in the same directory
     /// - Preserves file permissions and metadata
     /// - Automatically removed after successful upgrades
-    /// - Can be restored manually or via `ccpm upgrade --rollback`
+    /// - Can be restored manually or via `agpm upgrade --rollback`
     ///
     /// # Disabling Backups
     ///
@@ -137,7 +137,7 @@ pub struct UpgradeConfig {
 
     /// Whether to verify checksums of downloaded binaries.
     ///
-    /// When enabled, CCPM verifies the integrity of downloaded binaries by
+    /// When enabled, AGPM verifies the integrity of downloaded binaries by
     /// comparing their checksums against expected values. This provides
     /// protection against corrupted downloads and potential security issues.
     ///
@@ -192,7 +192,7 @@ impl Default for UpgradeConfig {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::upgrade::config::UpgradeConfig;
+    /// use agpm::upgrade::config::UpgradeConfig;
     ///
     /// let config = UpgradeConfig::default();
     /// assert_eq!(config.check_on_startup, false);
@@ -212,7 +212,7 @@ impl Default for UpgradeConfig {
 
 /// Default value for startup update checking.
 ///
-/// Returns `false` to avoid adding network latency to every CCPM invocation.
+/// Returns `false` to avoid adding network latency to every AGPM invocation.
 /// Users can explicitly enable this or use manual update checking.
 fn default_check_on_startup() -> bool {
     false // Default to not checking on startup to avoid slowing down the CLI
@@ -251,7 +251,7 @@ impl UpgradeConfig {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::upgrade::config::UpgradeConfig;
+    /// use agpm::upgrade::config::UpgradeConfig;
     ///
     /// // These are equivalent
     /// let config1 = UpgradeConfig::new();

--- a/src/upgrade/mod.rs
+++ b/src/upgrade/mod.rs
@@ -1,6 +1,6 @@
-//! Self-update functionality for CCPM.
+//! Self-update functionality for AGPM.
 //!
-//! This module provides comprehensive self-update capabilities for the CCPM binary,
+//! This module provides comprehensive self-update capabilities for the AGPM binary,
 //! allowing users to upgrade to newer versions directly from the command line.
 //! The implementation follows safety-first principles with automatic backups,
 //! rollback capabilities, and robust error handling.
@@ -73,21 +73,21 @@
 //!
 //! ## Basic Update Check
 //! ```bash
-//! ccpm upgrade --check          # Check for updates without installing
-//! ccpm upgrade --status         # Show current and latest versions
+//! agpm upgrade --check          # Check for updates without installing
+//! agpm upgrade --status         # Show current and latest versions
 //! ```
 //!
 //! ## Safe Upgrade
 //! ```bash
-//! ccpm upgrade                  # Upgrade to latest with automatic backup
-//! ccpm upgrade v0.4.0          # Upgrade to specific version
+//! agpm upgrade                  # Upgrade to latest with automatic backup
+//! agpm upgrade v0.4.0          # Upgrade to specific version
 //! ```
 //!
 //! ## Advanced Options
 //! ```bash
-//! ccpm upgrade --force          # Force upgrade even if on latest
-//! ccpm upgrade --no-backup      # Skip backup creation (not recommended)
-//! ccpm upgrade --rollback       # Restore from backup
+//! agpm upgrade --force          # Force upgrade even if on latest
+//! agpm upgrade --no-backup      # Skip backup creation (not recommended)
+//! agpm upgrade --rollback       # Restore from backup
 //! ```
 //!
 //! # Module Structure
@@ -104,7 +104,7 @@
 //! All functions return `Result<T, E>` for proper error propagation:
 //!
 //! ```rust,no_run
-//! use ccpm::upgrade::SelfUpdater;
+//! use agpm::upgrade::SelfUpdater;
 //!
 //! # async fn example() -> anyhow::Result<()> {
 //! let updater = SelfUpdater::new();
@@ -125,30 +125,30 @@
 //! - Includes comprehensive logging for debugging
 //! - Designed for minimal external dependencies
 
-/// Backup management for CCPM binary upgrades.
+/// Backup management for AGPM binary upgrades.
 ///
 /// The backup module provides functionality to create, manage, and restore backups
-/// of the CCPM binary during upgrade operations. This ensures safe upgrades with
+/// of the AGPM binary during upgrade operations. This ensures safe upgrades with
 /// the ability to rollback if issues occur.
 pub mod backup;
 /// Configuration structures for upgrade behavior.
 ///
-/// Defines configuration options that control how CCPM handles self-updates,
+/// Defines configuration options that control how AGPM handles self-updates,
 /// including backup settings, version checking preferences, and security options.
 pub mod config;
 /// Core self-update implementation.
 ///
 /// Contains the main SelfUpdater struct that handles downloading and installing
-/// CCPM updates from GitHub releases with proper version management and safety checks.
+/// AGPM updates from GitHub releases with proper version management and safety checks.
 pub mod self_updater;
 /// Download verification and integrity checking.
 ///
 /// Provides checksum verification and integrity validation for downloaded
-/// CCPM binaries to ensure secure and reliable upgrades.
+/// AGPM binaries to ensure secure and reliable upgrades.
 pub mod verification;
 /// Version checking and comparison utilities.
 ///
-/// Handles checking for available CCPM updates, comparing versions, and
+/// Handles checking for available AGPM updates, comparing versions, and
 /// maintaining update check caches to avoid unnecessary network requests.
 pub mod version_check;
 

--- a/src/upgrade/mod.rs
+++ b/src/upgrade/mod.rs
@@ -138,7 +138,7 @@ pub mod backup;
 pub mod config;
 /// Core self-update implementation.
 ///
-/// Contains the main SelfUpdater struct that handles downloading and installing
+/// Contains the main `SelfUpdater` struct that handles downloading and installing
 /// AGPM updates from GitHub releases with proper version management and safety checks.
 pub mod self_updater;
 /// Download verification and integrity checking.

--- a/src/upgrade/self_updater.rs
+++ b/src/upgrade/self_updater.rs
@@ -22,10 +22,10 @@ use tracing::{debug, info, warn};
 /// ```rust,no_run
 /// // This function is used internally by SelfUpdater::with_repo()
 /// // for repository identifier validation
-/// use ccpm::upgrade::SelfUpdater;
+/// use agpm::upgrade::SelfUpdater;
 ///
 /// // Valid repository identifiers
-/// let updater = SelfUpdater::with_repo("aig787", "ccpm");
+/// let updater = SelfUpdater::with_repo("aig787", "agpm");
 /// assert!(updater.is_ok());
 ///
 /// let updater = SelfUpdater::with_repo("my-repo", "my_project");
@@ -175,15 +175,15 @@ impl Default for ChecksumPolicy {
     }
 }
 
-/// Core self-update manager for CCPM binary upgrades.
+/// Core self-update manager for AGPM binary upgrades.
 ///
-/// `SelfUpdater` handles the entire process of checking for and installing CCPM updates
+/// `SelfUpdater` handles the entire process of checking for and installing AGPM updates
 /// from GitHub releases. It provides a safe, reliable way to upgrade the running binary
 /// with proper error handling and version management.
 ///
 /// # Features
 ///
-/// - **GitHub Integration**: Fetches releases from the official CCPM repository
+/// - **GitHub Integration**: Fetches releases from the official AGPM repository
 /// - **Version Comparison**: Uses semantic versioning for intelligent update detection
 /// - **Force Updates**: Allows forcing updates even when already on latest version
 /// - **Target Versions**: Supports upgrading to specific versions or latest
@@ -200,7 +200,7 @@ impl Default for ChecksumPolicy {
 ///
 /// ## Check for Updates
 /// ```rust,no_run
-/// use ccpm::upgrade::SelfUpdater;
+/// use agpm::upgrade::SelfUpdater;
 ///
 /// # async fn example() -> anyhow::Result<()> {
 /// let updater = SelfUpdater::new();
@@ -217,7 +217,7 @@ impl Default for ChecksumPolicy {
 ///
 /// ## Update to Latest Version
 /// ```rust,no_run
-/// use ccpm::upgrade::SelfUpdater;
+/// use agpm::upgrade::SelfUpdater;
 ///
 /// # async fn example() -> anyhow::Result<()> {
 /// let updater = SelfUpdater::new();
@@ -232,7 +232,7 @@ impl Default for ChecksumPolicy {
 ///
 /// ## Force Update with Required Checksums
 /// ```rust,no_run
-/// use ccpm::upgrade::{SelfUpdater, ChecksumPolicy};
+/// use agpm::upgrade::{SelfUpdater, ChecksumPolicy};
 ///
 /// # async fn example() -> anyhow::Result<()> {
 /// let updater = SelfUpdater::new()
@@ -248,8 +248,8 @@ impl Default for ChecksumPolicy {
 ///
 /// # Repository Configuration
 ///
-/// By default, updates are fetched from `aig787/ccpm` on GitHub. This is configured
-/// in the [`Default`] implementation and targets the official CCPM repository.
+/// By default, updates are fetched from `aig787/agpm` on GitHub. This is configured
+/// in the [`Default`] implementation and targets the official AGPM repository.
 ///
 /// # Error Handling
 ///
@@ -262,7 +262,7 @@ impl Default for ChecksumPolicy {
 pub struct SelfUpdater {
     /// GitHub repository owner (e.g., "aig787").
     repo_owner: String,
-    /// GitHub repository name (e.g., "ccpm").
+    /// GitHub repository name (e.g., "agpm").
     repo_name: String,
     /// Current version of the running binary.
     current_version: String,
@@ -277,15 +277,15 @@ impl Default for SelfUpdater {
     ///
     /// # Default Configuration
     ///
-    /// - **Repository**: `aig787/ccpm` (official CCPM repository)
-    /// - **Binary Name**: `ccpm`
+    /// - **Repository**: `aig787/agpm` (official AGPM repository)
+    /// - **Binary Name**: `agpm`
     /// - **Current Version**: Detected from build-time crate version
     /// - **Force Mode**: Disabled (respects version comparisons)
     ///
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::upgrade::SelfUpdater;
+    /// use agpm::upgrade::SelfUpdater;
     ///
     /// let updater = SelfUpdater::default();
     /// println!("Current version: {}", updater.current_version());
@@ -293,7 +293,7 @@ impl Default for SelfUpdater {
     fn default() -> Self {
         // These are hardcoded safe values for the official repository
         let repo_owner = "aig787".to_string();
-        let repo_name = "ccpm".to_string();
+        let repo_name = "agpm".to_string();
 
         // Validate even hardcoded values for extra safety
         debug_assert!(
@@ -324,7 +324,7 @@ impl SelfUpdater {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::upgrade::SelfUpdater;
+    /// use agpm::upgrade::SelfUpdater;
     ///
     /// let updater = SelfUpdater::new();
     /// assert_eq!(updater.current_version(), env!("CARGO_PKG_VERSION"));
@@ -341,7 +341,7 @@ impl SelfUpdater {
     /// # Arguments
     ///
     /// * `repo_owner` - GitHub repository owner (e.g., "aig787")
-    /// * `repo_name` - GitHub repository name (e.g., "ccpm")
+    /// * `repo_name` - GitHub repository name (e.g., "agpm")
     ///
     /// # Errors
     ///
@@ -351,11 +351,11 @@ impl SelfUpdater {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::upgrade::SelfUpdater;
+    /// use agpm::upgrade::SelfUpdater;
     ///
     /// # fn example() -> anyhow::Result<()> {
     /// // Valid repository identifiers
-    /// let updater = SelfUpdater::with_repo("aig787", "ccpm")?;
+    /// let updater = SelfUpdater::with_repo("aig787", "agpm")?;
     /// let custom = SelfUpdater::with_repo("my-org", "my_fork")?;
     ///
     /// // This would fail due to invalid characters
@@ -400,7 +400,7 @@ impl SelfUpdater {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::upgrade::SelfUpdater;
+    /// use agpm::upgrade::SelfUpdater;
     ///
     /// // Normal update (respects versions)
     /// let updater = SelfUpdater::new();
@@ -431,7 +431,7 @@ impl SelfUpdater {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::upgrade::{SelfUpdater, ChecksumPolicy};
+    /// use agpm::upgrade::{SelfUpdater, ChecksumPolicy};
     ///
     /// // Require checksum verification (most secure)
     /// let secure_updater = SelfUpdater::new()
@@ -446,7 +446,7 @@ impl SelfUpdater {
         self
     }
 
-    /// Get the current version of the running CCPM binary.
+    /// Get the current version of the running AGPM binary.
     ///
     /// This version is determined at compile time from the crate's `Cargo.toml`
     /// and represents the version of the currently executing binary.
@@ -458,10 +458,10 @@ impl SelfUpdater {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::upgrade::SelfUpdater;
+    /// use agpm::upgrade::SelfUpdater;
     ///
     /// let updater = SelfUpdater::new();
-    /// println!("Current CCPM version: {}", updater.current_version());
+    /// println!("Current AGPM version: {}", updater.current_version());
     /// ```
     pub fn current_version(&self) -> &str {
         &self.current_version
@@ -557,7 +557,7 @@ impl SelfUpdater {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::upgrade::SelfUpdater;
+    /// use agpm::upgrade::SelfUpdater;
     ///
     /// # async fn example() -> anyhow::Result<()> {
     /// let updater = SelfUpdater::new();
@@ -586,7 +586,7 @@ impl SelfUpdater {
         let client = reqwest::Client::new();
         let response = client
             .get(&url)
-            .header("User-Agent", "ccpm")
+            .header("User-Agent", "agpm")
             .send()
             .await
             .context("Failed to fetch release information")?;
@@ -623,7 +623,7 @@ impl SelfUpdater {
         }
     }
 
-    /// Update the CCPM binary to a specific version or latest.
+    /// Update the AGPM binary to a specific version or latest.
     ///
     /// Downloads and installs the specified version from GitHub releases,
     /// replacing the current binary. This is the core update method used by
@@ -664,7 +664,7 @@ impl SelfUpdater {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::upgrade::SelfUpdater;
+    /// use agpm::upgrade::SelfUpdater;
     ///
     /// # async fn example() -> anyhow::Result<()> {
     /// let updater = SelfUpdater::new();
@@ -697,7 +697,7 @@ impl SelfUpdater {
             let client = reqwest::Client::new();
             let response = client
                 .get(&url)
-                .header("User-Agent", "ccpm")
+                .header("User-Agent", "agpm")
                 .send()
                 .await
                 .context("Failed to fetch release information")?;
@@ -729,7 +729,7 @@ impl SelfUpdater {
 
         // Download to temp file
         let temp_dir = tempfile::tempdir()?;
-        let archive_path = temp_dir.path().join("ccpm-archive");
+        let archive_path = temp_dir.path().join("agpm-archive");
 
         self.download_file(&archive_url, &archive_path).await?;
 
@@ -761,7 +761,7 @@ impl SelfUpdater {
             "tar.xz"
         };
 
-        let filename = format!("ccpm-{}.{}", platform, extension);
+        let filename = format!("agpm-{}.{}", platform, extension);
         Ok(self.build_github_download_url(version, &filename))
     }
 
@@ -778,7 +778,7 @@ impl SelfUpdater {
         let mut delay = std::time::Duration::from_secs(1);
 
         loop {
-            match client.get(url).header("User-Agent", "ccpm").send().await {
+            match client.get(url).header("User-Agent", "agpm").send().await {
                 Ok(response) => {
                     if !response.status().is_success() {
                         if retries > 0 && response.status().is_server_error() {
@@ -876,7 +876,7 @@ impl SelfUpdater {
 
         let response = client
             .get(checksum_url)
-            .header("User-Agent", "ccpm")
+            .header("User-Agent", "agpm")
             .send()
             .await
             .context("Failed to download checksum file")?;
@@ -932,9 +932,9 @@ impl SelfUpdater {
         temp_dir: &std::path::Path,
     ) -> Result<std::path::PathBuf> {
         let binary_name = if std::env::consts::OS == "windows" {
-            "ccpm.exe"
+            "agpm.exe"
         } else {
-            "ccpm"
+            "agpm"
         };
 
         if archive_path.to_string_lossy().ends_with(".zip") {
@@ -1123,7 +1123,7 @@ impl SelfUpdater {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::upgrade::SelfUpdater;
+    /// use agpm::upgrade::SelfUpdater;
     ///
     /// # async fn example() -> anyhow::Result<()> {
     /// let updater = SelfUpdater::new();
@@ -1170,7 +1170,7 @@ impl SelfUpdater {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::upgrade::SelfUpdater;
+    /// use agpm::upgrade::SelfUpdater;
     ///
     /// # async fn example() -> anyhow::Result<()> {
     /// let updater = SelfUpdater::new();

--- a/src/upgrade/tests.rs
+++ b/src/upgrade/tests.rs
@@ -10,7 +10,7 @@ mod tests {
 
         // Set up environment to use temp directory
         unsafe {
-            std::env::set_var("CCPM_CONFIG_PATH", temp_dir.path().join("config.toml"));
+            std::env::set_var("AGPM_CONFIG_PATH", temp_dir.path().join("config.toml"));
         }
 
         // Test cache creation and serialization
@@ -31,7 +31,7 @@ mod tests {
 
         // Clean up environment
         unsafe {
-            std::env::remove_var("CCPM_CONFIG_PATH");
+            std::env::remove_var("AGPM_CONFIG_PATH");
         }
     }
 
@@ -129,13 +129,13 @@ mod tests {
     fn test_self_updater_platform_detection() {
         // Test platform-specific binary naming
         #[cfg(windows)]
-        let expected_name = "ccpm.exe";
+        let expected_name = "agpm.exe";
 
         #[cfg(not(windows))]
-        let expected_name = "ccpm";
+        let expected_name = "agpm";
 
         // Verify the expectation is correct
-        assert!(expected_name.contains("ccpm"));
+        assert!(expected_name.contains("agpm"));
     }
 
     #[test]
@@ -155,7 +155,7 @@ mod tests {
     async fn test_self_updater_download_url_construction() {
         // Test expected GitHub release URL components
         let version = "1.0.0";
-        let expected_components = vec!["github.com", "aig787/ccpm", version, "ccpm"];
+        let expected_components = vec!["github.com", "aig787/agpm", version, "agpm"];
 
         // Verify platform-specific target triple
         #[cfg(target_os = "macos")]
@@ -192,7 +192,7 @@ mod tests {
     #[tokio::test]
     async fn test_self_updater_checksum_url() {
         // Test checksum URL construction
-        let download_url = "https://github.com/aig787/ccpm/releases/download/v1.0.0/ccpm-x86_64-unknown-linux-gnu.tar.xz";
+        let download_url = "https://github.com/aig787/agpm/releases/download/v1.0.0/agpm-x86_64-unknown-linux-gnu.tar.xz";
         let expected_checksum_url = format!("{}.sha256", download_url);
 
         // Verify GitHub URLs get .sha256 suffix
@@ -200,18 +200,18 @@ mod tests {
         assert!(expected_checksum_url.ends_with(".sha256"));
 
         // Non-GitHub URLs behavior
-        let non_github = "https://example.com/ccpm.tar.gz";
+        let non_github = "https://example.com/agpm.tar.gz";
         assert!(!non_github.contains("github.com"));
     }
 
     #[tokio::test]
     async fn test_backup_path_generation() {
         let temp_dir = TempDir::new().unwrap();
-        let binary_path = temp_dir.path().join("ccpm");
+        let binary_path = temp_dir.path().join("agpm");
         let manager = backup::BackupManager::new(binary_path.clone());
 
         let backup_path = manager.backup_path();
-        assert_eq!(backup_path.file_name().unwrap(), "ccpm.backup");
+        assert_eq!(backup_path.file_name().unwrap(), "agpm.backup");
         assert_eq!(backup_path.parent().unwrap(), binary_path.parent().unwrap());
     }
 
@@ -243,7 +243,7 @@ mod tests {
         use serde_json;
 
         let temp_dir = TempDir::new().unwrap();
-        let cache_path = temp_dir.path().join(".ccpm").join(".version_cache");
+        let cache_path = temp_dir.path().join(".agpm").join(".version_cache");
 
         // Create cache directory
         tokio::fs::create_dir_all(cache_path.parent().unwrap())
@@ -265,8 +265,8 @@ mod tests {
         // Set up environment to use temp directory
         unsafe {
             std::env::set_var(
-                "CCPM_CONFIG_PATH",
-                temp_dir.path().join(".ccpm").join("config.toml"),
+                "AGPM_CONFIG_PATH",
+                temp_dir.path().join(".agpm").join("config.toml"),
             );
         }
 
@@ -279,7 +279,7 @@ mod tests {
 
         // Clean up environment
         unsafe {
-            std::env::remove_var("CCPM_CONFIG_PATH");
+            std::env::remove_var("AGPM_CONFIG_PATH");
         }
     }
 

--- a/src/upgrade/verification.rs
+++ b/src/upgrade/verification.rs
@@ -31,7 +31,7 @@ impl ChecksumVerifier {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::upgrade::verification::ChecksumVerifier;
+    /// use agpm::upgrade::verification::ChecksumVerifier;
     /// use std::path::Path;
     ///
     /// # async fn example() -> anyhow::Result<()> {
@@ -69,7 +69,7 @@ impl ChecksumVerifier {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::upgrade::verification::ChecksumVerifier;
+    /// use agpm::upgrade::verification::ChecksumVerifier;
     /// use std::path::Path;
     ///
     /// # async fn example() -> anyhow::Result<()> {
@@ -117,8 +117,8 @@ impl ChecksumVerifier {
     ///
     /// Expected format (one per line):
     /// ```text
-    /// abc123def456...  ccpm-linux-x86_64
-    /// 789ghi012jkl...  ccpm-macos-aarch64
+    /// abc123def456...  agpm-linux-x86_64
+    /// 789ghi012jkl...  agpm-macos-aarch64
     /// ```
     pub async fn fetch_expected_checksum(
         checksums_url: &str,
@@ -151,7 +151,7 @@ impl ChecksumVerifier {
                 let (checksum, filename) = (parts[0], parts[1]);
 
                 // Check if this line is for our binary
-                // Handle both exact matches and pattern matches (e.g., ccpm-linux-x86_64)
+                // Handle both exact matches and pattern matches (e.g., agpm-linux-x86_64)
                 if filename == binary_name || filename.contains(binary_name) {
                     debug!("Found checksum for {}: {}", binary_name, checksum);
                     return Ok(Some(checksum.to_string()));

--- a/src/upgrade/version_check.rs
+++ b/src/upgrade/version_check.rs
@@ -24,7 +24,7 @@ use crate::upgrade::SelfUpdater;
 ///
 /// # Serialization
 ///
-/// This struct is serialized to JSON for persistent caching between CCPM runs.
+/// This struct is serialized to JSON for persistent caching between AGPM runs.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct VersionCheckCache {
     /// The latest version string from GitHub releases (e.g., "0.4.0").
@@ -143,23 +143,23 @@ impl VersionChecker {
     /// # Cache Location
     ///
     /// The cache file is stored at:
-    /// - Unix/macOS: `~/.ccpm/.version_cache`
-    /// - Windows: `%LOCALAPPDATA%\ccpm\.version_cache`
+    /// - Unix/macOS: `~/.agpm/.version_cache`
+    /// - Windows: `%LOCALAPPDATA%\agpm\.version_cache`
     pub async fn new() -> Result<Self> {
         let config = GlobalConfig::load().await?;
         let updater = SelfUpdater::new();
 
         // Determine cache path based on configuration directory
-        let cache_path = if let Ok(path) = std::env::var("CCPM_CONFIG_PATH") {
+        let cache_path = if let Ok(path) = std::env::var("AGPM_CONFIG_PATH") {
             PathBuf::from(path)
                 .parent()
                 .map(|p| p.to_path_buf())
-                .unwrap_or_else(|| PathBuf::from(".ccpm"))
+                .unwrap_or_else(|| PathBuf::from(".agpm"))
                 .join(".version_cache")
         } else {
             dirs::home_dir()
                 .context("Could not determine home directory")?
-                .join(".ccpm")
+                .join(".agpm")
                 .join(".version_cache")
         };
 
@@ -373,15 +373,15 @@ impl VersionChecker {
             "{}",
             "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━".bright_cyan()
         );
-        eprintln!("{} A new version of CCPM is available!", "📦".bright_cyan());
+        eprintln!("{} A new version of AGPM is available!", "📦".bright_cyan());
         eprintln!();
         eprintln!("  Current version: {}", current_version.yellow());
         eprintln!("  Latest version:  {}", latest_version.green().bold());
         eprintln!();
-        eprintln!("  Run {} to upgrade", "ccpm upgrade".cyan().bold());
+        eprintln!("  Run {} to upgrade", "agpm upgrade".cyan().bold());
         eprintln!();
         eprintln!("  To disable automatic update checks, run:");
-        eprintln!("  {}", "ccpm config set upgrade.check_interval 0".dimmed());
+        eprintln!("  {}", "agpm config set upgrade.check_interval 0".dimmed());
         eprintln!(
             "{}",
             "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━".bright_cyan()
@@ -441,7 +441,7 @@ mod tests {
     async fn test_cache_save_load() -> Result<()> {
         let temp_dir = TempDir::new()?;
         unsafe {
-            std::env::set_var("CCPM_CONFIG_PATH", temp_dir.path().join("config.toml"));
+            std::env::set_var("AGPM_CONFIG_PATH", temp_dir.path().join("config.toml"));
         }
 
         // Can't test the full VersionChecker without mocking, but can test cache directly
@@ -459,7 +459,7 @@ mod tests {
         assert!(loaded.update_available);
 
         unsafe {
-            std::env::remove_var("CCPM_CONFIG_PATH");
+            std::env::remove_var("AGPM_CONFIG_PATH");
         }
         Ok(())
     }

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -15,7 +15,7 @@
 //! # Examples
 //!
 //! ```rust,no_run
-//! use ccpm::utils::fs::{ensure_dir, safe_write, calculate_checksum};
+//! use agpm::utils::fs::{ensure_dir, safe_write, calculate_checksum};
 //! use std::path::Path;
 //!
 //! # fn example() -> anyhow::Result<()> {
@@ -74,7 +74,7 @@ use std::path::{Path, PathBuf};
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::fs::ensure_dir;
+/// use agpm::utils::fs::ensure_dir;
 /// use std::path::Path;
 ///
 /// # fn example() -> anyhow::Result<()> {
@@ -136,7 +136,7 @@ pub fn ensure_dir(path: &Path) -> Result<()> {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::fs::safe_write;
+/// use agpm::utils::fs::safe_write;
 /// use std::path::Path;
 ///
 /// # fn example() -> anyhow::Result<()> {
@@ -176,12 +176,12 @@ pub fn safe_write(path: &Path, content: &str) -> Result<()> {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::fs::atomic_write;
+/// use agpm::utils::fs::atomic_write;
 /// use std::path::Path;
 ///
 /// # fn example() -> anyhow::Result<()> {
 /// let config_bytes = b"[sources]\ncommunity = \"https://example.com\"";
-/// atomic_write(Path::new("ccpm.toml"), config_bytes)?;
+/// atomic_write(Path::new("agpm.toml"), config_bytes)?;
 /// # Ok(())
 /// # }
 /// ```
@@ -259,7 +259,7 @@ pub fn atomic_write(path: &Path, content: &[u8]) -> Result<()> {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::fs::copy_dir;
+/// use agpm::utils::fs::copy_dir;
 /// use std::path::Path;
 ///
 /// # fn example() -> anyhow::Result<()> {
@@ -332,7 +332,7 @@ pub fn copy_dir(src: &Path, dst: &Path) -> Result<()> {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::fs::remove_dir_all;
+/// use agpm::utils::fs::remove_dir_all;
 /// use std::path::Path;
 ///
 /// # fn example() -> anyhow::Result<()> {
@@ -382,7 +382,7 @@ pub fn remove_dir_all(path: &Path) -> Result<()> {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::fs::normalize_path;
+/// use agpm::utils::fs::normalize_path;
 /// use std::path::{Path, PathBuf};
 ///
 /// let path = Path::new("/foo/./bar/../baz");
@@ -441,7 +441,7 @@ pub fn normalize_path(path: &Path) -> PathBuf {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::fs::is_safe_path;
+/// use agpm::utils::fs::is_safe_path;
 /// use std::path::Path;
 ///
 /// let base = Path::new("/home/user/project");
@@ -498,7 +498,7 @@ pub fn is_safe_path(base: &Path, path: &Path) -> bool {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::fs::find_files;
+/// use agpm::utils::fs::find_files;
 /// use std::path::Path;
 ///
 /// # fn example() -> anyhow::Result<()> {
@@ -570,11 +570,11 @@ fn find_files_recursive(dir: &Path, pattern: &str, files: &mut Vec<PathBuf>) -> 
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::fs::dir_size;
+/// use agpm::utils::fs::dir_size;
 /// use std::path::Path;
 ///
 /// # fn example() -> anyhow::Result<()> {
-/// let cache_size = dir_size(Path::new("~/.ccpm/cache"))?;
+/// let cache_size = dir_size(Path::new("~/.agpm/cache"))?;
 /// println!("Cache size: {} bytes ({:.2} MB)", cache_size, cache_size as f64 / 1024.0 / 1024.0);
 /// # Ok(())
 /// # }
@@ -632,11 +632,11 @@ pub fn dir_size(path: &Path) -> Result<u64> {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::fs::get_directory_size;
+/// use agpm::utils::fs::get_directory_size;
 /// use std::path::Path;
 ///
 /// # async fn example() -> anyhow::Result<()> {
-/// let cache_size = get_directory_size(Path::new("~/.ccpm/cache")).await?;
+/// let cache_size = get_directory_size(Path::new("~/.agpm/cache")).await?;
 /// println!("Cache size: {} bytes", cache_size);
 /// # Ok(())
 /// # }
@@ -680,7 +680,7 @@ pub async fn get_directory_size(path: &Path) -> Result<u64> {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::fs::ensure_parent_dir;
+/// use agpm::utils::fs::ensure_parent_dir;
 /// use std::path::Path;
 ///
 /// # fn example() -> anyhow::Result<()> {
@@ -718,10 +718,10 @@ pub fn copy_dir_all(src: &Path, dst: &Path) -> Result<()> {
     copy_dir(src, dst)
 }
 
-/// Finds the CCPM project root by searching for `ccpm.toml` in the directory hierarchy.
+/// Finds the AGPM project root by searching for `agpm.toml` in the directory hierarchy.
 ///
 /// This function starts from the given directory and walks up the directory tree
-/// looking for a `ccpm.toml` file, which indicates the root of a CCPM project.
+/// looking for a `agpm.toml` file, which indicates the root of a AGPM project.
 /// This is similar to how Git finds the repository root by looking for `.git`.
 ///
 /// # Arguments
@@ -730,12 +730,12 @@ pub fn copy_dir_all(src: &Path, dst: &Path) -> Result<()> {
 ///
 /// # Returns
 ///
-/// The path to the directory containing `ccpm.toml`, or an error if not found
+/// The path to the directory containing `agpm.toml`, or an error if not found
 ///
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::fs::find_project_root;
+/// use agpm::utils::fs::find_project_root;
 /// use std::env;
 ///
 /// # fn example() -> anyhow::Result<()> {
@@ -750,13 +750,13 @@ pub fn copy_dir_all(src: &Path, dst: &Path) -> Result<()> {
 /// # Behavior
 ///
 /// - Starts from the given directory and searches upward
-/// - Returns the first directory containing `ccpm.toml`
+/// - Returns the first directory containing `agpm.toml`
 /// - Canonicalizes the starting path to handle symlinks
-/// - Stops at filesystem root if no `ccpm.toml` is found
+/// - Stops at filesystem root if no `agpm.toml` is found
 ///
 /// # Error Cases
 ///
-/// - No `ccpm.toml` found in the directory hierarchy
+/// - No `agpm.toml` found in the directory hierarchy
 /// - Permission denied accessing parent directories
 /// - Invalid or inaccessible starting path
 ///
@@ -764,24 +764,24 @@ pub fn copy_dir_all(src: &Path, dst: &Path) -> Result<()> {
 ///
 /// - CLI commands that need to operate on the current project
 /// - Finding configuration files relative to project root
-/// - Validating that commands are run within a CCPM project
+/// - Validating that commands are run within a AGPM project
 pub fn find_project_root(start: &Path) -> Result<PathBuf> {
     let mut current = start.canonicalize().unwrap_or_else(|_| start.to_path_buf());
 
     loop {
-        if current.join("ccpm.toml").exists() {
+        if current.join("agpm.toml").exists() {
             return Ok(current);
         }
 
         if !current.pop() {
             return Err(anyhow::anyhow!(
-                "No ccpm.toml found in current directory or any parent directory"
+                "No agpm.toml found in current directory or any parent directory"
             ));
         }
     }
 }
 
-/// Returns the path to the global CCPM configuration file.
+/// Returns the path to the global AGPM configuration file.
 ///
 /// This function constructs the path to the global configuration file following
 /// platform conventions. The global config contains user-specific settings like
@@ -789,13 +789,13 @@ pub fn find_project_root(start: &Path) -> Result<PathBuf> {
 ///
 /// # Returns
 ///
-/// The path to `~/.config/ccpm/config.toml`, or an error if the home directory
+/// The path to `~/.config/agpm/config.toml`, or an error if the home directory
 /// cannot be determined
 ///
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::fs::get_global_config_path;
+/// use agpm::utils::fs::get_global_config_path;
 ///
 /// # fn example() -> anyhow::Result<()> {
 /// let config_path = get_global_config_path()?;
@@ -812,9 +812,9 @@ pub fn find_project_root(start: &Path) -> Result<PathBuf> {
 ///
 /// # Platform Paths
 ///
-/// - **Linux**: `~/.config/ccpm/config.toml`
-/// - **macOS**: `~/.config/ccpm/config.toml`
-/// - **Windows**: `%USERPROFILE%\.config\ccpm\config.toml`
+/// - **Linux**: `~/.config/agpm/config.toml`
+/// - **macOS**: `~/.config/agpm/config.toml`
+/// - **Windows**: `%USERPROFILE%\.config\agpm\config.toml`
 ///
 /// # Use Cases
 ///
@@ -828,7 +828,7 @@ pub fn find_project_root(start: &Path) -> Result<PathBuf> {
 /// be committed to version control or shared publicly.
 pub fn get_global_config_path() -> Result<PathBuf> {
     let home = crate::utils::platform::get_home_dir()?;
-    Ok(home.join(".config").join("ccpm").join("config.toml"))
+    Ok(home.join(".config").join("agpm").join("config.toml"))
 }
 
 /// A temporary directory that automatically cleans up when dropped.
@@ -840,7 +840,7 @@ pub fn get_global_config_path() -> Result<PathBuf> {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::fs::TempDir;
+/// use agpm::utils::fs::TempDir;
 ///
 /// # fn example() -> anyhow::Result<()> {
 /// {
@@ -882,7 +882,7 @@ impl TempDir {
     /// Creates a new temporary directory with the given prefix.
     ///
     /// The directory is created immediately and will have a name like
-    /// `ccpm_{prefix}_{uuid}` in the system temporary directory.
+    /// `agpm_{prefix}_{uuid}` in the system temporary directory.
     ///
     /// # Arguments
     ///
@@ -895,7 +895,7 @@ impl TempDir {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::utils::fs::TempDir;
+    /// use agpm::utils::fs::TempDir;
     ///
     /// # fn example() -> anyhow::Result<()> {
     /// let temp = TempDir::new("cache")?;
@@ -905,7 +905,7 @@ impl TempDir {
     /// ```
     pub fn new(prefix: &str) -> Result<Self> {
         let temp_dir = std::env::temp_dir();
-        let unique_name = format!("ccpm_{}_{}", prefix, uuid::Uuid::new_v4());
+        let unique_name = format!("agpm_{}_{}", prefix, uuid::Uuid::new_v4());
         let path = temp_dir.join(unique_name);
 
         ensure_dir(&path)?;
@@ -950,7 +950,7 @@ impl Drop for TempDir {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::fs::calculate_checksum;
+/// use agpm::utils::fs::calculate_checksum;
 /// use std::path::Path;
 ///
 /// # fn example() -> anyhow::Result<()> {
@@ -1014,7 +1014,7 @@ pub fn calculate_checksum(path: &Path) -> Result<String> {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::fs::calculate_checksums_parallel;
+/// use agpm::utils::fs::calculate_checksums_parallel;
 /// use std::path::PathBuf;
 ///
 /// # async fn example() -> anyhow::Result<()> {
@@ -1120,7 +1120,7 @@ pub async fn calculate_checksums_parallel(paths: &[PathBuf]) -> Result<Vec<(Path
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::fs::copy_files_parallel;
+/// use agpm::utils::fs::copy_files_parallel;
 /// use std::path::PathBuf;
 ///
 /// # async fn example() -> anyhow::Result<()> {
@@ -1235,7 +1235,7 @@ pub async fn copy_files_parallel(sources_and_destinations: &[(PathBuf, PathBuf)]
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::fs::atomic_write_multiple;
+/// use agpm::utils::fs::atomic_write_multiple;
 /// use std::path::PathBuf;
 ///
 /// # async fn example() -> anyhow::Result<()> {
@@ -1331,7 +1331,7 @@ pub async fn atomic_write_multiple(files: &[(PathBuf, Vec<u8>)]) -> Result<()> {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::fs::copy_dirs_parallel;
+/// use agpm::utils::fs::copy_dirs_parallel;
 /// use std::path::PathBuf;
 ///
 /// # async fn example() -> anyhow::Result<()> {
@@ -1432,12 +1432,12 @@ pub async fn copy_dirs_parallel(sources_and_destinations: &[(PathBuf, PathBuf)])
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::fs::read_files_parallel;
+/// use agpm::utils::fs::read_files_parallel;
 /// use std::path::PathBuf;
 ///
 /// # async fn example() -> anyhow::Result<()> {
 /// let config_files = vec![
-///     PathBuf::from("ccpm.toml"),
+///     PathBuf::from("agpm.toml"),
 ///     PathBuf::from("agents/agent1.md"),
 ///     PathBuf::from("snippets/snippet1.md"),
 /// ];
@@ -1970,7 +1970,7 @@ mod tests {
         let subdir = project.join("src").join("subdir");
 
         ensure_dir(&subdir).unwrap();
-        std::fs::write(project.join("ccpm.toml"), "[sources]").unwrap();
+        std::fs::write(project.join("agpm.toml"), "[sources]").unwrap();
 
         let root = find_project_root(&subdir).unwrap();
         assert_eq!(
@@ -1990,7 +1990,7 @@ mod tests {
     fn test_get_global_config_path() {
         let config_path = get_global_config_path().unwrap();
         assert!(config_path.to_string_lossy().contains(".config"));
-        assert!(config_path.to_string_lossy().contains("ccpm"));
+        assert!(config_path.to_string_lossy().contains("agpm"));
     }
 
     #[test]
@@ -2553,10 +2553,10 @@ mod tests {
         let deep = subproject.join("src");
 
         ensure_dir(&deep).unwrap();
-        std::fs::write(root.join("ccpm.toml"), "[sources]").unwrap();
-        std::fs::write(subproject.join("ccpm.toml"), "[sources]").unwrap();
+        std::fs::write(root.join("agpm.toml"), "[sources]").unwrap();
+        std::fs::write(subproject.join("agpm.toml"), "[sources]").unwrap();
 
-        // Should find the closest ccpm.toml
+        // Should find the closest agpm.toml
         let found = find_project_root(&deep).unwrap();
         assert_eq!(
             found.canonicalize().unwrap(),
@@ -2573,10 +2573,10 @@ mod tests {
         // The cache directory should be a valid non-empty path
         assert!(!cache_dir.as_os_str().is_empty());
 
-        // When no env var is set, it should contain "ccpm" in its path
-        // (unless CCPM_CACHE_DIR is already set in the test environment)
-        if std::env::var("CCPM_CACHE_DIR").is_err() {
-            assert!(cache_dir.to_string_lossy().contains("ccpm"));
+        // When no env var is set, it should contain "agpm" in its path
+        // (unless AGPM_CACHE_DIR is already set in the test environment)
+        if std::env::var("AGPM_CACHE_DIR").is_err() {
+            assert!(cache_dir.to_string_lossy().contains("agpm"));
         }
     }
 }

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -1564,7 +1564,7 @@ pub fn write_text_file(path: &Path, content: &str) -> Result<()> {
 /// * `path` - The path to the JSON file
 ///
 /// # Type Parameters
-/// * `T` - The type to deserialize into (must implement DeserializeOwned)
+/// * `T` - The type to deserialize into (must implement `DeserializeOwned`)
 ///
 /// # Returns
 /// The parsed JSON data
@@ -1615,7 +1615,7 @@ where
 /// * `path` - The path to the TOML file
 ///
 /// # Type Parameters
-/// * `T` - The type to deserialize into (must implement DeserializeOwned)
+/// * `T` - The type to deserialize into (must implement `DeserializeOwned`)
 ///
 /// # Returns
 /// The parsed TOML data
@@ -1663,7 +1663,7 @@ where
 /// * `path` - The path to the YAML file
 ///
 /// # Type Parameters
-/// * `T` - The type to deserialize into (must implement DeserializeOwned)
+/// * `T` - The type to deserialize into (must implement `DeserializeOwned`)
 ///
 /// # Returns
 /// The parsed YAML data
@@ -1711,7 +1711,7 @@ where
 /// * `content` - The content to write to the file
 ///
 /// # Returns
-/// A TempPath that will delete the file when dropped
+/// A `TempPath` that will delete the file when dropped
 ///
 /// # Errors
 /// Returns an error if the temp file cannot be created
@@ -1744,7 +1744,7 @@ pub fn file_exists_and_readable(path: &Path) -> bool {
 /// * `path` - The path to the file
 ///
 /// # Returns
-/// The modification time as a SystemTime
+/// The modification time as a `SystemTime`
 ///
 /// # Errors
 /// Returns an error if the file metadata cannot be read

--- a/src/utils/manifest_utils.rs
+++ b/src/utils/manifest_utils.rs
@@ -10,13 +10,13 @@ use std::path::Path;
 
 /// Load a project manifest from the standard location
 ///
-/// This function looks for a `ccpm.toml` file in the given project directory
+/// This function looks for a `agpm.toml` file in the given project directory
 /// and returns a parsed Manifest. It provides consistent error messages
 /// across all commands.
 ///
 /// # Arguments
 ///
-/// * `project_dir` - The project directory to search for ccpm.toml
+/// * `project_dir` - The project directory to search for agpm.toml
 ///
 /// # Returns
 ///
@@ -29,31 +29,31 @@ use std::path::Path;
 /// # use anyhow::Result;
 /// # fn example() -> Result<()> {
 /// use std::path::Path;
-/// use ccpm::utils::manifest_utils::load_project_manifest;
+/// use agpm::utils::manifest_utils::load_project_manifest;
 ///
 /// let manifest = load_project_manifest(Path::new("."))?;
 /// # Ok(())
 /// # }
 /// ```
 pub fn load_project_manifest(project_dir: &Path) -> Result<Manifest> {
-    let manifest_path = project_dir.join("ccpm.toml");
+    let manifest_path = project_dir.join("agpm.toml");
 
     if !manifest_path.exists() {
         return Err(
-            anyhow!("No ccpm.toml found in {}", project_dir.display()).context(ErrorContext {
-                error: crate::core::CcpmError::ManifestNotFound,
-                suggestion: Some("Run 'ccpm init' to create a new project".to_string()),
+            anyhow!("No agpm.toml found in {}", project_dir.display()).context(ErrorContext {
+                error: crate::core::AgpmError::ManifestNotFound,
+                suggestion: Some("Run 'agpm init' to create a new project".to_string()),
                 details: Some(format!("Expected manifest at: {}", manifest_path.display())),
             }),
         );
     }
 
     Manifest::load(&manifest_path).with_context(|| ErrorContext {
-        error: crate::core::CcpmError::ManifestParseError {
+        error: crate::core::AgpmError::ManifestParseError {
             file: manifest_path.display().to_string(),
             reason: "Failed to parse manifest".to_string(),
         },
-        suggestion: Some("Check that ccpm.toml is valid TOML syntax".to_string()),
+        suggestion: Some("Check that agpm.toml is valid TOML syntax".to_string()),
         details: Some(format!("Manifest path: {}", manifest_path.display())),
     })
 }
@@ -90,10 +90,10 @@ pub fn load_and_validate_manifest(
     if require_sources && manifest.sources.is_empty() {
         return Err(
             anyhow!("No sources defined in manifest").context(ErrorContext {
-                error: crate::core::CcpmError::ManifestValidationError {
+                error: crate::core::AgpmError::ManifestValidationError {
                     reason: "No sources defined in manifest".to_string(),
                 },
-                suggestion: Some("Add at least one source using 'ccpm add source'".to_string()),
+                suggestion: Some("Add at least one source using 'agpm add source'".to_string()),
                 details: None,
             }),
         );
@@ -107,10 +107,10 @@ pub fn load_and_validate_manifest(
     {
         return Err(
             anyhow!("No dependencies defined in manifest").context(ErrorContext {
-                error: crate::core::CcpmError::ManifestValidationError {
+                error: crate::core::AgpmError::ManifestValidationError {
                     reason: "No dependencies defined in manifest".to_string(),
                 },
-                suggestion: Some("Add dependencies using 'ccpm add dep'".to_string()),
+                suggestion: Some("Add dependencies using 'agpm add dep'".to_string()),
                 details: None,
             }),
         );
@@ -127,9 +127,9 @@ pub fn load_and_validate_manifest(
 ///
 /// # Returns
 ///
-/// * `true` if ccpm.toml exists, `false` otherwise
+/// * `true` if agpm.toml exists, `false` otherwise
 pub fn manifest_exists(project_dir: &Path) -> bool {
-    project_dir.join("ccpm.toml").exists()
+    project_dir.join("agpm.toml").exists()
 }
 
 /// Get the path to the manifest file
@@ -140,9 +140,9 @@ pub fn manifest_exists(project_dir: &Path) -> bool {
 ///
 /// # Returns
 ///
-/// The path to ccpm.toml in the project directory
+/// The path to agpm.toml in the project directory
 pub fn manifest_path(project_dir: &Path) -> std::path::PathBuf {
-    project_dir.join("ccpm.toml")
+    project_dir.join("agpm.toml")
 }
 
 #[cfg(test)]
@@ -159,13 +159,13 @@ mod tests {
         // The error will contain both the initial message and the context
         let err = result.unwrap_err();
         let err_str = err.to_string();
-        assert!(err_str.contains("ccpm.toml") || err_str.contains("Manifest"));
+        assert!(err_str.contains("agpm.toml") || err_str.contains("Manifest"));
     }
 
     #[test]
     fn test_load_project_manifest_invalid() {
         let temp_dir = tempdir().unwrap();
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
         fs::write(&manifest_path, "invalid toml {").unwrap();
 
         let result = load_project_manifest(temp_dir.path());
@@ -178,7 +178,7 @@ mod tests {
         let temp_dir = tempdir().unwrap();
         assert!(!manifest_exists(temp_dir.path()));
 
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
         fs::write(&manifest_path, "[sources]").unwrap();
         assert!(manifest_exists(temp_dir.path()));
     }
@@ -187,13 +187,13 @@ mod tests {
     fn test_manifest_path() {
         let temp_dir = tempdir().unwrap();
         let path = manifest_path(temp_dir.path());
-        assert_eq!(path, temp_dir.path().join("ccpm.toml"));
+        assert_eq!(path, temp_dir.path().join("agpm.toml"));
     }
 
     #[test]
     fn test_load_and_validate_manifest_success() {
         let temp_dir = tempdir().unwrap();
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
 
         // Create valid manifest with sources and dependencies
         let content = r#"
@@ -217,7 +217,7 @@ test-agent = { source = "test", path = "agent.md", version = "v1.0.0" }
     #[test]
     fn test_load_and_validate_manifest_no_sources() {
         let temp_dir = tempdir().unwrap();
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
 
         // Create manifest without sources
         let content = r#"
@@ -239,7 +239,7 @@ test-agent = { path = "../local/agent.md" }
     #[test]
     fn test_load_and_validate_manifest_no_dependencies() {
         let temp_dir = tempdir().unwrap();
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
 
         // Create manifest with only sources
         let content = r#"
@@ -271,7 +271,7 @@ test = "https://github.com/test/repo.git"
     #[test]
     fn test_load_and_validate_manifest_with_snippets() {
         let temp_dir = tempdir().unwrap();
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
 
         // Create manifest with snippets dependency
         let content = r#"
@@ -291,7 +291,7 @@ test-snippet = { source = "test", path = "snippet.md", version = "v1.0.0" }
     #[test]
     fn test_load_and_validate_manifest_with_commands() {
         let temp_dir = tempdir().unwrap();
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
 
         // Create manifest with commands dependency
         let content = r#"
@@ -311,7 +311,7 @@ test-command = { source = "test", path = "command.md", version = "v1.0.0" }
     #[test]
     fn test_load_and_validate_manifest_with_mcp_servers() {
         let temp_dir = tempdir().unwrap();
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
 
         // Create manifest with MCP servers dependency
         let content = r#"
@@ -331,7 +331,7 @@ test-server = "../local/mcp-servers/test-server.json"
     #[test]
     fn test_load_project_manifest_valid() {
         let temp_dir = tempdir().unwrap();
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
 
         // Create a valid manifest
         let content = r#"
@@ -354,7 +354,7 @@ test-agent = { source = "test", path = "agent.md", version = "v1.0.0" }
     #[test]
     fn test_load_and_validate_empty_manifest() {
         let temp_dir = tempdir().unwrap();
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
 
         // Create an empty but valid manifest
         let content = "";
@@ -376,7 +376,7 @@ test-agent = { source = "test", path = "agent.md", version = "v1.0.0" }
     #[test]
     fn test_manifest_validation_mixed_dependencies() {
         let temp_dir = tempdir().unwrap();
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
 
         // Create manifest with multiple types of dependencies
         let content = r#"
@@ -417,13 +417,13 @@ cmd1 = { source = "source1", path = "cmd1.md", version = "v1.0.0" }
         let err_str = format!("{:?}", err_chain);
 
         // Should contain error context with suggestion
-        assert!(err_str.contains("ccpm.toml") || err_str.contains("init"));
+        assert!(err_str.contains("agpm.toml") || err_str.contains("init"));
     }
 
     #[test]
     fn test_error_context_in_validation() {
         let temp_dir = tempdir().unwrap();
-        let manifest_path = temp_dir.path().join("ccpm.toml");
+        let manifest_path = temp_dir.path().join("agpm.toml");
 
         // Create manifest without sources
         fs::write(&manifest_path, "").unwrap();

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -22,7 +22,7 @@
 //! # Example
 //!
 //! ```rust,no_run
-//! use ccpm::utils::{ensure_dir, atomic_write, MultiPhaseProgress, InstallationPhase};
+//! use agpm::utils::{ensure_dir, atomic_write, MultiPhaseProgress, InstallationPhase};
 //! use std::path::Path;
 //!
 //! # async fn example() -> anyhow::Result<()> {
@@ -71,7 +71,7 @@ pub use progress::{InstallationPhase, MultiPhaseProgress, ProgressBar, collect_d
 /// # Examples
 ///
 /// ```
-/// use ccpm::utils::is_local_path;
+/// use agpm::utils::is_local_path;
 ///
 /// // Unix-style paths
 /// assert!(is_local_path("/absolute/path"));
@@ -125,7 +125,7 @@ pub fn is_local_path(url: &str) -> bool {
 /// # Examples
 ///
 /// ```
-/// use ccpm::utils::is_git_url;
+/// use agpm::utils::is_git_url;
 ///
 /// assert!(is_git_url("https://github.com/user/repo.git"));
 /// assert!(is_git_url("git@github.com:user/repo.git"));

--- a/src/utils/path_validation.rs
+++ b/src/utils/path_validation.rs
@@ -127,7 +127,7 @@ pub fn safe_relative_path(base: &Path, target: &Path) -> Result<PathBuf> {
 
     target_canonical
         .strip_prefix(&base_canonical)
-        .map(|p| p.to_path_buf())
+        .map(std::path::Path::to_path_buf)
         .map_err(|_| {
             anyhow!(
                 "Cannot create relative path from {} to {}",

--- a/src/utils/path_validation.rs
+++ b/src/utils/path_validation.rs
@@ -1,4 +1,4 @@
-//! Path validation and security utilities for CCPM.
+//! Path validation and security utilities for AGPM.
 //!
 //! This module provides utilities for safe path handling, validation,
 //! and security checks to prevent path traversal attacks.
@@ -228,7 +228,7 @@ pub fn sanitize_file_name(name: &str) -> String {
 
 /// Gets the project root directory from a path.
 ///
-/// Searches upward from the given path to find a directory containing ccpm.toml
+/// Searches upward from the given path to find a directory containing agpm.toml
 ///
 /// # Arguments
 /// * `start_path` - The path to start searching from
@@ -245,7 +245,7 @@ pub fn find_project_root(start_path: &Path) -> Result<PathBuf> {
     };
 
     loop {
-        if current.join("ccpm.toml").exists() {
+        if current.join("agpm.toml").exists() {
             return safe_canonicalize(current);
         }
 
@@ -253,7 +253,7 @@ pub fn find_project_root(start_path: &Path) -> Result<PathBuf> {
             Some(parent) => current = parent,
             None => {
                 return Err(anyhow!(
-                    "No ccpm.toml found in any parent directory of {}",
+                    "No agpm.toml found in any parent directory of {}",
                     start_path.display()
                 ));
             }
@@ -327,8 +327,8 @@ mod tests {
         let temp_dir = tempdir()?;
         let project_dir = temp_dir.path();
 
-        // Create ccpm.toml
-        fs::write(project_dir.join("ccpm.toml"), "[project]")?;
+        // Create agpm.toml
+        fs::write(project_dir.join("agpm.toml"), "[project]")?;
 
         // Create nested directory
         let nested = project_dir.join("src").join("nested");

--- a/src/utils/platform.rs
+++ b/src/utils/platform.rs
@@ -1,6 +1,6 @@
 //! Platform-specific utilities and cross-platform compatibility helpers
 //!
-//! This module provides abstractions over platform differences to ensure CCPM
+//! This module provides abstractions over platform differences to ensure AGPM
 //! works consistently across Windows, macOS, and Linux. It handles differences in:
 //!
 //! - Path separators and conventions
@@ -11,14 +11,14 @@
 //!
 //! # Cross-Platform Design
 //!
-//! CCPM is designed to provide identical functionality across all supported platforms
+//! AGPM is designed to provide identical functionality across all supported platforms
 //! while respecting platform conventions and limitations. This module encapsulates
 //! the platform-specific logic to achieve this goal.
 //!
 //! # Examples
 //!
 //! ```rust,no_run
-//! use ccpm::utils::platform::{get_home_dir, resolve_path, is_windows};
+//! use agpm::utils::platform::{get_home_dir, resolve_path, is_windows};
 //!
 //! # fn example() -> anyhow::Result<()> {
 //! // Get platform-appropriate home directory
@@ -26,7 +26,7 @@
 //! println!("Home directory: {}", home.display());
 //!
 //! // Resolve paths with tilde expansion and env vars
-//! let config_path = resolve_path("~/.ccpm/config.toml")?;
+//! let config_path = resolve_path("~/.agpm/config.toml")?;
 //!
 //! // Handle platform differences
 //! if is_windows() {
@@ -74,7 +74,7 @@ use std::path::{Path, PathBuf};
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::platform::is_windows;
+/// use agpm::utils::platform::is_windows;
 ///
 /// if is_windows() {
 ///     println!("Windows-specific code path");
@@ -107,14 +107,14 @@ pub fn is_windows() -> bool {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::platform::get_home_dir;
+/// use agpm::utils::platform::get_home_dir;
 ///
 /// # fn example() -> anyhow::Result<()> {
 /// let home = get_home_dir()?;
 /// println!("Home directory: {}", home.display());
 ///
-/// let ccpm_dir = home.join(".ccpm");
-/// println!("CCPM directory would be: {}", ccpm_dir.display());
+/// let agpm_dir = home.join(".agpm");
+/// println!("AGPM directory would be: {}", agpm_dir.display());
 /// # Ok(())
 /// # }
 /// ```
@@ -160,7 +160,7 @@ pub fn get_home_dir() -> Result<PathBuf> {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::platform::get_git_command;
+/// use agpm::utils::platform::get_git_command;
 /// use std::process::Command;
 ///
 /// # fn example() -> anyhow::Result<()> {
@@ -212,11 +212,11 @@ pub fn get_git_command() -> &'static str {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::platform::resolve_path;
+/// use agpm::utils::platform::resolve_path;
 ///
 /// # fn example() -> anyhow::Result<()> {
 /// // Tilde expansion
-/// let config_path = resolve_path("~/.ccpm/config.toml")?;
+/// let config_path = resolve_path("~/.agpm/config.toml")?;
 /// println!("Config: {}", config_path.display());
 ///
 /// // Environment variable expansion (Unix)
@@ -347,7 +347,7 @@ pub fn resolve_path(path: &str) -> Result<PathBuf> {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::platform::normalize_path_separator;
+/// use agpm::utils::platform::normalize_path_separator;
 /// use std::path::Path;
 ///
 /// let mixed_path = Path::new("src/utils\\platform.rs");
@@ -403,7 +403,7 @@ pub fn normalize_path_separator(path: &Path) -> String {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::platform::path_to_string;
+/// use agpm::utils::platform::path_to_string;
 /// use std::path::Path;
 ///
 /// let path = Path::new("/home/user/file.txt");
@@ -455,7 +455,7 @@ pub fn path_to_string(path: &Path) -> String {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::platform::path_to_os_str;
+/// use agpm::utils::platform::path_to_os_str;
 /// use std::path::Path;
 /// use std::process::Command;
 ///
@@ -512,7 +512,7 @@ pub fn path_to_os_str(path: &Path) -> &std::ffi::OsStr {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::platform::paths_equal;
+/// use agpm::utils::platform::paths_equal;
 /// use std::path::Path;
 ///
 /// let path1 = Path::new("Config.toml");
@@ -586,7 +586,7 @@ pub fn paths_equal(path1: &Path, path2: &Path) -> bool {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::platform::safe_canonicalize;
+/// use agpm::utils::platform::safe_canonicalize;
 /// use std::path::Path;
 ///
 /// # fn example() -> anyhow::Result<()> {
@@ -673,7 +673,7 @@ pub fn safe_canonicalize(path: &Path) -> Result<PathBuf> {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::platform::command_exists;
+/// use agpm::utils::platform::command_exists;
 ///
 /// // Check if Git is available
 /// if command_exists("git") {
@@ -716,7 +716,7 @@ pub fn command_exists(cmd: &str) -> bool {
     which::which(cmd).is_ok()
 }
 
-/// Returns the platform-specific cache directory for CCPM.
+/// Returns the platform-specific cache directory for AGPM.
 ///
 /// This function returns the appropriate cache directory following platform
 /// conventions and standards (XDG Base Directory on Linux, standard locations
@@ -724,16 +724,16 @@ pub fn command_exists(cmd: &str) -> bool {
 ///
 /// # Returns
 ///
-/// The cache directory path (`{cache_dir}/ccpm`), or an error if it cannot be determined
+/// The cache directory path (`{cache_dir}/agpm`), or an error if it cannot be determined
 ///
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::platform::get_cache_dir;
+/// use agpm::utils::platform::get_cache_dir;
 ///
 /// # fn example() -> anyhow::Result<()> {
 /// let cache_dir = get_cache_dir()?;
-/// println!("CCPM cache directory: {}", cache_dir.display());
+/// println!("AGPM cache directory: {}", cache_dir.display());
 ///
 /// // Use for storing temporary data
 /// let repo_cache = cache_dir.join("repositories");
@@ -743,9 +743,9 @@ pub fn command_exists(cmd: &str) -> bool {
 ///
 /// # Platform Paths
 ///
-/// - **Linux**: `$XDG_CACHE_HOME/ccpm` or `$HOME/.cache/ccpm`
-/// - **macOS**: `$HOME/Library/Caches/ccpm`
-/// - **Windows**: `%LOCALAPPDATA%\ccpm`
+/// - **Linux**: `$XDG_CACHE_HOME/agpm` or `$HOME/.cache/agpm`
+/// - **macOS**: `$HOME/Library/Caches/agpm`
+/// - **Windows**: `%LOCALAPPDATA%\agpm`
 ///
 /// # Standards Compliance
 ///
@@ -770,7 +770,7 @@ pub fn command_exists(cmd: &str) -> bool {
 /// - [`get_data_dir`] for persistent application data
 /// - [`get_home_dir`] for user home directory
 pub fn get_cache_dir() -> Result<PathBuf> {
-    dirs::cache_dir().map(|p| p.join("ccpm")).ok_or_else(|| {
+    dirs::cache_dir().map(|p| p.join("agpm")).ok_or_else(|| {
         let platform_help = if is_windows() {
             "On Windows: Check that the LOCALAPPDATA environment variable is set"
         } else if cfg!(target_os = "macos") {
@@ -782,23 +782,23 @@ pub fn get_cache_dir() -> Result<PathBuf> {
     })
 }
 
-/// Returns the platform-specific data directory for CCPM.
+/// Returns the platform-specific data directory for AGPM.
 ///
 /// This function returns the appropriate data directory for storing persistent
 /// application data, following platform conventions and standards.
 ///
 /// # Returns
 ///
-/// The data directory path (`{data_dir}/ccpm`), or an error if it cannot be determined
+/// The data directory path (`{data_dir}/agpm`), or an error if it cannot be determined
 ///
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::platform::get_data_dir;
+/// use agpm::utils::platform::get_data_dir;
 ///
 /// # fn example() -> anyhow::Result<()> {
 /// let data_dir = get_data_dir()?;
-/// println!("CCPM data directory: {}", data_dir.display());
+/// println!("AGPM data directory: {}", data_dir.display());
 ///
 /// // Use for storing persistent data
 /// let lockfile_backup = data_dir.join("lockfile_backups");
@@ -808,9 +808,9 @@ pub fn get_cache_dir() -> Result<PathBuf> {
 ///
 /// # Platform Paths
 ///
-/// - **Linux**: `$XDG_DATA_HOME/ccpm` or `$HOME/.local/share/ccpm`
-/// - **macOS**: `$HOME/Library/Application Support/ccpm`
-/// - **Windows**: `%APPDATA%\ccpm`
+/// - **Linux**: `$XDG_DATA_HOME/agpm` or `$HOME/.local/share/agpm`
+/// - **macOS**: `$HOME/Library/Application Support/agpm`
+/// - **Windows**: `%APPDATA%\agpm`
 ///
 /// # Standards Compliance
 ///
@@ -840,7 +840,7 @@ pub fn get_cache_dir() -> Result<PathBuf> {
 /// - [`get_cache_dir`] for temporary cached data
 /// - [`get_home_dir`] for user home directory
 pub fn get_data_dir() -> Result<PathBuf> {
-    dirs::data_dir().map(|p| p.join("ccpm")).ok_or_else(|| {
+    dirs::data_dir().map(|p| p.join("agpm")).ok_or_else(|| {
         let platform_help = if is_windows() {
             "On Windows: Check that the APPDATA environment variable is set"
         } else if cfg!(target_os = "macos") {
@@ -870,7 +870,7 @@ pub fn get_data_dir() -> Result<PathBuf> {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::platform::windows_long_path;
+/// use agpm::utils::platform::windows_long_path;
 /// use std::path::Path;
 ///
 /// let long_path = Path::new("C:\\very\\long\\path\\that\\exceeds\\windows\\limit");
@@ -985,7 +985,7 @@ pub fn windows_long_path(path: &Path) -> PathBuf {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::platform::get_shell_command;
+/// use agpm::utils::platform::get_shell_command;
 /// use std::process::Command;
 ///
 /// # fn example() -> anyhow::Result<()> {
@@ -1055,7 +1055,7 @@ pub fn get_shell_command() -> (&'static str, &'static str) {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::platform::validate_path_chars;
+/// use agpm::utils::platform::validate_path_chars;
 ///
 /// # fn example() -> anyhow::Result<()> {
 /// // Valid paths
@@ -1174,7 +1174,7 @@ pub fn validate_path_chars(path: &str) -> Result<()> {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::utils::platform::safe_join;
+/// use agpm::utils::platform::safe_join;
 /// use std::path::Path;
 ///
 /// # fn example() -> anyhow::Result<()> {
@@ -1340,13 +1340,13 @@ mod tests {
     #[test]
     fn test_get_cache_dir() {
         let dir = get_cache_dir().unwrap();
-        assert!(dir.to_string_lossy().contains("ccpm"));
+        assert!(dir.to_string_lossy().contains("agpm"));
     }
 
     #[test]
     fn test_get_data_dir() {
         let dir = get_data_dir().unwrap();
-        assert!(dir.to_string_lossy().contains("ccpm"));
+        assert!(dir.to_string_lossy().contains("agpm"));
     }
 
     #[test]

--- a/src/utils/platform.rs
+++ b/src/utils/platform.rs
@@ -90,7 +90,7 @@ use std::path::{Path, PathBuf};
 /// - Platform-specific error messages
 /// - Command execution differences
 #[must_use]
-pub fn is_windows() -> bool {
+pub const fn is_windows() -> bool {
     cfg!(windows)
 }
 
@@ -143,7 +143,7 @@ pub fn get_home_dir() -> Result<PathBuf> {
         } else {
             "On Unix/Linux: Check that the HOME environment variable is set"
         };
-        anyhow::anyhow!("Could not determine home directory.\n\n{}", platform_help)
+        anyhow::anyhow!("Could not determine home directory.\n\n{platform_help}")
     })
 }
 
@@ -190,7 +190,7 @@ pub fn get_home_dir() -> Result<PathBuf> {
 /// - [`command_exists`] to check if Git is available
 /// - System PATH configuration for Git availability
 #[must_use]
-pub fn get_git_command() -> &'static str {
+pub const fn get_git_command() -> &'static str {
     if is_windows() { "git.exe" } else { "git" }
 }
 
@@ -261,17 +261,15 @@ pub fn resolve_path(path: &str) -> Result<PathBuf> {
         // Handle Windows-style user expansion like ~username
         if is_windows() && path.len() > 1 && !path.starts_with("~/") {
             return Err(anyhow::anyhow!(
-                "Invalid path: {}\n\n\
+                "Invalid path: {path}\n\n\
                 Windows tilde expansion only supports '~/' for current user home directory.\n\
-                Use '~/' followed by a relative path, like '~/Documents/file.txt'",
-                path
+                Use '~/' followed by a relative path, like '~/Documents/file.txt'"
             ));
         }
         return Err(anyhow::anyhow!(
-            "Invalid path: {}\n\n\
+            "Invalid path: {path}\n\n\
             Tilde expansion only supports '~/' for home directory.\n\
-            Use '~/' followed by a relative path, like '~/Documents/file.txt'",
-            path
+            Use '~/' followed by a relative path, like '~/Documents/file.txt'"
         ));
     } else {
         PathBuf::from(path)
@@ -778,7 +776,7 @@ pub fn get_cache_dir() -> Result<PathBuf> {
         } else {
             "On Linux: Check that the XDG_CACHE_HOME or HOME environment variable is set"
         };
-        anyhow::anyhow!("Could not determine cache directory.\n\n{}", platform_help)
+        anyhow::anyhow!("Could not determine cache directory.\n\n{platform_help}")
     })
 }
 
@@ -848,7 +846,7 @@ pub fn get_data_dir() -> Result<PathBuf> {
         } else {
             "On Linux: Check that the XDG_DATA_HOME or HOME environment variable is set"
         };
-        anyhow::anyhow!("Could not determine data directory.\n\n{}", platform_help)
+        anyhow::anyhow!("Could not determine data directory.\n\n{platform_help}")
     })
 }
 
@@ -1029,7 +1027,7 @@ pub fn windows_long_path(path: &Path) -> PathBuf {
 /// - [`command_exists`] for checking shell availability
 /// - [`std::process::Command`] for safe command execution
 #[must_use]
-pub fn get_shell_command() -> (&'static str, &'static str) {
+pub const fn get_shell_command() -> (&'static str, &'static str) {
     if is_windows() {
         ("cmd", "/C")
     } else {
@@ -1117,9 +1115,7 @@ pub fn validate_path_chars(path: &str) -> Result<()> {
         for ch in path.chars() {
             if INVALID_CHARS.contains(&ch) || ch.is_control() {
                 return Err(anyhow::anyhow!(
-                    "Invalid character '{}' in path: {}\\n\\n\\\n                    Windows paths cannot contain: < > : \" | ? * or control characters",
-                    ch,
-                    path
+                    "Invalid character '{ch}' in path: {path}\\n\\n\\\n                    Windows paths cannot contain: < > : \" | ? * or control characters"
                 ));
             }
         }
@@ -1242,8 +1238,7 @@ pub fn safe_join(base: &Path, path: &str) -> Result<PathBuf> {
         let normalized = crate::utils::fs::normalize_path(&joined);
         if !normalized.starts_with(base) {
             return Err(anyhow::anyhow!(
-                "Path traversal detected in: {}\\n\\n\\\n                Attempted to access path outside base directory",
-                path
+                "Path traversal detected in: {path}\\n\\n\\\n                Attempted to access path outside base directory"
             ));
         }
     }

--- a/src/utils/progress.rs
+++ b/src/utils/progress.rs
@@ -1,19 +1,19 @@
 //! Progress indicators and user interface utilities
 //!
 //! This module provides a unified progress system for AGPM operations using the
-//! MultiPhaseProgress approach. All progress tracking goes through phases to ensure
+//! `MultiPhaseProgress` approach. All progress tracking goes through phases to ensure
 //! consistent user experience across different operations.
 //!
 //! # Features
 //!
-//! - **Unified progress**: All operations use MultiPhaseProgress for consistency
+//! - **Unified progress**: All operations use `MultiPhaseProgress` for consistency
 //! - **Phase-based tracking**: Installation/update operations broken into logical phases
 //! - **CI/quiet mode support**: Automatically disables in non-interactive environments
 //! - **Thread safety**: Safe to use across async tasks and parallel operations
 //!
 //! # Configuration
 //!
-//! Progress indicators are now controlled via the MultiPhaseProgress constructor
+//! Progress indicators are now controlled via the `MultiPhaseProgress` constructor
 //! parameter rather than environment variables for better thread safety.
 //!
 //! # Examples
@@ -62,7 +62,7 @@ pub enum InstallationPhase {
 
 impl InstallationPhase {
     /// Get a human-readable description of the phase
-    pub fn description(&self) -> &'static str {
+    pub const fn description(&self) -> &'static str {
         match self {
             Self::SyncingSources => "Syncing sources",
             Self::ResolvingDependencies => "Resolving dependencies",
@@ -73,7 +73,7 @@ impl InstallationPhase {
     }
 
     /// Get the spinner prefix for this phase
-    pub fn spinner_prefix(&self) -> &'static str {
+    pub const fn spinner_prefix(&self) -> &'static str {
         match self {
             Self::SyncingSources => "⏳",
             Self::ResolvingDependencies => "🔍",
@@ -88,7 +88,7 @@ impl InstallationPhase {
 /// with completed phases showing as static messages
 #[derive(Clone)]
 pub struct MultiPhaseProgress {
-    /// MultiProgress container from indicatif
+    /// `MultiProgress` container from indicatif
     multi: Arc<indicatif::MultiProgress>,
     /// Current active spinner/progress bar
     current_bar: Arc<Mutex<Option<IndicatifBar>>>,
@@ -118,7 +118,7 @@ impl MultiPhaseProgress {
             } else {
                 format!("{} {}", phase.spinner_prefix(), phase.description())
             };
-            println!("{}", phase_msg);
+            println!("{phase_msg}");
             return;
         }
 
@@ -238,7 +238,7 @@ impl MultiPhaseProgress {
                 return;
             }
             if let Some(msg) = message {
-                println!("✓ {}", msg);
+                println!("✓ {msg}");
             }
             return;
         }
@@ -252,7 +252,7 @@ impl MultiPhaseProgress {
 
             // Set the final message
             let final_message = if let Some(msg) = message {
-                format!("✓ {}", msg)
+                format!("✓ {msg}")
             } else {
                 "✓ Phase complete".to_string()
             };
@@ -263,7 +263,7 @@ impl MultiPhaseProgress {
             // Use suspend to print the completion message outside of the MultiProgress
             // This ensures it stays visible
             self.multi.suspend(|| {
-                println!("{}", final_message);
+                println!("{final_message}");
             });
         }
     }
@@ -300,7 +300,7 @@ pub fn collect_dependency_names(manifest: &Manifest) -> Vec<String> {
     manifest
         .all_dependencies()
         .iter()
-        .map(|(name, _)| name.to_string())
+        .map(|(name, _)| (*name).to_string())
         .collect()
 }
 

--- a/src/utils/progress.rs
+++ b/src/utils/progress.rs
@@ -1,6 +1,6 @@
 //! Progress indicators and user interface utilities
 //!
-//! This module provides a unified progress system for CCPM operations using the
+//! This module provides a unified progress system for AGPM operations using the
 //! MultiPhaseProgress approach. All progress tracking goes through phases to ensure
 //! consistent user experience across different operations.
 //!
@@ -21,7 +21,7 @@
 //! ## Multi-Phase Progress
 //!
 //! ```rust,no_run
-//! use ccpm::utils::progress::{MultiPhaseProgress, InstallationPhase};
+//! use agpm::utils::progress::{MultiPhaseProgress, InstallationPhase};
 //!
 //! let progress = MultiPhaseProgress::new(true);
 //!

--- a/src/utils/security.rs
+++ b/src/utils/security.rs
@@ -41,7 +41,7 @@ pub static BLACKLISTED_PATHS: &[&str] = &[
 ///
 /// # Examples
 /// ```
-/// use ccpm::utils::security::is_path_blacklisted;
+/// use agpm::utils::security::is_path_blacklisted;
 /// use std::path::Path;
 ///
 /// assert!(is_path_blacklisted(Path::new("/etc/passwd")));

--- a/src/version/comparison.rs
+++ b/src/version/comparison.rs
@@ -15,7 +15,7 @@
 //! # Examples
 //!
 //! ```rust,no_run
-//! use ccpm::version::comparison::VersionComparator;
+//! use agpm::version::comparison::VersionComparator;
 //!
 //! # fn example() -> anyhow::Result<()> {
 //! let versions = vec![
@@ -74,7 +74,7 @@ impl VersionComparator {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::version::comparison::VersionComparator;
+    /// use agpm::version::comparison::VersionComparator;
     ///
     /// # fn example() -> anyhow::Result<()> {
     /// let versions = vec!["v1.0.0".to_string(), "v1.1.0".to_string(), "v2.0.0".to_string()];
@@ -126,7 +126,7 @@ impl VersionComparator {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::version::comparison::VersionComparator;
+    /// use agpm::version::comparison::VersionComparator;
     ///
     /// # fn example() -> anyhow::Result<()> {
     /// let versions = vec![
@@ -192,7 +192,7 @@ impl VersionComparator {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::version::comparison::VersionComparator;
+    /// use agpm::version::comparison::VersionComparator;
     ///
     /// # fn example() -> anyhow::Result<()> {
     /// let versions = vec![

--- a/src/version/conflict.rs
+++ b/src/version/conflict.rs
@@ -9,7 +9,7 @@ use semver::{Op, Version, VersionReq};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 
-use crate::core::CcpmError;
+use crate::core::AgpmError;
 use pubgrub::Ranges;
 
 /// Represents a version conflict between dependencies
@@ -339,7 +339,7 @@ impl ConflictDetector {
         if !conflicts.is_empty() {
             let conflict_messages: Vec<String> = conflicts.iter().map(|c| c.to_string()).collect();
 
-            return Err(CcpmError::Other {
+            return Err(AgpmError::Other {
                 message: format!(
                     "Unable to resolve version conflicts:\n{}",
                     conflict_messages.join("\n")
@@ -352,7 +352,7 @@ impl ConflictDetector {
         for (resource, requirements) in &self.requirements {
             let versions = available_versions
                 .get(resource)
-                .ok_or_else(|| CcpmError::Other {
+                .ok_or_else(|| AgpmError::Other {
                     message: format!("No versions available for resource: {}", resource),
                 })?;
 
@@ -383,7 +383,7 @@ impl ConflictDetector {
         }
 
         if candidates.is_empty() {
-            return Err(CcpmError::Other {
+            return Err(AgpmError::Other {
                 message: format!("No version satisfies all requirements: {:?}", requirements),
             }
             .into());

--- a/src/version/constraints.rs
+++ b/src/version/constraints.rs
@@ -282,9 +282,7 @@ impl VersionConstraint {
                     || trimmed.starts_with('<')
                 {
                     return Err(anyhow::anyhow!(
-                        "Invalid semver constraint '{}': {}",
-                        trimmed,
-                        e
+                        "Invalid semver constraint '{trimmed}': {e}"
                     ));
                 }
                 // Otherwise it might be a git ref, continue
@@ -495,7 +493,7 @@ impl VersionConstraint {
     /// During version resolution, if any constraint in a set allows prereleases,
     /// the entire constraint set will consider prerelease versions as candidates.
     #[must_use]
-    pub fn allows_prerelease(&self) -> bool {
+    pub const fn allows_prerelease(&self) -> bool {
         matches!(self, Self::LatestPrerelease | Self::GitRef(_))
     }
 }
@@ -611,7 +609,7 @@ impl ConstraintSet {
     ///
     /// Returns a new `ConstraintSet` with no constraints
     #[must_use]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             constraints: Vec::new(),
         }

--- a/src/version/constraints.rs
+++ b/src/version/constraints.rs
@@ -1,12 +1,12 @@
-//! Version constraint parsing and resolution for CCPM dependencies.
+//! Version constraint parsing and resolution for AGPM dependencies.
 //!
-//! This module provides comprehensive version constraint handling for CCPM dependencies,
+//! This module provides comprehensive version constraint handling for AGPM dependencies,
 //! supporting semantic versioning, Git references, and various constraint types. It enables
 //! dependency resolution with conflict detection and version matching.
 //!
 //! # Version Constraint Types
 //!
-//! CCPM supports several types of version constraints:
+//! AGPM supports several types of version constraints:
 //!
 //! - **Exact versions**: `"1.0.0"` - Matches exactly the specified version
 //! - **Semantic version ranges**: `"^1.0.0"`, `"~1.2.0"`, `">=1.0.0"` - Uses semver ranges
@@ -26,7 +26,7 @@
 //! ## Basic Constraint Parsing
 //!
 //! ```rust,no_run
-//! use ccpm::version::constraints::VersionConstraint;
+//! use agpm::version::constraints::VersionConstraint;
 //!
 //! // Parse different constraint types
 //! let exact = VersionConstraint::parse("1.0.0")?;
@@ -39,7 +39,7 @@
 //! ## Constraint Set Management
 //!
 //! ```rust,no_run
-//! use ccpm::version::constraints::{ConstraintSet, VersionConstraint};
+//! use agpm::version::constraints::{ConstraintSet, VersionConstraint};
 //! use semver::Version;
 //!
 //! let mut set = ConstraintSet::new();
@@ -60,7 +60,7 @@
 //! ## Dependency Resolution
 //!
 //! ```rust,no_run
-//! use ccpm::version::constraints::ConstraintResolver;
+//! use agpm::version::constraints::ConstraintResolver;
 //! use semver::Version;
 //! use std::collections::HashMap;
 //!
@@ -94,7 +94,7 @@
 //!
 //! # Version Resolution Precedence
 //!
-//! When resolving versions, CCPM follows this precedence:
+//! When resolving versions, AGPM follows this precedence:
 //!
 //! 1. **Exact matches** take highest priority
 //! 2. **Semantic version requirements** are resolved to highest compatible version
@@ -122,11 +122,11 @@ use semver::{Version, VersionReq};
 use std::collections::HashMap;
 use std::fmt;
 
-use crate::core::CcpmError;
+use crate::core::AgpmError;
 
 /// A version constraint that defines acceptable versions for a dependency.
 ///
-/// Version constraints in CCPM support multiple formats to handle different
+/// Version constraints in AGPM support multiple formats to handle different
 /// versioning strategies and Git-based dependencies. Each constraint type
 /// provides specific matching behavior for version resolution.
 ///
@@ -141,7 +141,7 @@ use crate::core::CcpmError;
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::version::constraints::VersionConstraint;
+/// use agpm::version::constraints::VersionConstraint;
 /// use semver::Version;
 ///
 /// // Parse various constraint formats
@@ -216,7 +216,7 @@ impl VersionConstraint {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::version::constraints::VersionConstraint;
+    /// use agpm::version::constraints::VersionConstraint;
     ///
     /// // Exact version matching
     /// let exact = VersionConstraint::parse("1.0.0")?;
@@ -317,7 +317,7 @@ impl VersionConstraint {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::version::constraints::VersionConstraint;
+    /// use agpm::version::constraints::VersionConstraint;
     /// use semver::Version;
     ///
     /// let constraint = VersionConstraint::parse("^1.0.0")?;
@@ -365,7 +365,7 @@ impl VersionConstraint {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::version::constraints::VersionConstraint;
+    /// use agpm::version::constraints::VersionConstraint;
     ///
     /// let branch_constraint = VersionConstraint::parse("main")?;
     /// assert!(branch_constraint.matches_ref("main"));
@@ -410,7 +410,7 @@ impl VersionConstraint {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::version::constraints::VersionConstraint;
+    /// use agpm::version::constraints::VersionConstraint;
     /// use semver::Version;
     ///
     /// let exact = VersionConstraint::parse("1.0.0")?;
@@ -474,7 +474,7 @@ impl VersionConstraint {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::version::constraints::VersionConstraint;
+    /// use agpm::version::constraints::VersionConstraint;
     ///
     /// let latest = VersionConstraint::parse("latest")?;
     /// assert!(!latest.allows_prerelease()); // Stable only
@@ -543,7 +543,7 @@ impl fmt::Display for VersionConstraint {
 /// ## Basic Usage
 ///
 /// ```rust,no_run
-/// use ccpm::version::constraints::{ConstraintSet, VersionConstraint};
+/// use agpm::version::constraints::{ConstraintSet, VersionConstraint};
 /// use semver::Version;
 ///
 /// let mut set = ConstraintSet::new();
@@ -561,7 +561,7 @@ impl fmt::Display for VersionConstraint {
 /// ## Best Match Selection
 ///
 /// ```rust,no_run
-/// use ccpm::version::constraints::{ConstraintSet, VersionConstraint};
+/// use agpm::version::constraints::{ConstraintSet, VersionConstraint};
 /// use semver::Version;
 ///
 /// let mut set = ConstraintSet::new();
@@ -582,7 +582,7 @@ impl fmt::Display for VersionConstraint {
 /// ## Conflict Detection
 ///
 /// ```rust,no_run
-/// use ccpm::version::constraints::{ConstraintSet, VersionConstraint};
+/// use agpm::version::constraints::{ConstraintSet, VersionConstraint};
 /// use semver::Version;
 ///
 /// let mut set = ConstraintSet::new();
@@ -644,7 +644,7 @@ impl ConstraintSet {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::version::constraints::{ConstraintSet, VersionConstraint};
+    /// use agpm::version::constraints::{ConstraintSet, VersionConstraint};
     ///
     /// let mut set = ConstraintSet::new();
     ///
@@ -661,7 +661,7 @@ impl ConstraintSet {
     pub fn add(&mut self, constraint: VersionConstraint) -> Result<()> {
         // Check for conflicting constraints
         if self.has_conflict(&constraint) {
-            return Err(CcpmError::Other {
+            return Err(AgpmError::Other {
                 message: format!("Constraint {constraint} conflicts with existing constraints"),
             }
             .into());
@@ -689,7 +689,7 @@ impl ConstraintSet {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::version::constraints::{ConstraintSet, VersionConstraint};
+    /// use agpm::version::constraints::{ConstraintSet, VersionConstraint};
     /// use semver::Version;
     ///
     /// let mut set = ConstraintSet::new();
@@ -715,7 +715,7 @@ impl ConstraintSet {
     /// Find the best matching version from a list of available versions.
     ///
     /// This method filters the provided versions to find those that satisfy all
-    /// constraints, then selects the "best" match according to CCPM's resolution
+    /// constraints, then selects the "best" match according to AGPM's resolution
     /// strategy. The selection prioritizes newer versions while respecting prerelease
     /// preferences.
     ///
@@ -738,7 +738,7 @@ impl ConstraintSet {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::version::constraints::{ConstraintSet, VersionConstraint};
+    /// use agpm::version::constraints::{ConstraintSet, VersionConstraint};
     /// use semver::Version;
     ///
     /// let mut set = ConstraintSet::new();
@@ -760,7 +760,7 @@ impl ConstraintSet {
     /// ## Prerelease Handling
     ///
     /// ```rust,no_run
-    /// use ccpm::version::constraints::{ConstraintSet, VersionConstraint};
+    /// use agpm::version::constraints::{ConstraintSet, VersionConstraint};
     /// use semver::Version;
     ///
     /// let mut set = ConstraintSet::new();
@@ -806,7 +806,7 @@ impl ConstraintSet {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::version::constraints::{ConstraintSet, VersionConstraint};
+    /// use agpm::version::constraints::{ConstraintSet, VersionConstraint};
     ///
     /// let mut stable_set = ConstraintSet::new();
     /// stable_set.add(VersionConstraint::parse("^1.0.0")?)?;
@@ -862,7 +862,7 @@ impl ConstraintSet {
     /// # Examples
     ///
     /// ```rust,no_run,ignore
-    /// use ccpm::version::constraints::{ConstraintSet, VersionConstraint};
+    /// use agpm::version::constraints::{ConstraintSet, VersionConstraint};
     ///
     /// let mut set = ConstraintSet::new();
     /// set.add(VersionConstraint::parse("1.0.0")?)?;
@@ -929,7 +929,7 @@ impl ConstraintSet {
 /// ## Basic Multi-Dependency Resolution
 ///
 /// ```rust,no_run
-/// use ccpm::version::constraints::ConstraintResolver;
+/// use agpm::version::constraints::ConstraintResolver;
 /// use semver::Version;
 /// use std::collections::HashMap;
 ///
@@ -955,7 +955,7 @@ impl ConstraintSet {
 /// ## Incremental Constraint Addition
 ///
 /// ```rust,no_run
-/// use ccpm::version::constraints::ConstraintResolver;
+/// use agpm::version::constraints::ConstraintResolver;
 ///
 /// let mut resolver = ConstraintResolver::new();
 ///
@@ -1027,7 +1027,7 @@ impl ConstraintResolver {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::version::constraints::ConstraintResolver;
+    /// use agpm::version::constraints::ConstraintResolver;
     ///
     /// let mut resolver = ConstraintResolver::new();
     ///
@@ -1095,7 +1095,7 @@ impl ConstraintResolver {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::version::constraints::ConstraintResolver;
+    /// use agpm::version::constraints::ConstraintResolver;
     /// use semver::Version;
     /// use std::collections::HashMap;
     ///
@@ -1133,7 +1133,7 @@ impl ConstraintResolver {
     /// ## Error Handling
     ///
     /// ```rust,no_run
-    /// use ccpm::version::constraints::ConstraintResolver;
+    /// use agpm::version::constraints::ConstraintResolver;
     /// use std::collections::HashMap;
     ///
     /// let mut resolver = ConstraintResolver::new();
@@ -1160,14 +1160,14 @@ impl ConstraintResolver {
         for (dep, constraint_set) in &self.constraints {
             let versions = available_versions
                 .get(dep)
-                .ok_or_else(|| CcpmError::Other {
+                .ok_or_else(|| AgpmError::Other {
                     message: format!("No versions available for dependency: {dep}"),
                 })?;
 
             let best_match =
                 constraint_set
                     .find_best_match(versions)
-                    .ok_or_else(|| CcpmError::Other {
+                    .ok_or_else(|| AgpmError::Other {
                         message: format!("No version satisfies constraints for dependency: {dep}"),
                     })?;
 

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -1,6 +1,6 @@
-//! Version constraint parsing, comparison, and resolution for CCPM dependencies.
+//! Version constraint parsing, comparison, and resolution for AGPM dependencies.
 //!
-//! This module provides comprehensive version management for CCPM, handling semantic
+//! This module provides comprehensive version management for AGPM, handling semantic
 //! versioning, Git references, and dependency resolution. It supports multiple version
 //! specification formats and provides sophisticated constraint resolution with conflict
 //! detection and prerelease handling.
@@ -13,7 +13,7 @@
 //!
 //! # Version Specifications
 //!
-//! CCPM supports several version specification formats:
+//! AGPM supports several version specification formats:
 //!
 //! ## Semantic Versions
 //! - **Exact versions**: `"1.0.0"` - Matches exactly the specified version
@@ -52,8 +52,8 @@
 //! ## Basic Git Tag Resolution
 //!
 //! ```rust,no_run
-//! use ccpm::version::{VersionResolver, VersionInfo};
-//! use ccpm::git::GitRepo;
+//! use agpm::version::{VersionResolver, VersionInfo};
+//! use agpm::git::GitRepo;
 //! use std::path::PathBuf;
 //!
 //! # async fn example() -> anyhow::Result<()> {
@@ -75,7 +75,7 @@
 //! ## Advanced Constraint Resolution
 //!
 //! ```rust,no_run
-//! use ccpm::version::constraints::{ConstraintResolver, VersionConstraint};
+//! use agpm::version::constraints::{ConstraintResolver, VersionConstraint};
 //! use semver::Version;
 //! use std::collections::HashMap;
 //!
@@ -103,7 +103,7 @@
 //! ## Version Comparison and Analysis
 //!
 //! ```rust,no_run
-//! use ccpm::version::comparison::VersionComparator;
+//! use agpm::version::comparison::VersionComparator;
 //!
 //! # fn example() -> anyhow::Result<()> {
 //! let available_versions = vec![
@@ -132,7 +132,7 @@
 //!
 //! # Prerelease Version Handling
 //!
-//! CCPM provides sophisticated prerelease version management:
+//! AGPM provides sophisticated prerelease version management:
 //!
 //! - **Default exclusion**: Most constraints exclude prereleases for stability
 //! - **Explicit inclusion**: Use `latest-prerelease` or Git refs to include them
@@ -177,7 +177,7 @@ use serde::{Deserialize, Serialize};
 /// # Examples
 ///
 /// ```
-/// use ccpm::version::parse_version_req;
+/// use agpm::version::parse_version_req;
 ///
 /// // All of these parse successfully:
 /// assert!(parse_version_req("1.0.0").is_ok());
@@ -216,7 +216,7 @@ pub fn parse_version_req(requirement: &str) -> Result<VersionReq, semver::Error>
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::version::VersionInfo;
+/// use agpm::version::VersionInfo;
 /// use semver::Version;
 ///
 /// let info = VersionInfo {
@@ -268,8 +268,8 @@ pub struct VersionInfo {
 /// ## Creating from Git Repository
 ///
 /// ```rust,no_run
-/// use ccpm::version::VersionResolver;
-/// use ccpm::git::GitRepo;
+/// use agpm::version::VersionResolver;
+/// use agpm::git::GitRepo;
 /// use std::path::PathBuf;
 ///
 /// # async fn example() -> anyhow::Result<()> {
@@ -284,8 +284,8 @@ pub struct VersionInfo {
 /// ## Version Resolution
 ///
 /// ```rust,no_run
-/// # use ccpm::version::VersionResolver;
-/// # use ccpm::git::GitRepo;
+/// # use agpm::version::VersionResolver;
+/// # use agpm::git::GitRepo;
 /// # use std::path::PathBuf;
 /// #
 /// # async fn example() -> anyhow::Result<()> {
@@ -322,7 +322,7 @@ impl VersionResolver {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::version::VersionResolver;
+    /// use agpm::version::VersionResolver;
     ///
     /// let resolver = VersionResolver::new();
     /// assert_eq!(resolver.list_all().len(), 0);
@@ -363,8 +363,8 @@ impl VersionResolver {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::version::VersionResolver;
-    /// use ccpm::git::GitRepo;
+    /// use agpm::version::VersionResolver;
+    /// use agpm::git::GitRepo;
     /// use std::path::PathBuf;
     ///
     /// # async fn example() -> anyhow::Result<()> {
@@ -428,7 +428,7 @@ impl VersionResolver {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::version::VersionResolver;
+    /// use agpm::version::VersionResolver;
     /// use semver::Version;
     ///
     /// // These would all parse successfully (if the method were public)
@@ -479,8 +479,8 @@ impl VersionResolver {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::version::VersionResolver;
-    /// use ccpm::git::GitRepo;
+    /// use agpm::version::VersionResolver;
+    /// use agpm::git::GitRepo;
     /// use std::path::PathBuf;
     ///
     /// # async fn example() -> anyhow::Result<()> {
@@ -576,8 +576,8 @@ impl VersionResolver {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::version::VersionResolver;
-    /// use ccpm::git::GitRepo;
+    /// use agpm::version::VersionResolver;
+    /// use agpm::git::GitRepo;
     /// use std::path::PathBuf;
     ///
     /// # async fn example() -> anyhow::Result<()> {
@@ -626,8 +626,8 @@ impl VersionResolver {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::version::VersionResolver;
-    /// use ccpm::git::GitRepo;
+    /// use agpm::version::VersionResolver;
+    /// use agpm::git::GitRepo;
     /// use std::path::PathBuf;
     ///
     /// # async fn example() -> anyhow::Result<()> {
@@ -648,8 +648,8 @@ impl VersionResolver {
     /// # Comparison with `get_latest()`
     ///
     /// ```rust,no_run
-    /// # use ccpm::version::VersionResolver;
-    /// # use ccpm::git::GitRepo;
+    /// # use agpm::version::VersionResolver;
+    /// # use agpm::git::GitRepo;
     /// # use std::path::PathBuf;
     /// #
     /// # async fn example() -> anyhow::Result<()> {
@@ -706,8 +706,8 @@ impl VersionResolver {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::version::VersionResolver;
-    /// use ccpm::git::GitRepo;
+    /// use agpm::version::VersionResolver;
+    /// use agpm::git::GitRepo;
     /// use std::path::PathBuf;
     ///
     /// # async fn example() -> anyhow::Result<()> {
@@ -728,8 +728,8 @@ impl VersionResolver {
     /// ## Filtering and Analysis
     ///
     /// ```rust,no_run
-    /// # use ccpm::version::VersionResolver;
-    /// # use ccpm::git::GitRepo;
+    /// # use agpm::version::VersionResolver;
+    /// # use agpm::git::GitRepo;
     /// # use std::path::PathBuf;
     /// #
     /// # async fn example() -> anyhow::Result<()> {
@@ -786,8 +786,8 @@ impl VersionResolver {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::version::VersionResolver;
-    /// use ccpm::git::GitRepo;
+    /// use agpm::version::VersionResolver;
+    /// use agpm::git::GitRepo;
     /// use std::path::PathBuf;
     ///
     /// # async fn example() -> anyhow::Result<()> {
@@ -808,8 +808,8 @@ impl VersionResolver {
     /// ## Comparison with All Versions
     ///
     /// ```rust,no_run
-    /// # use ccpm::version::VersionResolver;
-    /// # use ccpm::git::GitRepo;
+    /// # use agpm::version::VersionResolver;
+    /// # use agpm::git::GitRepo;
     /// # use std::path::PathBuf;
     /// #
     /// # async fn example() -> anyhow::Result<()> {
@@ -872,8 +872,8 @@ impl VersionResolver {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::version::VersionResolver;
-    /// use ccpm::git::GitRepo;
+    /// use agpm::version::VersionResolver;
+    /// use agpm::git::GitRepo;
     /// use std::path::PathBuf;
     ///
     /// # async fn example() -> anyhow::Result<()> {
@@ -906,8 +906,8 @@ impl VersionResolver {
     /// ## Validation Before Resolution
     ///
     /// ```rust,no_run
-    /// # use ccpm::version::VersionResolver;
-    /// # use ccpm::git::GitRepo;
+    /// # use agpm::version::VersionResolver;
+    /// # use agpm::git::GitRepo;
     /// # use std::path::PathBuf;
     /// #
     /// # async fn example() -> anyhow::Result<()> {
@@ -980,7 +980,7 @@ impl Default for VersionResolver {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::version::matches_requirement;
+/// use agpm::version::matches_requirement;
 ///
 /// # fn example() -> anyhow::Result<()> {
 /// // Exact version matching
@@ -1011,7 +1011,7 @@ impl Default for VersionResolver {
 /// ## Complex Range Matching
 ///
 /// ```rust,no_run
-/// use ccpm::version::matches_requirement;
+/// use agpm::version::matches_requirement;
 ///
 /// # fn example() -> anyhow::Result<()> {
 /// // Multiple constraints
@@ -1087,7 +1087,7 @@ pub fn matches_requirement(version: &str, requirement: &str) -> Result<bool> {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::version::{parse_version_constraint, VersionConstraint};
+/// use agpm::version::{parse_version_constraint, VersionConstraint};
 ///
 /// // Semantic versions are classified as tags
 /// let constraint = parse_version_constraint("1.0.0");
@@ -1182,15 +1182,15 @@ pub mod conflict;
 /// Version constraint parsing, sets, and resolution system.
 ///
 /// The [`constraints`] module contains the core constraint management system for
-/// CCPM, including constraint parsing, conflict detection, and multi-dependency
+/// AGPM, including constraint parsing, conflict detection, and multi-dependency
 /// resolution. See the module documentation for comprehensive examples.
 pub mod constraints;
 
-/// Represents different types of version constraints in CCPM.
+/// Represents different types of version constraints in AGPM.
 ///
 /// `VersionConstraint` is a simple enum that categorizes version references into
 /// three main types: Git tags (including semantic versions), Git branches, and
-/// Git commit hashes. This classification helps CCPM route version resolution
+/// Git commit hashes. This classification helps AGPM route version resolution
 /// to the appropriate handling logic.
 ///
 /// # Variants
@@ -1207,7 +1207,7 @@ pub mod constraints;
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ccpm::version::VersionConstraint;
+/// use agpm::version::VersionConstraint;
 ///
 /// // Create different constraint types
 /// let version = VersionConstraint::Tag("1.0.0".to_string());
@@ -1243,7 +1243,7 @@ impl VersionConstraint {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use ccpm::version::VersionConstraint;
+    /// use agpm::version::VersionConstraint;
     ///
     /// let tag = VersionConstraint::Tag("^1.0.0".to_string());
     /// assert_eq!(tag.as_str(), "^1.0.0");

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,4 +1,4 @@
-//! Common test utilities and fixtures for CCPM integration tests
+//! Common test utilities and fixtures for AGPM integration tests
 //!
 //! This module consolidates frequently used test patterns to reduce duplication
 //! and improve test maintainability.
@@ -53,7 +53,7 @@ impl TestGit {
     /// Configure git user for tests
     pub fn config_user(&self) -> Result<()> {
         self.run_git_command(
-            &["config", "user.email", "test@ccpm.example"],
+            &["config", "user.email", "test@agpm.example"],
             "Failed to configure git user email",
         )?;
 
@@ -198,7 +198,7 @@ impl TestProject {
     pub async fn new() -> Result<Self> {
         let temp_dir = TempDir::new()?;
         let project_dir = temp_dir.path().join("project");
-        let cache_dir = temp_dir.path().join(".ccpm").join("cache");
+        let cache_dir = temp_dir.path().join(".agpm").join("cache");
         let sources_dir = temp_dir.path().join("sources");
 
         fs::create_dir_all(&project_dir).await?;
@@ -230,7 +230,7 @@ impl TestProject {
 
     /// Write a manifest file to the project directory
     pub async fn write_manifest(&self, content: &str) -> Result<()> {
-        let manifest_path = self.project_dir.join("ccpm.toml");
+        let manifest_path = self.project_dir.join("agpm.toml");
         fs::write(&manifest_path, content)
             .await
             .with_context(|| format!("Failed to write manifest to {:?}", manifest_path))?;
@@ -239,7 +239,7 @@ impl TestProject {
 
     /// Write a lockfile to the project directory
     pub async fn write_lockfile(&self, content: &str) -> Result<()> {
-        let lockfile_path = self.project_dir.join("ccpm.lock");
+        let lockfile_path = self.project_dir.join("agpm.lock");
         fs::write(&lockfile_path, content)
             .await
             .with_context(|| format!("Failed to write lockfile to {:?}", lockfile_path))?;
@@ -248,7 +248,7 @@ impl TestProject {
 
     /// Read the lockfile from the project directory
     pub async fn read_lockfile(&self) -> Result<String> {
-        let lockfile_path = self.project_dir.join("ccpm.lock");
+        let lockfile_path = self.project_dir.join("agpm.lock");
         fs::read_to_string(&lockfile_path)
             .await
             .with_context(|| format!("Failed to read lockfile from {:?}", lockfile_path))
@@ -287,24 +287,24 @@ impl TestProject {
         })
     }
 
-    /// Run a CCPM command in the project directory
-    pub fn run_ccpm(&self, args: &[&str]) -> Result<CommandOutput> {
-        self.run_ccpm_with_env(args, &[])
+    /// Run a AGPM command in the project directory
+    pub fn run_agpm(&self, args: &[&str]) -> Result<CommandOutput> {
+        self.run_agpm_with_env(args, &[])
     }
 
-    /// Run a CCPM command with custom environment variables
-    pub fn run_ccpm_with_env(
+    /// Run a AGPM command with custom environment variables
+    pub fn run_agpm_with_env(
         &self,
         args: &[&str],
         env_vars: &[(&str, &str)],
     ) -> Result<CommandOutput> {
-        let ccpm_binary = env!("CARGO_BIN_EXE_ccpm");
-        let mut cmd = Command::new(ccpm_binary);
+        let agpm_binary = env!("CARGO_BIN_EXE_agpm");
+        let mut cmd = Command::new(agpm_binary);
 
         cmd.args(args)
             .current_dir(&self.project_dir)
-            .env("CCPM_CACHE_DIR", &self.cache_dir)
-            .env("CCPM_TEST_MODE", "true")
+            .env("AGPM_CACHE_DIR", &self.cache_dir)
+            .env("AGPM_TEST_MODE", "true")
             .env("NO_COLOR", "1");
 
         // Add custom environment variables
@@ -312,7 +312,7 @@ impl TestProject {
             cmd.env(key, value);
         }
 
-        let output = cmd.output().context("Failed to run ccpm command")?;
+        let output = cmd.output().context("Failed to run agpm command")?;
 
         Ok(CommandOutput {
             stdout: String::from_utf8_lossy(&output.stdout).to_string(),

--- a/tests/fixtures/mod.rs
+++ b/tests/fixtures/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-/// Test fixture for creating sample ccpm.toml files
+/// Test fixture for creating sample agpm.toml files
 pub struct ManifestFixture {
     pub content: String,
     #[allow(dead_code)]
@@ -14,8 +14,8 @@ impl ManifestFixture {
             name: "basic".to_string(),
             content: r#"
 [sources]
-official = "https://github.com/example-org/ccpm-official.git"
-community = "https://github.com/example-org/ccpm-community.git"
+official = "https://github.com/example-org/agpm-official.git"
+community = "https://github.com/example-org/agpm-community.git"
 
 [agents]
 my-agent = { source = "official", path = "agents/my-agent.md", version = "v1.0.0" }
@@ -36,7 +36,7 @@ utils = { source = "official", path = "snippets/utils.md", version = "v1.0.0" }
             name: "with_local".to_string(),
             content: r#"
 [sources]
-official = "https://github.com/example-org/ccpm-official.git"
+official = "https://github.com/example-org/agpm-official.git"
 
 [agents]
 my-agent = { source = "official", path = "agents/my-agent.md", version = "v1.0.0" }
@@ -56,7 +56,7 @@ local-utils = { path = "./snippets/local-utils.md" }
             name: "invalid_syntax".to_string(),
             content: r#"
 [sources
-official = "https://github.com/example-org/ccpm-official.git"
+official = "https://github.com/example-org/agpm-official.git"
 
 [agents]
 my-agent = { source = "official", path = "agents/my-agent.md", version = "v1.0.0"
@@ -73,7 +73,7 @@ my-agent = { source = "official", path = "agents/my-agent.md", version = "v1.0.0
             name: "missing_fields".to_string(),
             content: r#"
 [sources]
-official = "https://github.com/example-org/ccpm-official.git"
+official = "https://github.com/example-org/agpm-official.git"
 
 [agents]
 incomplete-agent = { source = "official", path = "" }  # Missing path
@@ -90,8 +90,8 @@ incomplete-agent = { source = "official", path = "" }  # Missing path
             name: "version_conflicts".to_string(),
             content: r#"
 [sources]
-source1 = "https://github.com/example-org/ccpm-repo1.git"
-source2 = "https://github.com/example-org/ccpm-repo2.git"
+source1 = "https://github.com/example-org/agpm-repo1.git"
+source2 = "https://github.com/example-org/agpm-repo2.git"
 
 [agents]
 # Agents that would conflict if installed together
@@ -122,13 +122,13 @@ version = 1
 
 [[sources]]
 name = "official"
-url = "https://github.com/example-org/ccpm-official.git"
+url = "https://github.com/example-org/agpm-official.git"
 commit = "abc123456789abcdef123456789abcdef12345678"
 fetched_at = "2024-01-01T00:00:00Z"
 
 [[sources]]
 name = "community"
-url = "https://github.com/example-org/ccpm-community.git"
+url = "https://github.com/example-org/agpm-community.git"
 commit = "def456789abcdef123456789abcdef123456789ab"
 fetched_at = "2024-01-01T00:00:00Z"
 
@@ -175,7 +175,7 @@ version = 1
 
 [[sources]]
 name = "official"
-url = "https://github.com/example-org/ccpm-official.git"
+url = "https://github.com/example-org/agpm-official.git"
 commit = "old123456789abcdef123456789abcdef123456789"
 fetched_at = "2023-12-01T00:00:00Z"
 

--- a/tests/integration_cache_behavior.rs
+++ b/tests/integration_cache_behavior.rs
@@ -46,7 +46,7 @@ agent3 = {{ source = "official", path = "agents/agent-3.md", version = "v1.0.0" 
 
     // First install - should populate cache
     let start = Instant::now();
-    let output = project.run_ccpm(&["install"])?;
+    let output = project.run_agpm(&["install"])?;
     output.assert_success();
     let first_duration = start.elapsed();
 
@@ -55,7 +55,7 @@ agent3 = {{ source = "official", path = "agents/agent-3.md", version = "v1.0.0" 
 
     // Second install - should reuse cached worktrees
     let start = Instant::now();
-    let output = project.run_ccpm(&["install"])?;
+    let output = project.run_agpm(&["install"])?;
     output.assert_success();
     let second_duration = start.elapsed();
 
@@ -143,7 +143,7 @@ snippet1 = {{ source = "official", path = "snippets/fetch-snippet-1.md", version
 
     // Install with high parallelism - should use fetch caching
     let start = Instant::now();
-    let output = project.run_ccpm(&["install", "--verbose"])?;
+    let output = project.run_agpm(&["install", "--verbose"])?;
     output.assert_success();
     let duration = start.elapsed();
 
@@ -171,7 +171,7 @@ snippet1 = {{ source = "official", path = "snippets/fetch-snippet-1.md", version
     assert!(
         project
             .project_path()
-            .join(".claude/ccpm/snippets/fetch-snippet-1.md")
+            .join(".claude/agpm/snippets/fetch-snippet-1.md")
             .exists()
     );
 
@@ -220,7 +220,7 @@ official = "{}"
 
     // Install with maximum parallelism
     let start = Instant::now();
-    let output = project.run_ccpm(&["install"])?;
+    let output = project.run_agpm(&["install"])?;
     output.assert_success();
     let duration = start.elapsed();
 
@@ -279,15 +279,15 @@ snippet = {{ source = "official", path = "snippets/persistent-snippet.md", versi
     project.write_manifest(&manifest_content).await?;
 
     // First command: install
-    let output = project.run_ccpm(&["install"])?;
+    let output = project.run_agpm(&["install"])?;
     output.assert_success();
 
     // Second command: update (should reuse cache)
-    let output = project.run_ccpm(&["update"])?;
+    let output = project.run_agpm(&["update"])?;
     output.assert_success();
 
     // Third command: list (should work with cached data)
-    let output = project.run_ccpm(&["list"])?;
+    let output = project.run_agpm(&["list"])?;
     output.assert_success();
 
     // Verify final state
@@ -301,7 +301,7 @@ snippet = {{ source = "official", path = "snippets/persistent-snippet.md", versi
     assert!(
         project
             .project_path()
-            .join(".claude/ccpm/snippets/persistent-snippet.md")
+            .join(".claude/agpm/snippets/persistent-snippet.md")
             .exists()
     );
 

--- a/tests/integration_conflict_detection.rs
+++ b/tests/integration_conflict_detection.rs
@@ -22,7 +22,7 @@ async fn test_exact_version_conflict_blocks_install() {
         &manifest_path,
         r#"
 [sources]
-community = "https://github.com/aig787/ccpm-community.git"
+community = "https://github.com/aig787/agpm-community.git"
 
 [agents]
 # Same path, different versions - should conflict

--- a/tests/integration_conflict_detection.rs
+++ b/tests/integration_conflict_detection.rs
@@ -15,7 +15,7 @@ use common::TestProject;
 #[tokio::test]
 async fn test_exact_version_conflict_blocks_install() {
     let temp_dir = TempDir::new().unwrap();
-    let manifest_path = temp_dir.path().join("ccpm.toml");
+    let manifest_path = temp_dir.path().join("agpm.toml");
 
     // Create manifest with two resources pointing to same source:path but different versions
     fs::write(
@@ -33,7 +33,7 @@ api-designer-v2 = { source = "community", path = "agents/awesome-claude-code-sub
     .await
     .unwrap();
 
-    let mut cmd = Command::cargo_bin("ccpm").unwrap();
+    let mut cmd = Command::cargo_bin("agpm").unwrap();
     cmd.current_dir(temp_dir.path())
         .arg("install")
         .assert()
@@ -76,7 +76,7 @@ test-agent-2 = {{ source = "test-repo", path = "agents/test-agent.md", version =
     );
     project.write_manifest(&manifest).await.unwrap();
 
-    let output = project.run_ccpm(&["install"]).unwrap();
+    let output = project.run_agpm(&["install"]).unwrap();
     assert!(
         output.success,
         "Install should succeed. Stderr: {}",
@@ -141,7 +141,7 @@ agent-dev = {{ source = "test-repo", path = "agents/test-agent.md", branch = "ma
     );
     project.write_manifest(&manifest).await.unwrap();
 
-    let output = project.run_ccpm(&["install"]).unwrap();
+    let output = project.run_agpm(&["install"]).unwrap();
     assert!(
         !output.success,
         "Install should fail with version conflict. Stderr: {}",
@@ -191,7 +191,7 @@ agent-pinned = {{ source = "test-repo", path = "agents/test-agent.md", version =
     );
     project.write_manifest(&manifest).await.unwrap();
 
-    let output = project.run_ccpm(&["install"]).unwrap();
+    let output = project.run_agpm(&["install"]).unwrap();
     assert!(
         !output.success,
         "Install should fail with version conflict. Stderr: {}",
@@ -252,7 +252,7 @@ agent-dev = {{ source = "test-repo", path = "agents/test-agent.md", branch = "de
     );
     project.write_manifest(&manifest).await.unwrap();
 
-    let output = project.run_ccpm(&["install"]).unwrap();
+    let output = project.run_agpm(&["install"]).unwrap();
     assert!(
         !output.success,
         "Install should fail with version conflict. Stderr: {}",
@@ -316,7 +316,7 @@ agent-2 = {{ source = "test-repo", path = "agents/test-agent.md", branch = "Main
     );
     project.write_manifest(&manifest).await.unwrap();
 
-    let output = project.run_ccpm(&["install"]).unwrap();
+    let output = project.run_agpm(&["install"]).unwrap();
     assert!(
         output.success,
         "Install should succeed. Stderr: {}",

--- a/tests/integration_deploy.rs
+++ b/tests/integration_deploy.rs
@@ -48,7 +48,7 @@ helper = {{ source = "community", path = "agents/helper.md", version = "v1.0.0" 
     project.write_manifest(&manifest_content).await.unwrap();
 
     // Run install command
-    let output = project.run_ccpm(&["install", "--no-cache"]).unwrap();
+    let output = project.run_agpm(&["install", "--no-cache"]).unwrap();
     output.assert_success();
     assert!(
         output.stdout.contains("Installing")
@@ -59,7 +59,7 @@ helper = {{ source = "community", path = "agents/helper.md", version = "v1.0.0" 
     );
 
     // Verify lockfile was created
-    let lockfile_path = project.project_path().join("ccpm.lock");
+    let lockfile_path = project.project_path().join("agpm.lock");
     FileAssert::exists(&lockfile_path).await;
 
     // Verify lockfile content structure
@@ -152,12 +152,12 @@ installed_at = ".claude/agents/helper.md"
         official_url, official_sha, community_url, community_sha, official_sha, community_sha
     );
 
-    fs::write(project.project_path().join("ccpm.lock"), lockfile_content)
+    fs::write(project.project_path().join("agpm.lock"), lockfile_content)
         .await
         .unwrap();
 
     // Run install command
-    let output = project.run_ccpm(&["install", "--no-cache"]).unwrap();
+    let output = project.run_agpm(&["install", "--no-cache"]).unwrap();
     output.assert_success();
     assert!(
         output.stdout.contains("Installing")
@@ -174,15 +174,15 @@ installed_at = ".claude/agents/helper.md"
     DirAssert::contains_file(&agents_dir, "helper.md").await;
 }
 
-/// Test install command without ccpm.toml
+/// Test install command without agpm.toml
 #[tokio::test]
 async fn test_install_without_manifest() {
     let project = TestProject::new().await.unwrap();
 
-    let output = project.run_ccpm(&["install", "--no-cache"]).unwrap();
+    let output = project.run_agpm(&["install", "--no-cache"]).unwrap();
     assert!(!output.success, "Expected command to fail but it succeeded");
     assert!(
-        output.stderr.contains("Manifest file ccpm.toml not found"),
+        output.stderr.contains("Manifest file agpm.toml not found"),
         "Expected manifest not found error, got: {}",
         output.stderr
     );
@@ -195,7 +195,7 @@ async fn test_install_invalid_manifest_syntax() {
     let manifest_content = ManifestFixture::invalid_syntax().content;
     project.write_manifest(&manifest_content).await.unwrap();
 
-    let output = project.run_ccpm(&["install", "--no-cache"]).unwrap();
+    let output = project.run_agpm(&["install", "--no-cache"]).unwrap();
     assert!(!output.success, "Expected command to fail but it succeeded");
     assert!(
         output.stderr.contains("Invalid manifest file syntax"),
@@ -211,7 +211,7 @@ async fn test_install_missing_manifest_fields() {
     let manifest_content = ManifestFixture::missing_fields().content;
     project.write_manifest(&manifest_content).await.unwrap();
 
-    let output = project.run_ccpm(&["install", "--no-cache"]).unwrap();
+    let output = project.run_agpm(&["install", "--no-cache"]).unwrap();
     assert!(!output.success, "Expected command to fail but it succeeded");
     assert!(
         output.stderr.contains("Missing required field"),
@@ -266,7 +266,7 @@ helper = {{ source = "community", path = "agents/helper.md", version = "v1.0.0" 
     project.write_manifest(&manifest_content).await.unwrap();
 
     // Run install command
-    let output = project.run_ccpm(&["install", "--no-cache"]).unwrap();
+    let output = project.run_agpm(&["install", "--no-cache"]).unwrap();
     output.assert_success();
     assert!(
         output.stdout.contains("Installing")
@@ -336,7 +336,7 @@ local-utils = {{ path = "./snippets/local-utils.md" }}
     project.write_manifest(&manifest_content).await.unwrap();
 
     // Run install command
-    let output = project.run_ccpm(&["install", "--no-cache"]).unwrap();
+    let output = project.run_agpm(&["install", "--no-cache"]).unwrap();
     output.assert_success();
     assert!(
         output.stdout.contains("Installing")
@@ -347,7 +347,7 @@ local-utils = {{ path = "./snippets/local-utils.md" }}
     );
 
     // Verify lockfile was created and contains all dependencies
-    let lockfile_content = fs::read_to_string(project.project_path().join("ccpm.lock"))
+    let lockfile_content = fs::read_to_string(project.project_path().join("agpm.lock"))
         .await
         .unwrap();
     assert!(lockfile_content.contains("my-agent")); // remote dependency
@@ -362,7 +362,7 @@ local-utils = {{ path = "./snippets/local-utils.md" }}
     let snippets_dir = project
         .project_path()
         .join(".claude")
-        .join("ccpm")
+        .join("agpm")
         .join("snippets");
     assert!(snippets_dir.join("local-utils.md").exists());
 }
@@ -400,7 +400,7 @@ my-agent = {{ source = "official", path = "agents/my-agent.md", version = "v1.0.
 
     // Run install command with verbose flag
     let output = project
-        .run_ccpm(&["install", "--no-cache", "--verbose"])
+        .run_agpm(&["install", "--no-cache", "--verbose"])
         .unwrap();
     output.assert_success();
     assert!(
@@ -442,7 +442,7 @@ my-agent = {{ source = "official", path = "agents/my-agent.md", version = "v1.0.
 
     // Run install command with quiet flag
     let output = project
-        .run_ccpm(&["install", "--no-cache", "--quiet"])
+        .run_agpm(&["install", "--no-cache", "--quiet"])
         .unwrap();
     output.assert_success();
 }
@@ -462,7 +462,7 @@ my-agent = { source = "official", path = "agents/my-agent.md", version = "v1.0.0
 "#;
     project.write_manifest(manifest_content).await.unwrap();
 
-    let output = project.run_ccpm(&["install", "--no-cache"]).unwrap();
+    let output = project.run_agpm(&["install", "--no-cache"]).unwrap();
     assert!(!output.success, "Expected command to fail but it succeeded");
     assert!(
         output.stderr.contains("Failed to clone")
@@ -478,7 +478,7 @@ my-agent = { source = "official", path = "agents/my-agent.md", version = "v1.0.0
 /// Test install help command
 #[tokio::test]
 async fn test_install_help() {
-    let mut cmd = assert_cmd::Command::cargo_bin("ccpm").unwrap();
+    let mut cmd = assert_cmd::Command::cargo_bin("agpm").unwrap();
     cmd.arg("install")
         .arg("--help")
         .assert()
@@ -500,13 +500,13 @@ async fn test_install_corrupted_lockfile() {
 
     // Create corrupted lockfile
     fs::write(
-        project.project_path().join("ccpm.lock"),
+        project.project_path().join("agpm.lock"),
         "corrupted content",
     )
     .await
     .unwrap();
 
-    let output = project.run_ccpm(&["install", "--no-cache"]).unwrap();
+    let output = project.run_agpm(&["install", "--no-cache"]).unwrap();
     assert!(!output.success, "Expected command to fail but it succeeded");
     assert!(
         output.stderr.contains("Invalid lockfile syntax"),

--- a/tests/integration_deps_refresh.rs
+++ b/tests/integration_deps_refresh.rs
@@ -104,13 +104,13 @@ installed_at = "snippets/utils.md"
 "#
     );
     fs::write(
-        project.project_path().join("ccpm.lock"),
+        project.project_path().join("agpm.lock"),
         lockfile_content.trim(),
     )
     .await
     .unwrap();
 
-    let output = project.run_ccpm(&["update"]).unwrap();
+    let output = project.run_agpm(&["update"]).unwrap();
     assert!(output.success);
     eprintln!("=== STDOUT ===\n{}", output.stdout);
     eprintln!("=== STDERR ===\n{}", output.stderr);
@@ -120,7 +120,7 @@ installed_at = "snippets/utils.md"
     assert!(output.stdout.contains("resources"));
 
     // Verify lockfile was updated
-    let lockfile_path = project.project_path().join("ccpm.lock");
+    let lockfile_path = project.project_path().join("agpm.lock");
     assert!(lockfile_path.exists());
 
     let lockfile_content = fs::read_to_string(&lockfile_path).await.unwrap();
@@ -197,18 +197,18 @@ installed_at = "snippets/utils.md"
 "#
     );
     fs::write(
-        project.project_path().join("ccpm.lock"),
+        project.project_path().join("agpm.lock"),
         lockfile_content.trim(),
     )
     .await
     .unwrap();
 
-    let output = project.run_ccpm(&["update", "my-agent"]).unwrap();
+    let output = project.run_agpm(&["update", "my-agent"]).unwrap();
     assert!(output.success);
     assert!(output.stdout.contains("Found") || output.stdout.contains("update"));
 
     // Verify only the specified dependency was updated
-    let lockfile_content = fs::read_to_string(project.project_path().join("ccpm.lock"))
+    let lockfile_content = fs::read_to_string(project.project_path().join("agpm.lock"))
         .await
         .unwrap();
     assert!(lockfile_content.contains("my-agent"));
@@ -219,9 +219,9 @@ installed_at = "snippets/utils.md"
 async fn test_update_without_manifest() {
     let project = TestProject::new().await.unwrap();
 
-    let output = project.run_ccpm(&["update"]).unwrap();
+    let output = project.run_agpm(&["update"]).unwrap();
     assert!(!output.success);
-    assert!(output.stderr.contains("ccpm.toml not found"));
+    assert!(output.stderr.contains("agpm.toml not found"));
 }
 
 /// Test update without lockfile (should perform fresh install)
@@ -247,13 +247,13 @@ utils = {{ source = "official", path = "snippets/utils.md", version = "v1.0.0" }
     );
     project.write_manifest(&manifest_content).await.unwrap();
 
-    let output = project.run_ccpm(&["update"]).unwrap();
+    let output = project.run_agpm(&["update"]).unwrap();
     assert!(output.success);
     assert!(output.stdout.contains("No lockfile found"));
     assert!(output.stdout.contains("Performing fresh install"));
 
     // Verify lockfile was created
-    assert!(project.project_path().join("ccpm.lock").exists());
+    assert!(project.project_path().join("agpm.lock").exists());
 }
 
 /// Test update with --check flag (dry run)
@@ -306,13 +306,13 @@ installed_at = "agents/my-agent.md"
 "#
     );
     fs::write(
-        project.project_path().join("ccpm.lock"),
+        project.project_path().join("agpm.lock"),
         lockfile_content.trim(),
     )
     .await
     .unwrap();
 
-    let output = project.run_ccpm(&["update", "--check"]).unwrap();
+    let output = project.run_agpm(&["update", "--check"]).unwrap();
     // Should exit with code 1 when updates are available (useful for CI)
     assert!(
         !output.success,
@@ -397,17 +397,17 @@ installed_at = "snippets/utils.md"
 "#
     );
     fs::write(
-        project.project_path().join("ccpm.lock"),
+        project.project_path().join("agpm.lock"),
         lockfile_content.trim(),
     )
     .await
     .unwrap();
 
-    let output = project.run_ccpm(&["update"]).unwrap();
+    let output = project.run_agpm(&["update"]).unwrap();
     assert!(output.success);
     assert!(output.stdout.contains("Found") || output.stdout.contains("update"));
 
-    let lockfile_content = fs::read_to_string(project.project_path().join("ccpm.lock"))
+    let lockfile_content = fs::read_to_string(project.project_path().join("agpm.lock"))
         .await
         .unwrap();
     assert!(lockfile_content.contains("my-agent"));
@@ -438,11 +438,11 @@ utils = {{ source = "official", path = "snippets/utils.md", version = "v1.0.0" }
     );
     project.write_manifest(&manifest_content).await.unwrap();
 
-    let output = project.run_ccpm(&["update", "--backup"]).unwrap();
+    let output = project.run_agpm(&["update", "--backup"]).unwrap();
     assert!(output.success);
     // Note: backup functionality may not be implemented yet, so we just check success
     // assert!(output.stdout.contains("Created backup"));
-    // assert!(project.project_path().join("ccpm.lock.backup").exists());
+    // assert!(project.project_path().join("agpm.lock.backup").exists());
 }
 
 /// Test update with verbose output
@@ -468,7 +468,7 @@ utils = {{ source = "official", path = "snippets/utils.md", version = "v1.0.0" }
     );
     project.write_manifest(&manifest_content).await.unwrap();
 
-    let output = project.run_ccpm(&["update", "--verbose"]).unwrap();
+    let output = project.run_agpm(&["update", "--verbose"]).unwrap();
     assert!(output.success);
     assert!(
         output.stdout.contains("Found")
@@ -500,7 +500,7 @@ utils = {{ source = "official", path = "snippets/utils.md", version = "v1.0.0" }
     );
     project.write_manifest(&manifest_content).await.unwrap();
 
-    let output = project.run_ccpm(&["update", "--quiet"]).unwrap();
+    let output = project.run_agpm(&["update", "--quiet"]).unwrap();
     assert!(output.success);
     // Should have minimal output in quiet mode
 }
@@ -575,18 +575,18 @@ installed_at = "snippets/utils.md"
 "#
     );
     fs::write(
-        project.project_path().join("ccpm.lock"),
+        project.project_path().join("agpm.lock"),
         lockfile_content.trim(),
     )
     .await
     .unwrap();
 
     // Store original lockfile content
-    let original_lockfile = fs::read_to_string(project.project_path().join("ccpm.lock"))
+    let original_lockfile = fs::read_to_string(project.project_path().join("agpm.lock"))
         .await
         .unwrap();
 
-    let output = project.run_ccpm(&["update", "--dry-run"]).unwrap();
+    let output = project.run_agpm(&["update", "--dry-run"]).unwrap();
     // Should exit with code 1 when updates are available (useful for CI)
     assert!(
         !output.success,
@@ -599,7 +599,7 @@ installed_at = "snippets/utils.md"
     );
 
     // Verify lockfile wasn't actually modified
-    let current_lockfile = fs::read_to_string(project.project_path().join("ccpm.lock"))
+    let current_lockfile = fs::read_to_string(project.project_path().join("agpm.lock"))
         .await
         .unwrap();
     assert_eq!(original_lockfile, current_lockfile);
@@ -685,13 +685,13 @@ installed_at = "snippets/utils.md"
         sources_path, sources_path
     );
     fs::write(
-        project.project_path().join("ccpm.lock"),
+        project.project_path().join("agpm.lock"),
         lockfile_content.trim(),
     )
     .await
     .unwrap();
 
-    let output = project.run_ccpm(&["update"]).unwrap();
+    let output = project.run_agpm(&["update"]).unwrap();
     assert!(!output.success);
     assert!(
         output.stderr.contains("Failed to clone")
@@ -711,7 +711,7 @@ installed_at = "snippets/utils.md"
 /// Test update help command
 #[tokio::test]
 async fn test_update_help() {
-    let mut cmd = assert_cmd::Command::cargo_bin("ccpm").unwrap();
+    let mut cmd = assert_cmd::Command::cargo_bin("agpm").unwrap();
     cmd.arg("update")
         .arg("--help")
         .assert()
@@ -733,13 +733,13 @@ async fn test_update_corrupted_lockfile() {
 
     // Create corrupted lockfile
     fs::write(
-        project.project_path().join("ccpm.lock"),
+        project.project_path().join("agpm.lock"),
         "corrupted lockfile content",
     )
     .await
     .unwrap();
 
-    let output = project.run_ccpm(&["update"]).unwrap();
+    let output = project.run_agpm(&["update"]).unwrap();
     assert!(!output.success);
     assert!(
         output.stderr.contains("Failed to parse lockfile")
@@ -773,7 +773,7 @@ utils = {{ source = "official", path = "snippets/utils.md", version = "v1.0.0" }
     );
     project.write_manifest(&manifest_content).await.unwrap();
 
-    let output = project.run_ccpm(&["update"]).unwrap();
+    let output = project.run_agpm(&["update"]).unwrap();
     assert!(output.success);
     assert!(
         output.stdout.contains("All dependencies are up to date")

--- a/tests/integration_error_scenarios.rs
+++ b/tests/integration_error_scenarios.rs
@@ -346,7 +346,7 @@ async fn test_system_limits() {
     let mut manifest_content = String::from(
         r#"
 [sources]
-official = "https://github.com/example-org/ccpm-official.git"
+official = "https://github.com/example-org/agpm-official.git"
 
 [agents]
 "#,
@@ -402,7 +402,7 @@ version = 1
 
 [[sources]]
 name = "official"
-url = "https://github.com/example-org/ccpm-official.git"
+url = "https://github.com/example-org/agpm-official.git"
 "#;
     fs::write(project.project_path().join("agpm.lock"), partial_lockfile)
         .await
@@ -562,7 +562,7 @@ version = 1
 
 [[sources]]
 name = "official"
-url = "https://github.com/example-org/ccpm-official.git"
+url = "https://github.com/example-org/agpm-official.git"
 commit = "abc123456789abcdef123456789abcdef12345678"
 
 [[agents]]
@@ -601,7 +601,7 @@ async fn test_git_command_missing() {
     // Create a manifest that requires git operations
     let manifest_content = r#"
 [sources]
-official = "https://github.com/example-org/ccpm-official.git"
+official = "https://github.com/example-org/agpm-official.git"
 
 [agents]
 test-agent = { source = "official", path = "agents/test.md", version = "v1.0.0" }

--- a/tests/integration_file_url.rs
+++ b/tests/integration_file_url.rs
@@ -46,7 +46,7 @@ test-agent = {{ source = "local", path = "agents/test.md", version = "v2.0.0" }}
     );
     project.write_manifest(&manifest).await?;
 
-    project.run_ccpm(&["install"])?.assert_success();
+    project.run_agpm(&["install"])?.assert_success();
 
     // Verify the installed file is from v2.0.0
     // Files use basename from path, not dependency name
@@ -105,7 +105,7 @@ test-agent = {{ source = "local", path = "agents/test.md", version = "v1.0.0" }}
     );
     project.write_manifest(&manifest_v1).await?;
 
-    project.run_ccpm(&["install"])?.assert_success();
+    project.run_agpm(&["install"])?.assert_success();
 
     // Verify v1 is installed
     // Files use basename from path, not dependency name
@@ -131,7 +131,7 @@ test-agent = {{ source = "local", path = "agents/test.md", version = "v2.0.0" }}
     );
     project.write_manifest(&manifest_v2).await?;
 
-    project.run_ccpm(&["install"])?.assert_success();
+    project.run_agpm(&["install"])?.assert_success();
 
     // Verify v2 is now installed
     // Files use basename from path, not dependency name
@@ -184,7 +184,7 @@ test-agent = {{ source = "local", path = "agents/test.md", version = "v1.0.0" }}
     );
     project.write_manifest(&manifest).await?;
 
-    project.run_ccpm(&["install"])?.assert_success();
+    project.run_agpm(&["install"])?.assert_success();
 
     // Verify the installed file is from the committed v1.0.0, not the uncommitted changes
     // Files use basename from path, not dependency name

--- a/tests/integration_gitignore.rs
+++ b/tests/integration_gitignore.rs
@@ -1,6 +1,6 @@
 //! Integration tests for .gitignore management functionality
 //!
-//! These tests verify that CCPM correctly manages .gitignore files
+//! These tests verify that AGPM correctly manages .gitignore files
 //! based on the target.gitignore configuration setting.
 
 use anyhow::Result;
@@ -22,7 +22,7 @@ async fn create_test_manifest(gitignore: bool, source_dir: &Path) -> String {
 
 [target]
 agents = ".claude/agents"
-snippets = ".claude/ccpm/snippets"
+snippets = ".claude/agpm/snippets"
 commands = ".claude/commands"
 gitignore = {}
 
@@ -49,7 +49,7 @@ async fn create_test_manifest_default(source_dir: &Path) -> String {
 
 [target]
 agents = ".claude/agents"
-snippets = ".claude/ccpm/snippets"
+snippets = ".claude/agpm/snippets"
 commands = ".claude/commands"
 
 [agents.test-agent]
@@ -74,7 +74,7 @@ installed_at = ".claude/agents/test-agent.md"
 name = "test-snippet"
 path = "source/snippets/test.md"
 checksum = ""
-installed_at = ".claude/ccpm/snippets/test-snippet.md"
+installed_at = ".claude/agpm/snippets/test-snippet.md"
 
 [[commands]]
 name = "test-command"
@@ -102,7 +102,7 @@ async fn create_test_source_files(source_dir: &Path) -> Result<()> {
 
 #[tokio::test]
 async fn test_gitignore_enabled_by_default() {
-    ccpm::test_utils::init_test_logging(None);
+    agpm::test_utils::init_test_logging(None);
     let temp = TempDir::new().unwrap();
     let project_dir = temp.path();
     let source_dir = temp.path().join("source");
@@ -111,7 +111,7 @@ async fn test_gitignore_enabled_by_default() {
     create_test_source_files(&source_dir).await.unwrap();
 
     // Create manifest without explicit gitignore setting (should default to true)
-    let manifest_path = project_dir.join("ccpm.toml");
+    let manifest_path = project_dir.join("agpm.toml");
     fs::write(
         &manifest_path,
         create_test_manifest_default(&source_dir).await,
@@ -120,13 +120,13 @@ async fn test_gitignore_enabled_by_default() {
     .unwrap();
 
     // Create lockfile
-    let lockfile_path = project_dir.join("ccpm.lock");
+    let lockfile_path = project_dir.join("agpm.lock");
     fs::write(&lockfile_path, create_test_lockfile().await)
         .await
         .unwrap();
 
     // Run install command
-    Command::cargo_bin("ccpm")
+    Command::cargo_bin("agpm")
         .unwrap()
         .arg("install")
         .arg("--quiet")
@@ -142,13 +142,13 @@ async fn test_gitignore_enabled_by_default() {
 
     // Check that it has the expected structure
     let content = fs::read_to_string(&gitignore_path).await.unwrap();
-    assert!(content.contains("CCPM managed entries"));
-    assert!(content.contains("# End of CCPM managed entries"));
+    assert!(content.contains("AGPM managed entries"));
+    assert!(content.contains("# End of AGPM managed entries"));
 }
 
 #[tokio::test]
 async fn test_gitignore_explicitly_enabled() {
-    ccpm::test_utils::init_test_logging(None);
+    agpm::test_utils::init_test_logging(None);
     let temp = TempDir::new().unwrap();
     let project_dir = temp.path();
     let source_dir = temp.path().join("source");
@@ -157,7 +157,7 @@ async fn test_gitignore_explicitly_enabled() {
     create_test_source_files(&source_dir).await.unwrap();
 
     // Create manifest with gitignore = true
-    let manifest_path = project_dir.join("ccpm.toml");
+    let manifest_path = project_dir.join("agpm.toml");
     fs::write(
         &manifest_path,
         create_test_manifest(true, &source_dir).await,
@@ -166,13 +166,13 @@ async fn test_gitignore_explicitly_enabled() {
     .unwrap();
 
     // Create lockfile
-    let lockfile_path = project_dir.join("ccpm.lock");
+    let lockfile_path = project_dir.join("agpm.lock");
     fs::write(&lockfile_path, create_test_lockfile().await)
         .await
         .unwrap();
 
     // Run install command
-    Command::cargo_bin("ccpm")
+    Command::cargo_bin("agpm")
         .unwrap()
         .arg("install")
         .arg("--quiet")
@@ -185,14 +185,14 @@ async fn test_gitignore_explicitly_enabled() {
 
     // Verify content structure
     let content = fs::read_to_string(&gitignore_path).await.unwrap();
-    assert!(content.contains("CCPM managed entries"));
-    assert!(content.contains("CCPM managed entries - do not edit below this line"));
-    assert!(content.contains("# End of CCPM managed entries"));
+    assert!(content.contains("AGPM managed entries"));
+    assert!(content.contains("AGPM managed entries - do not edit below this line"));
+    assert!(content.contains("# End of AGPM managed entries"));
 }
 
 #[tokio::test]
 async fn test_gitignore_disabled() {
-    ccpm::test_utils::init_test_logging(None);
+    agpm::test_utils::init_test_logging(None);
     let temp = TempDir::new().unwrap();
     let project_dir = temp.path();
     let source_dir = temp.path().join("source");
@@ -201,7 +201,7 @@ async fn test_gitignore_disabled() {
     create_test_source_files(&source_dir).await.unwrap();
 
     // Create manifest with gitignore = false
-    let manifest_path = project_dir.join("ccpm.toml");
+    let manifest_path = project_dir.join("agpm.toml");
     fs::write(
         &manifest_path,
         create_test_manifest(false, &source_dir).await,
@@ -210,13 +210,13 @@ async fn test_gitignore_disabled() {
     .unwrap();
 
     // Create lockfile
-    let lockfile_path = project_dir.join("ccpm.lock");
+    let lockfile_path = project_dir.join("agpm.lock");
     fs::write(&lockfile_path, create_test_lockfile().await)
         .await
         .unwrap();
 
     // Run install command
-    Command::cargo_bin("ccpm")
+    Command::cargo_bin("agpm")
         .unwrap()
         .arg("install")
         .arg("--quiet")
@@ -233,7 +233,7 @@ async fn test_gitignore_disabled() {
 
 #[tokio::test]
 async fn test_gitignore_preserves_user_entries() {
-    ccpm::test_utils::init_test_logging(None);
+    agpm::test_utils::init_test_logging(None);
     let temp = TempDir::new().unwrap();
     let project_dir = temp.path();
     let source_dir = temp.path().join("source");
@@ -253,14 +253,14 @@ async fn test_gitignore_preserves_user_entries() {
 user-file.txt
 temp/
 
-# CCPM managed entries - do not edit below this line
+# AGPM managed entries - do not edit below this line
 .claude/agents/old-agent.md
-# End of CCPM managed entries
+# End of AGPM managed entries
 "#;
     fs::write(&gitignore_path, user_content).await.unwrap();
 
     // Create manifest with gitignore enabled
-    let manifest_path = project_dir.join("ccpm.toml");
+    let manifest_path = project_dir.join("agpm.toml");
     fs::write(
         &manifest_path,
         create_test_manifest(true, &source_dir).await,
@@ -269,13 +269,13 @@ temp/
     .unwrap();
 
     // Create lockfile
-    let lockfile_path = project_dir.join("ccpm.lock");
+    let lockfile_path = project_dir.join("agpm.lock");
     fs::write(&lockfile_path, create_test_lockfile().await)
         .await
         .unwrap();
 
     // Run install command
-    Command::cargo_bin("ccpm")
+    Command::cargo_bin("agpm")
         .unwrap()
         .arg("install")
         .arg("--quiet")
@@ -289,15 +289,15 @@ temp/
     assert!(updated_content.contains("user-file.txt"));
     assert!(updated_content.contains("temp/"));
 
-    // Check that CCPM section exists (entries will be based on what was actually installed)
-    assert!(updated_content.contains("CCPM managed entries"));
-    assert!(updated_content.contains("# End of CCPM managed entries"));
-    assert!(updated_content.contains(".claude/ccpm/snippets/test-snippet.md"));
+    // Check that AGPM section exists (entries will be based on what was actually installed)
+    assert!(updated_content.contains("AGPM managed entries"));
+    assert!(updated_content.contains("# End of AGPM managed entries"));
+    assert!(updated_content.contains(".claude/agpm/snippets/test-snippet.md"));
 }
 
 #[tokio::test]
-async fn test_gitignore_preserves_content_after_ccpm_section() {
-    ccpm::test_utils::init_test_logging(None);
+async fn test_gitignore_preserves_content_after_agpm_section() {
+    agpm::test_utils::init_test_logging(None);
     let temp = TempDir::new().unwrap();
     let project_dir = temp.path();
     let source_dir = temp.path().join("source");
@@ -310,17 +310,17 @@ async fn test_gitignore_preserves_content_after_ccpm_section() {
         .await
         .unwrap();
 
-    // Create existing gitignore with content after CCPM section
+    // Create existing gitignore with content after AGPM section
     let gitignore_path = project_dir.join(".gitignore");
     let user_content = r#"# Project gitignore
 *.backup
 temp/
 
-# CCPM managed entries - do not edit below this line
+# AGPM managed entries - do not edit below this line
 .claude/agents/old-agent.md
-# End of CCPM managed entries
+# End of AGPM managed entries
 
-# Additional entries after CCPM section
+# Additional entries after AGPM section
 local-config.json
 debug/
 # End comment
@@ -328,7 +328,7 @@ debug/
     fs::write(&gitignore_path, user_content).await.unwrap();
 
     // Create manifest with gitignore enabled
-    let manifest_path = project_dir.join("ccpm.toml");
+    let manifest_path = project_dir.join("agpm.toml");
     fs::write(
         &manifest_path,
         create_test_manifest(true, &source_dir).await,
@@ -337,13 +337,13 @@ debug/
     .unwrap();
 
     // Create lockfile
-    let lockfile_path = project_dir.join("ccpm.lock");
+    let lockfile_path = project_dir.join("agpm.lock");
     fs::write(&lockfile_path, create_test_lockfile().await)
         .await
         .unwrap();
 
     // Run install command
-    Command::cargo_bin("ccpm")
+    Command::cargo_bin("agpm")
         .unwrap()
         .arg("install")
         .arg("--quiet")
@@ -353,29 +353,29 @@ debug/
     // Check that all sections are preserved
     let updated_content = fs::read_to_string(&gitignore_path).await.unwrap();
 
-    // Check content before CCPM section
+    // Check content before AGPM section
     assert!(updated_content.contains("# Project gitignore"));
     assert!(updated_content.contains("*.backup"));
     assert!(updated_content.contains("temp/"));
 
-    // Check CCPM section is updated
-    assert!(updated_content.contains("CCPM managed entries"));
-    assert!(updated_content.contains("# End of CCPM managed entries"));
-    assert!(updated_content.contains(".claude/ccpm/snippets/test-snippet.md"));
+    // Check AGPM section is updated
+    assert!(updated_content.contains("AGPM managed entries"));
+    assert!(updated_content.contains("# End of AGPM managed entries"));
+    assert!(updated_content.contains(".claude/agpm/snippets/test-snippet.md"));
 
-    // Check content after CCPM section is preserved
-    assert!(updated_content.contains("# Additional entries after CCPM section"));
+    // Check content after AGPM section is preserved
+    assert!(updated_content.contains("# Additional entries after AGPM section"));
     assert!(updated_content.contains("local-config.json"));
     assert!(updated_content.contains("debug/"));
     assert!(updated_content.contains("# End comment"));
 
-    // Verify old CCPM entry is removed
+    // Verify old AGPM entry is removed
     assert!(!updated_content.contains(".claude/agents/old-agent.md"));
 }
 
 #[tokio::test]
 async fn test_gitignore_update_command() {
-    ccpm::test_utils::init_test_logging(None);
+    agpm::test_utils::init_test_logging(None);
     let temp = TempDir::new().unwrap();
     let project_dir = temp.path();
     let source_dir = temp.path().join("source");
@@ -384,7 +384,7 @@ async fn test_gitignore_update_command() {
     create_test_source_files(&source_dir).await.unwrap();
 
     // Create manifest
-    let manifest_path = project_dir.join("ccpm.toml");
+    let manifest_path = project_dir.join("agpm.toml");
     fs::write(
         &manifest_path,
         create_test_manifest(true, &source_dir).await,
@@ -393,13 +393,13 @@ async fn test_gitignore_update_command() {
     .unwrap();
 
     // Create initial lockfile
-    let lockfile_path = project_dir.join("ccpm.lock");
+    let lockfile_path = project_dir.join("agpm.lock");
     fs::write(&lockfile_path, create_test_lockfile().await)
         .await
         .unwrap();
 
     // Run update command (which should also update gitignore)
-    Command::cargo_bin("ccpm")
+    Command::cargo_bin("agpm")
         .unwrap()
         .arg("update")
         .arg("--quiet")
@@ -410,18 +410,18 @@ async fn test_gitignore_update_command() {
     let gitignore_path = project_dir.join(".gitignore");
     if gitignore_path.exists() {
         let content = fs::read_to_string(&gitignore_path).await.unwrap();
-        assert!(content.contains("CCPM managed entries"));
+        assert!(content.contains("AGPM managed entries"));
     }
 }
 
 #[tokio::test]
 async fn test_gitignore_handles_external_paths() {
-    ccpm::test_utils::init_test_logging(None);
+    agpm::test_utils::init_test_logging(None);
     let temp = TempDir::new().unwrap();
     let project_dir = temp.path();
 
     // Create manifest
-    let manifest_path = project_dir.join("ccpm.toml");
+    let manifest_path = project_dir.join("agpm.toml");
     let manifest_content = r#"
 [sources]
 test-source = "https://github.com/test/repo.git"
@@ -465,7 +465,7 @@ resolved_commit = "abc123"
 checksum = "sha256:test"
 installed_at = ".claude/agents/internal.md"
 "#;
-    let lockfile_path = project_dir.join("ccpm.lock");
+    let lockfile_path = project_dir.join("agpm.lock");
     fs::write(&lockfile_path, lockfile_content).await.unwrap();
 
     // Create directories
@@ -488,7 +488,7 @@ installed_at = ".claude/agents/internal.md"
     .unwrap();
 
     // Run install command
-    Command::cargo_bin("ccpm")
+    Command::cargo_bin("agpm")
         .unwrap()
         .arg("install")
         .arg("--quiet")
@@ -514,7 +514,7 @@ installed_at = ".claude/agents/internal.md"
 
 #[tokio::test]
 async fn test_gitignore_empty_lockfile() {
-    ccpm::test_utils::init_test_logging(None);
+    agpm::test_utils::init_test_logging(None);
     let temp = TempDir::new().unwrap();
     let project_dir = temp.path();
     let source_dir = temp.path().join("source");
@@ -523,7 +523,7 @@ async fn test_gitignore_empty_lockfile() {
     create_test_source_files(&source_dir).await.unwrap();
 
     // Create manifest
-    let manifest_path = project_dir.join("ccpm.toml");
+    let manifest_path = project_dir.join("agpm.toml");
     fs::write(
         &manifest_path,
         create_test_manifest(true, &source_dir).await,
@@ -532,11 +532,11 @@ async fn test_gitignore_empty_lockfile() {
     .unwrap();
 
     // Create empty lockfile
-    let lockfile_path = project_dir.join("ccpm.lock");
+    let lockfile_path = project_dir.join("agpm.lock");
     fs::write(&lockfile_path, "version = 1\n").await.unwrap();
 
     // Run install command
-    Command::cargo_bin("ccpm")
+    Command::cargo_bin("agpm")
         .unwrap()
         .arg("install")
         .arg("--quiet")
@@ -551,13 +551,13 @@ async fn test_gitignore_empty_lockfile() {
     );
 
     let content = fs::read_to_string(&gitignore_path).await.unwrap();
-    assert!(content.contains("CCPM managed entries"));
-    assert!(content.contains("# End of CCPM managed entries"));
+    assert!(content.contains("AGPM managed entries"));
+    assert!(content.contains("# End of AGPM managed entries"));
 }
 
 #[tokio::test]
 async fn test_gitignore_idempotent() {
-    ccpm::test_utils::init_test_logging(None);
+    agpm::test_utils::init_test_logging(None);
     let temp = TempDir::new().unwrap();
     let project_dir = temp.path();
     let source_dir = temp.path().join("source");
@@ -566,7 +566,7 @@ async fn test_gitignore_idempotent() {
     create_test_source_files(&source_dir).await.unwrap();
 
     // Create manifest
-    let manifest_path = project_dir.join("ccpm.toml");
+    let manifest_path = project_dir.join("agpm.toml");
     fs::write(
         &manifest_path,
         create_test_manifest(true, &source_dir).await,
@@ -575,13 +575,13 @@ async fn test_gitignore_idempotent() {
     .unwrap();
 
     // Create lockfile
-    let lockfile_path = project_dir.join("ccpm.lock");
+    let lockfile_path = project_dir.join("agpm.lock");
     fs::write(&lockfile_path, create_test_lockfile().await)
         .await
         .unwrap();
 
     // Run install command
-    Command::cargo_bin("ccpm")
+    Command::cargo_bin("agpm")
         .unwrap()
         .arg("install")
         .arg("--quiet")
@@ -597,7 +597,7 @@ async fn test_gitignore_idempotent() {
     };
 
     // Run again
-    Command::cargo_bin("ccpm")
+    Command::cargo_bin("agpm")
         .unwrap()
         .arg("install")
         .arg("--quiet")
@@ -620,7 +620,7 @@ async fn test_gitignore_idempotent() {
 
 #[tokio::test]
 async fn test_gitignore_switch_enabled_disabled() {
-    ccpm::test_utils::init_test_logging(None);
+    agpm::test_utils::init_test_logging(None);
     let temp = TempDir::new().unwrap();
     let project_dir = temp.path();
     let source_dir = temp.path().join("source");
@@ -629,7 +629,7 @@ async fn test_gitignore_switch_enabled_disabled() {
     create_test_source_files(&source_dir).await.unwrap();
 
     // Start with gitignore enabled
-    let manifest_path = project_dir.join("ccpm.toml");
+    let manifest_path = project_dir.join("agpm.toml");
     fs::write(
         &manifest_path,
         create_test_manifest(true, &source_dir).await,
@@ -637,13 +637,13 @@ async fn test_gitignore_switch_enabled_disabled() {
     .await
     .unwrap();
 
-    let lockfile_path = project_dir.join("ccpm.lock");
+    let lockfile_path = project_dir.join("agpm.lock");
     fs::write(&lockfile_path, create_test_lockfile().await)
         .await
         .unwrap();
 
     // Run install with gitignore enabled
-    Command::cargo_bin("ccpm")
+    Command::cargo_bin("agpm")
         .unwrap()
         .arg("install")
         .arg("--quiet")
@@ -662,7 +662,7 @@ async fn test_gitignore_switch_enabled_disabled() {
     .unwrap();
 
     // Run install again
-    Command::cargo_bin("ccpm")
+    Command::cargo_bin("agpm")
         .unwrap()
         .arg("install")
         .arg("--quiet")
@@ -686,13 +686,13 @@ async fn test_gitignore_switch_enabled_disabled() {
     // Add a user entry to the existing gitignore
     let content = fs::read_to_string(&gitignore_path).await.unwrap();
     let modified_content = content.replace(
-        "# CCPM managed entries",
-        "user-custom.txt\n\n# CCPM managed entries",
+        "# AGPM managed entries",
+        "user-custom.txt\n\n# AGPM managed entries",
     );
     fs::write(&gitignore_path, modified_content).await.unwrap();
 
     // Run install again
-    Command::cargo_bin("ccpm")
+    Command::cargo_bin("agpm")
         .unwrap()
         .arg("install")
         .arg("--quiet")
@@ -709,7 +709,7 @@ async fn test_gitignore_switch_enabled_disabled() {
 
 #[tokio::test]
 async fn test_gitignore_actually_ignored_by_git() {
-    ccpm::test_utils::init_test_logging(None);
+    agpm::test_utils::init_test_logging(None);
 
     let project = TestProject::new().await.unwrap();
     let project_dir = project.project_path().to_path_buf();
@@ -729,14 +729,14 @@ async fn test_gitignore_actually_ignored_by_git() {
         .unwrap();
 
     project
-        .run_ccpm(&["install", "--quiet"])
+        .run_agpm(&["install", "--quiet"])
         .unwrap()
         .assert_success();
 
     assert!(project_dir.join(".claude/agents/test-agent.md").exists());
     assert!(
         project_dir
-            .join(".claude/ccpm/snippets/test-snippet.md")
+            .join(".claude/agpm/snippets/test-snippet.md")
             .exists()
     );
     assert!(
@@ -769,12 +769,12 @@ async fn test_gitignore_actually_ignored_by_git() {
         status
     );
     assert!(
-        status.contains("ccpm.toml"),
+        status.contains("agpm.toml"),
         "Manifest should be tracked by git\nGit status:\n{}",
         status
     );
     assert!(
-        status.contains("ccpm.lock"),
+        status.contains("agpm.lock"),
         "Lockfile should be tracked by git\nGit status:\n{}",
         status
     );
@@ -784,7 +784,7 @@ async fn test_gitignore_actually_ignored_by_git() {
         "Agent file should be ignored by git check-ignore"
     );
     assert!(
-        git.check_ignore(".claude/ccpm/snippets/test-snippet.md")
+        git.check_ignore(".claude/agpm/snippets/test-snippet.md")
             .unwrap(),
         "Snippet file should be ignored by git check-ignore"
     );
@@ -797,7 +797,7 @@ async fn test_gitignore_actually_ignored_by_git() {
 
 #[tokio::test]
 async fn test_gitignore_disabled_files_not_ignored_by_git() {
-    ccpm::test_utils::init_test_logging(None);
+    agpm::test_utils::init_test_logging(None);
 
     let project = TestProject::new().await.unwrap();
     let project_dir = project.project_path().to_path_buf();
@@ -817,14 +817,14 @@ async fn test_gitignore_disabled_files_not_ignored_by_git() {
         .unwrap();
 
     project
-        .run_ccpm(&["install", "--quiet"])
+        .run_agpm(&["install", "--quiet"])
         .unwrap()
         .assert_success();
 
     assert!(project_dir.join(".claude/agents/test-agent.md").exists());
     assert!(
         project_dir
-            .join(".claude/ccpm/snippets/test-snippet.md")
+            .join(".claude/agpm/snippets/test-snippet.md")
             .exists()
     );
     assert!(
@@ -866,7 +866,7 @@ Git status:
 
 #[tokio::test]
 async fn test_gitignore_malformed_existing() {
-    ccpm::test_utils::init_test_logging(None);
+    agpm::test_utils::init_test_logging(None);
     let temp = TempDir::new().unwrap();
     let project_dir = temp.path();
     let source_dir = temp.path().join("source");
@@ -884,14 +884,14 @@ async fn test_gitignore_malformed_existing() {
     let malformed_content = r#"# Some content
 user-file.txt
 
-# CCPM managed entries - do not edit below this line
+# AGPM managed entries - do not edit below this line
 /old/entry.md
 # Missing end marker!
 "#;
     fs::write(&gitignore_path, malformed_content).await.unwrap();
 
     // Create manifest and lockfile
-    let manifest_path = project_dir.join("ccpm.toml");
+    let manifest_path = project_dir.join("agpm.toml");
     fs::write(
         &manifest_path,
         create_test_manifest(true, &source_dir).await,
@@ -899,13 +899,13 @@ user-file.txt
     .await
     .unwrap();
 
-    let lockfile_path = project_dir.join("ccpm.lock");
+    let lockfile_path = project_dir.join("agpm.lock");
     fs::write(&lockfile_path, create_test_lockfile().await)
         .await
         .unwrap();
 
     // Run install command
-    Command::cargo_bin("ccpm")
+    Command::cargo_bin("agpm")
         .unwrap()
         .arg("install")
         .arg("--quiet")
@@ -914,7 +914,7 @@ user-file.txt
 
     // Check that gitignore was properly recreated
     let updated_content = fs::read_to_string(&gitignore_path).await.unwrap();
-    assert!(updated_content.contains("# End of CCPM managed entries"));
+    assert!(updated_content.contains("# End of AGPM managed entries"));
     assert!(updated_content.contains("user-file.txt"));
-    assert!(updated_content.contains("CCPM managed entries"));
+    assert!(updated_content.contains("AGPM managed entries"));
 }

--- a/tests/integration_hooks.rs
+++ b/tests/integration_hooks.rs
@@ -62,7 +62,7 @@ tool-hook = {{ source = "hooks", path = "hooks/pre-tool-use.json" }}
     project.write_manifest(&manifest_content).await?;
 
     // Run install
-    let output = project.run_ccpm(&["install"])?;
+    let output = project.run_agpm(&["install"])?;
     output.assert_success();
     output.assert_stdout_contains("✓ Configured 2 hook(s)");
 
@@ -146,8 +146,8 @@ async fn test_hooks_deduplication() -> Result<()> {
     let session_hook = serde_json::json!({
         "events": ["SessionStart"],
         "type": "command",
-        "command": "ccpm update",
-        "description": "Update CCPM"
+        "command": "agpm update",
+        "description": "Update AGPM"
     });
     fs::write(
         hooks_dir.join("hook1.json"),
@@ -178,7 +178,7 @@ second-hook = {{ source = "hooks", path = "hooks/hook2.json" }}
     project.write_manifest(&manifest_content).await?;
 
     // Run install
-    let output = project.run_ccpm(&["install"])?;
+    let output = project.run_agpm(&["install"])?;
     output.assert_success();
     output.assert_stdout_contains("✓ Configured 1 hook(s)"); // Deduplicated count
 
@@ -202,7 +202,7 @@ second-hook = {{ source = "hooks", path = "hooks/hook2.json" }}
     );
     assert_eq!(
         hook_commands[0].get("command").unwrap().as_str().unwrap(),
-        "ccpm update"
+        "agpm update"
     );
 
     Ok(())
@@ -249,7 +249,7 @@ future-hook = {{ source = "hooks", path = "hooks/future-hook.json" }}
     project.write_manifest(&manifest_content).await?;
 
     // Run install
-    let output = project.run_ccpm(&["install"])?;
+    let output = project.run_agpm(&["install"])?;
     output.assert_success();
     output.assert_stdout_contains("✓ Configured 1 hook(s)");
 
@@ -299,7 +299,7 @@ async fn test_hooks_empty_no_message() -> Result<()> {
     project.write_manifest(manifest_content).await?;
 
     // Run install
-    let output = project.run_ccpm(&["install"])?;
+    let output = project.run_agpm(&["install"])?;
     output.assert_success();
 
     // Should NOT contain any hook configuration message
@@ -363,12 +363,12 @@ session-hook = {{ source = "hooks", path = "hooks/session-start.json" }}
     project.write_manifest(&manifest_content).await?;
 
     // First install - should configure hooks and show message
-    let output1 = project.run_ccpm(&["install"])?;
+    let output1 = project.run_agpm(&["install"])?;
     output1.assert_success();
     output1.assert_stdout_contains("✓ Configured 1 hook(s)");
 
     // Second install with same hooks - should NOT show message (no changes)
-    let output2 = project.run_ccpm(&["install"])?;
+    let output2 = project.run_agpm(&["install"])?;
     output2.assert_success();
     assert!(!output2.stdout.contains("Configured"));
     assert!(!output2.stdout.contains("hook"));

--- a/tests/integration_incremental_add.rs
+++ b/tests/integration_incremental_add.rs
@@ -1,4 +1,4 @@
-//! Integration tests for incremental dependency addition with `ccpm add dep`.
+//! Integration tests for incremental dependency addition with `agpm add dep`.
 //!
 //! These tests verify that transitive dependency relationships are properly maintained
 //! when dependencies are added incrementally to a project manifest.
@@ -28,16 +28,16 @@ local = "{}"
 
 [target]
 agents = ".claude/agents"
-snippets = ".claude/ccpm/snippets"
+snippets = ".claude/agpm/snippets"
 commands = ".claude/commands"
-mcp-servers = ".claude/ccpm/mcp-servers"
-scripts = ".claude/ccpm/scripts"
-hooks = ".claude/ccpm/hooks"
+mcp-servers = ".claude/agpm/mcp-servers"
+scripts = ".claude/agpm/scripts"
+hooks = ".claude/agpm/hooks"
 gitignore = true
 "#,
         resources_dir.display().to_string().replace('\\', "/")
     );
-    fs::write(project_dir.join("ccpm.toml"), manifest_content).await?;
+    fs::write(project_dir.join("agpm.toml"), manifest_content).await?;
 
     // Create command file with transitive dependencies in local source
     let command_content = r#"---
@@ -128,10 +128,10 @@ async fn get_lockfile_dependencies(lockfile_path: &PathBuf, resource_name: &str)
 async fn test_incremental_add_preserves_transitive_dependencies() {
     let temp_dir = setup_test_project().await.unwrap();
     let project_dir = temp_dir.path();
-    let lockfile_path = project_dir.join("ccpm.lock");
+    let lockfile_path = project_dir.join("agpm.lock");
 
     // Step 1: Add command dependency (should discover transitive deps)
-    let mut cmd = Command::cargo_bin("ccpm").unwrap();
+    let mut cmd = Command::cargo_bin("agpm").unwrap();
     cmd.current_dir(project_dir)
         .arg("add")
         .arg("dep")
@@ -160,7 +160,7 @@ async fn test_incremental_add_preserves_transitive_dependencies() {
     );
 
     // Step 2: Add agent dependency explicitly (making it a base dependency)
-    let mut cmd2 = Command::cargo_bin("ccpm").unwrap();
+    let mut cmd2 = Command::cargo_bin("agpm").unwrap();
     cmd2.current_dir(project_dir)
         .arg("add")
         .arg("dep")
@@ -205,10 +205,10 @@ async fn test_incremental_add_preserves_transitive_dependencies() {
 async fn test_incremental_add_chain_of_three_dependencies() {
     let temp_dir = setup_test_project().await.unwrap();
     let project_dir = temp_dir.path();
-    let lockfile_path = project_dir.join("ccpm.lock");
+    let lockfile_path = project_dir.join("agpm.lock");
 
     // Add command (discovers agent and snippet as transitive deps)
-    let mut cmd1 = Command::cargo_bin("ccpm").unwrap();
+    let mut cmd1 = Command::cargo_bin("agpm").unwrap();
     cmd1.current_dir(project_dir)
         .arg("add")
         .arg("dep")
@@ -226,7 +226,7 @@ async fn test_incremental_add_chain_of_three_dependencies() {
     );
 
     // Add agent explicitly (was transitive, now base)
-    let mut cmd2 = Command::cargo_bin("ccpm").unwrap();
+    let mut cmd2 = Command::cargo_bin("agpm").unwrap();
     cmd2.current_dir(project_dir)
         .arg("add")
         .arg("dep")
@@ -250,7 +250,7 @@ async fn test_incremental_add_chain_of_three_dependencies() {
     );
 
     // Add helper-snippet explicitly (was transitive of agent, now base)
-    let mut cmd3 = Command::cargo_bin("ccpm").unwrap();
+    let mut cmd3 = Command::cargo_bin("agpm").unwrap();
     cmd3.current_dir(project_dir)
         .arg("add")
         .arg("dep")
@@ -318,10 +318,10 @@ This command also uses test-snippet.
     .await
     .unwrap();
 
-    let lockfile_path = project_dir.join("ccpm.lock");
+    let lockfile_path = project_dir.join("agpm.lock");
 
     // Add first command
-    Command::cargo_bin("ccpm")
+    Command::cargo_bin("agpm")
         .unwrap()
         .current_dir(project_dir)
         .arg("add")
@@ -334,7 +334,7 @@ This command also uses test-snippet.
         .success();
 
     // Add second command
-    Command::cargo_bin("ccpm")
+    Command::cargo_bin("agpm")
         .unwrap()
         .current_dir(project_dir)
         .arg("add")
@@ -360,7 +360,7 @@ This command also uses test-snippet.
     );
 
     // Now add the shared snippet explicitly
-    Command::cargo_bin("ccpm")
+    Command::cargo_bin("agpm")
         .unwrap()
         .current_dir(project_dir)
         .arg("add")

--- a/tests/integration_list.rs
+++ b/tests/integration_list.rs
@@ -21,13 +21,13 @@ version = 1
 
 [[sources]]
 name = "official"
-url = "https://github.com/example-org/ccpm-official.git"
+url = "https://github.com/example-org/agpm-official.git"
 commit = "abc123456789abcdef123456789abcdef12345678"
 fetched_at = "2024-01-01T00:00:00Z"
 
 [[sources]]
 name = "community"
-url = "https://github.com/example-org/ccpm-community.git"
+url = "https://github.com/example-org/agpm-community.git"
 commit = "def456789abcdef123456789abcdef123456789ab"
 fetched_at = "2024-01-01T00:00:00Z"
 
@@ -213,13 +213,13 @@ version = 1
 
 [[sources]]
 name = "official"
-url = "https://github.com/example-org/ccpm-official.git"
+url = "https://github.com/example-org/agpm-official.git"
 commit = "abc123456789abcdef123456789abcdef12345678"
 fetched_at = "2024-01-01T00:00:00Z"
 
 [[sources]]
 name = "community"
-url = "https://github.com/example-org/ccpm-community.git"
+url = "https://github.com/example-org/agpm-community.git"
 commit = "def456789abcdef123456789abcdef123456789ab"
 fetched_at = "2024-01-01T00:00:00Z"
 
@@ -275,13 +275,13 @@ version = 1
 
 [[sources]]
 name = "official"
-url = "https://github.com/example-org/ccpm-official.git"
+url = "https://github.com/example-org/agpm-official.git"
 commit = "abc123456789abcdef123456789abcdef12345678"
 fetched_at = "2024-01-01T00:00:00Z"
 
 [[sources]]
 name = "community"
-url = "https://github.com/example-org/ccpm-community.git"
+url = "https://github.com/example-org/agpm-community.git"
 commit = "def456789abcdef123456789abcdef123456789ab"
 fetched_at = "2024-01-01T00:00:00Z"
 
@@ -336,13 +336,13 @@ version = 1
 
 [[sources]]
 name = "official"
-url = "https://github.com/example-org/ccpm-official.git"
+url = "https://github.com/example-org/agpm-official.git"
 commit = "abc123456789abcdef123456789abcdef12345678"
 fetched_at = "2024-01-01T00:00:00Z"
 
 [[sources]]
 name = "community"
-url = "https://github.com/example-org/ccpm-community.git"
+url = "https://github.com/example-org/agpm-community.git"
 commit = "def456789abcdef123456789abcdef123456789ab"
 fetched_at = "2024-01-01T00:00:00Z"
 
@@ -397,13 +397,13 @@ version = 1
 
 [[sources]]
 name = "official"
-url = "https://github.com/example-org/ccpm-official.git"
+url = "https://github.com/example-org/agpm-official.git"
 commit = "abc123456789abcdef123456789abcdef12345678"
 fetched_at = "2024-01-01T00:00:00Z"
 
 [[sources]]
 name = "community"
-url = "https://github.com/example-org/ccpm-community.git"
+url = "https://github.com/example-org/agpm-community.git"
 commit = "def456789abcdef123456789abcdef123456789ab"
 fetched_at = "2024-01-01T00:00:00Z"
 
@@ -458,13 +458,13 @@ version = 1
 
 [[sources]]
 name = "official"
-url = "https://github.com/example-org/ccpm-official.git"
+url = "https://github.com/example-org/agpm-official.git"
 commit = "abc123456789abcdef123456789abcdef12345678"
 fetched_at = "2024-01-01T00:00:00Z"
 
 [[sources]]
 name = "community"
-url = "https://github.com/example-org/ccpm-community.git"
+url = "https://github.com/example-org/agpm-community.git"
 commit = "def456789abcdef123456789abcdef123456789ab"
 fetched_at = "2024-01-01T00:00:00Z"
 
@@ -518,13 +518,13 @@ version = 1
 
 [[sources]]
 name = "official"
-url = "https://github.com/example-org/ccpm-official.git"
+url = "https://github.com/example-org/agpm-official.git"
 commit = "abc123456789abcdef123456789abcdef12345678"
 fetched_at = "2024-01-01T00:00:00Z"
 
 [[sources]]
 name = "community"
-url = "https://github.com/example-org/ccpm-community.git"
+url = "https://github.com/example-org/agpm-community.git"
 commit = "def456789abcdef123456789abcdef123456789ab"
 fetched_at = "2024-01-01T00:00:00Z"
 
@@ -579,13 +579,13 @@ version = 1
 
 [[sources]]
 name = "official"
-url = "https://github.com/example-org/ccpm-official.git"
+url = "https://github.com/example-org/agpm-official.git"
 commit = "abc123456789abcdef123456789abcdef12345678"
 fetched_at = "2024-01-01T00:00:00Z"
 
 [[sources]]
 name = "community"
-url = "https://github.com/example-org/ccpm-community.git"
+url = "https://github.com/example-org/agpm-community.git"
 commit = "def456789abcdef123456789abcdef123456789ab"
 fetched_at = "2024-01-01T00:00:00Z"
 
@@ -743,7 +743,7 @@ version = 1
 
 [[sources]]
 name = "official"
-url = "https://github.com/example-org/ccpm-official.git"
+url = "https://github.com/example-org/agpm-official.git"
 commit = "abc123456789abcdef123456789abcdef12345678"
 fetched_at = "2024-01-01T00:00:00Z"
 
@@ -807,7 +807,7 @@ async fn test_list_empty_project() {
 
     // Create minimal manifest with no dependencies
     let minimal_manifest = r#"[sources]
-official = "https://github.com/example-org/ccpm-official.git"
+official = "https://github.com/example-org/agpm-official.git"
 "#;
     project.write_manifest(minimal_manifest).await.unwrap();
 

--- a/tests/integration_list.rs
+++ b/tests/integration_list.rs
@@ -58,11 +58,11 @@ resolved_commit = "abc123456789abcdef123456789abcdef12345678"
 checksum = "sha256:74e6f7298a9c2d168935f58c6b6c5b5ea4c3df6a0b6b8d2e7b2a2b8c3d4e5f6a"
 installed_at = "snippets/utils.md"
 "#;
-    fs::write(project.project_path().join("ccpm.lock"), lockfile_content)
+    fs::write(project.project_path().join("agpm.lock"), lockfile_content)
         .await
         .unwrap();
 
-    let output = project.run_ccpm(&["list"]).unwrap();
+    let output = project.run_agpm(&["list"]).unwrap();
     output
         .assert_success()
         .assert_stdout_contains("my-agent")
@@ -77,11 +77,11 @@ async fn test_list_no_lockfile() {
     let manifest_content = ManifestFixture::basic().content;
     project.write_manifest(&manifest_content).await.unwrap();
 
-    let output = project.run_ccpm(&["list"]).unwrap();
+    let output = project.run_agpm(&["list"]).unwrap();
     output.assert_success();
     assert!(
         output.stdout.contains("No installed resources")
-            || output.stdout.contains("ccpm.lock not found"),
+            || output.stdout.contains("agpm.lock not found"),
         "Expected no resources message, got: {}",
         output.stdout
     );
@@ -92,10 +92,10 @@ async fn test_list_no_lockfile() {
 async fn test_list_without_project() {
     let project = TestProject::new().await.unwrap();
 
-    let output = project.run_ccpm(&["list"]).unwrap();
+    let output = project.run_agpm(&["list"]).unwrap();
     assert!(!output.success, "Expected command to fail but it succeeded");
     assert!(
-        output.stderr.contains("ccpm.toml not found"),
+        output.stderr.contains("agpm.toml not found"),
         "Expected manifest not found error, got: {}",
         output.stderr
     );
@@ -121,11 +121,11 @@ resolved_commit = "abc123456789abcdef123456789abcdef12345678"
 checksum = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 installed_at = "agents/my-agent.md"
 "#;
-    fs::write(project.project_path().join("ccpm.lock"), lockfile_content)
+    fs::write(project.project_path().join("agpm.lock"), lockfile_content)
         .await
         .unwrap();
 
-    let output = project.run_ccpm(&["list", "--format", "table"]).unwrap();
+    let output = project.run_agpm(&["list", "--format", "table"]).unwrap();
     output
         .assert_success()
         .assert_stdout_contains("Name")
@@ -155,11 +155,11 @@ resolved_commit = "abc123456789abcdef123456789abcdef12345678"
 checksum = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 installed_at = "agents/my-agent.md"
 "#;
-    fs::write(project.project_path().join("ccpm.lock"), lockfile_content)
+    fs::write(project.project_path().join("agpm.lock"), lockfile_content)
         .await
         .unwrap();
 
-    let output = project.run_ccpm(&["list", "--format", "json"]).unwrap();
+    let output = project.run_agpm(&["list", "--format", "json"]).unwrap();
     assert!(output.success);
     assert!(output.stdout.contains("{"));
     assert!(output.stdout.contains("\"name\""));
@@ -188,11 +188,11 @@ resolved_commit = "abc123456789abcdef123456789abcdef12345678"
 checksum = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 installed_at = "agents/my-agent.md"
 "#;
-    fs::write(project.project_path().join("ccpm.lock"), lockfile_content)
+    fs::write(project.project_path().join("agpm.lock"), lockfile_content)
         .await
         .unwrap();
 
-    let output = project.run_ccpm(&["list", "--format", "yaml"]).unwrap();
+    let output = project.run_agpm(&["list", "--format", "yaml"]).unwrap();
     assert!(output.success);
     assert!(output.stdout.contains("name:"));
     assert!(output.stdout.contains("version:"));
@@ -250,11 +250,11 @@ resolved_commit = "abc123456789abcdef123456789abcdef12345678"
 checksum = "sha256:74e6f7298a9c2d168935f58c6b6c5b5ea4c3df6a0b6b8d2e7b2a2b8c3d4e5f6a"
 installed_at = "snippets/utils.md"
 "#;
-    fs::write(project.project_path().join("ccpm.lock"), lockfile_content)
+    fs::write(project.project_path().join("agpm.lock"), lockfile_content)
         .await
         .unwrap();
 
-    let output = project.run_ccpm(&["list", "--format", "compact"]).unwrap();
+    let output = project.run_agpm(&["list", "--format", "compact"]).unwrap();
     output
         .assert_success()
         .assert_stdout_contains("my-agent")
@@ -312,11 +312,11 @@ resolved_commit = "abc123456789abcdef123456789abcdef12345678"
 checksum = "sha256:74e6f7298a9c2d168935f58c6b6c5b5ea4c3df6a0b6b8d2e7b2a2b8c3d4e5f6a"
 installed_at = "snippets/utils.md"
 "#;
-    fs::write(project.project_path().join("ccpm.lock"), lockfile_content)
+    fs::write(project.project_path().join("agpm.lock"), lockfile_content)
         .await
         .unwrap();
 
-    let output = project.run_ccpm(&["list", "--type", "agents"]).unwrap();
+    let output = project.run_agpm(&["list", "--type", "agents"]).unwrap();
     assert!(output.success);
     assert!(output.stdout.contains("my-agent"));
     assert!(output.stdout.contains("helper"));
@@ -373,11 +373,11 @@ resolved_commit = "abc123456789abcdef123456789abcdef12345678"
 checksum = "sha256:74e6f7298a9c2d168935f58c6b6c5b5ea4c3df6a0b6b8d2e7b2a2b8c3d4e5f6a"
 installed_at = "snippets/utils.md"
 "#;
-    fs::write(project.project_path().join("ccpm.lock"), lockfile_content)
+    fs::write(project.project_path().join("agpm.lock"), lockfile_content)
         .await
         .unwrap();
 
-    let output = project.run_ccpm(&["list", "--type", "snippets"]).unwrap();
+    let output = project.run_agpm(&["list", "--type", "snippets"]).unwrap();
     assert!(output.success);
     assert!(output.stdout.contains("utils"));
     assert!(!output.stdout.contains("my-agent")); // my-agent is an agent
@@ -434,11 +434,11 @@ resolved_commit = "abc123456789abcdef123456789abcdef12345678"
 checksum = "sha256:74e6f7298a9c2d168935f58c6b6c5b5ea4c3df6a0b6b8d2e7b2a2b8c3d4e5f6a"
 installed_at = "snippets/utils.md"
 "#;
-    fs::write(project.project_path().join("ccpm.lock"), lockfile_content)
+    fs::write(project.project_path().join("agpm.lock"), lockfile_content)
         .await
         .unwrap();
 
-    let output = project.run_ccpm(&["list", "--source", "official"]).unwrap();
+    let output = project.run_agpm(&["list", "--source", "official"]).unwrap();
     assert!(output.success);
     assert!(output.stdout.contains("my-agent"));
     assert!(output.stdout.contains("utils"));
@@ -495,11 +495,11 @@ resolved_commit = "abc123456789abcdef123456789abcdef12345678"
 checksum = "sha256:74e6f7298a9c2d168935f58c6b6c5b5ea4c3df6a0b6b8d2e7b2a2b8c3d4e5f6a"
 installed_at = "snippets/utils.md"
 "#;
-    fs::write(project.project_path().join("ccpm.lock"), lockfile_content)
+    fs::write(project.project_path().join("agpm.lock"), lockfile_content)
         .await
         .unwrap();
 
-    let output = project.run_ccpm(&["list", "--search", "agent"]).unwrap();
+    let output = project.run_agpm(&["list", "--search", "agent"]).unwrap();
     assert!(output.success);
     assert!(output.stdout.contains("my-agent"));
     assert!(!output.stdout.contains("utils"));
@@ -555,11 +555,11 @@ resolved_commit = "abc123456789abcdef123456789abcdef12345678"
 checksum = "sha256:74e6f7298a9c2d168935f58c6b6c5b5ea4c3df6a0b6b8d2e7b2a2b8c3d4e5f6a"
 installed_at = "snippets/utils.md"
 "#;
-    fs::write(project.project_path().join("ccpm.lock"), lockfile_content)
+    fs::write(project.project_path().join("agpm.lock"), lockfile_content)
         .await
         .unwrap();
 
-    let output = project.run_ccpm(&["list", "--detailed"]).unwrap();
+    let output = project.run_agpm(&["list", "--detailed"]).unwrap();
     assert!(output.success);
     assert!(output.stdout.contains("my-agent"));
     assert!(output.stdout.contains("Path:") || output.stdout.contains("agents/my-agent.md"));
@@ -616,7 +616,7 @@ resolved_commit = "abc123456789abcdef123456789abcdef12345678"
 checksum = "sha256:74e6f7298a9c2d168935f58c6b6c5b5ea4c3df6a0b6b8d2e7b2a2b8c3d4e5f6a"
 installed_at = "snippets/utils.md"
 "#;
-    fs::write(project.project_path().join("ccpm.lock"), lockfile_content)
+    fs::write(project.project_path().join("agpm.lock"), lockfile_content)
         .await
         .unwrap();
 
@@ -636,7 +636,7 @@ installed_at = "snippets/utils.md"
         .await
         .unwrap();
 
-    let output = project.run_ccpm(&["list", "--files"]).unwrap();
+    let output = project.run_agpm(&["list", "--files"]).unwrap();
     assert!(output.success);
     assert!(output.stdout.contains("agents/my-agent.md") || output.stdout.contains("my-agent"));
     assert!(output.stdout.contains("agents/helper.md") || output.stdout.contains("helper"));
@@ -663,11 +663,11 @@ resolved_commit = "abc123456789abcdef123456789abcdef12345678"
 checksum = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 installed_at = "agents/my-agent.md"
 "#;
-    fs::write(project.project_path().join("ccpm.lock"), lockfile_content)
+    fs::write(project.project_path().join("agpm.lock"), lockfile_content)
         .await
         .unwrap();
 
-    let output = project.run_ccpm(&["list", "--sort", "name"]).unwrap();
+    let output = project.run_agpm(&["list", "--sort", "name"]).unwrap();
     assert!(output.success);
     assert!(output.stdout.contains("my-agent"));
 }
@@ -692,11 +692,11 @@ resolved_commit = "abc123456789abcdef123456789abcdef12345678"
 checksum = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 installed_at = "agents/my-agent.md"
 "#;
-    fs::write(project.project_path().join("ccpm.lock"), lockfile_content)
+    fs::write(project.project_path().join("agpm.lock"), lockfile_content)
         .await
         .unwrap();
 
-    let output = project.run_ccpm(&["list", "--sort", "version"]).unwrap();
+    let output = project.run_agpm(&["list", "--sort", "version"]).unwrap();
     assert!(output.success);
     assert!(output.stdout.contains("my-agent"));
 }
@@ -721,11 +721,11 @@ resolved_commit = "abc123456789abcdef123456789abcdef12345678"
 checksum = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 installed_at = "agents/my-agent.md"
 "#;
-    fs::write(project.project_path().join("ccpm.lock"), lockfile_content)
+    fs::write(project.project_path().join("agpm.lock"), lockfile_content)
         .await
         .unwrap();
 
-    let output = project.run_ccpm(&["list", "--sort", "source"]).unwrap();
+    let output = project.run_agpm(&["list", "--sort", "source"]).unwrap();
     assert!(output.success);
     assert!(output.stdout.contains("my-agent"));
 }
@@ -770,11 +770,11 @@ version = "local"
 checksum = "sha256:local987654321fedcba987654321fedcba987654321fedcba"
 installed_at = "snippets/local-utils.md"
 "#;
-    fs::write(project.project_path().join("ccpm.lock"), lockfile_content)
+    fs::write(project.project_path().join("agpm.lock"), lockfile_content)
         .await
         .unwrap();
 
-    let output = project.run_ccpm(&["list"]).unwrap();
+    let output = project.run_agpm(&["list"]).unwrap();
     assert!(output.success);
     assert!(output.stdout.contains("local-agent"));
     assert!(output.stdout.contains("local-utils"));
@@ -784,7 +784,7 @@ installed_at = "snippets/local-utils.md"
 /// Test list help command
 #[tokio::test]
 async fn test_list_help() {
-    let mut cmd = assert_cmd::Command::cargo_bin("ccpm").unwrap();
+    let mut cmd = assert_cmd::Command::cargo_bin("agpm").unwrap();
     cmd.arg("list")
         .arg("--help")
         .assert()
@@ -815,11 +815,11 @@ official = "https://github.com/example-org/ccpm-official.git"
     let empty_lockfile = r#"# Auto-generated lockfile - DO NOT EDIT
 version = 1
 "#;
-    fs::write(project.project_path().join("ccpm.lock"), empty_lockfile)
+    fs::write(project.project_path().join("agpm.lock"), empty_lockfile)
         .await
         .unwrap();
 
-    let output = project.run_ccpm(&["list"]).unwrap();
+    let output = project.run_agpm(&["list"]).unwrap();
     assert!(output.success);
     assert!(
         output.stdout.contains("No installed resources") || output.stdout.contains("Empty project"),
@@ -837,13 +837,13 @@ async fn test_list_corrupted_lockfile() {
 
     // Create corrupted lockfile
     fs::write(
-        project.project_path().join("ccpm.lock"),
+        project.project_path().join("agpm.lock"),
         "corrupted content",
     )
     .await
     .unwrap();
 
-    let output = project.run_ccpm(&["list"]).unwrap();
+    let output = project.run_agpm(&["list"]).unwrap();
     assert!(!output.success);
     assert!(
         output.stderr.contains("Invalid lockfile syntax")
@@ -873,11 +873,11 @@ resolved_commit = "abc123456789abcdef123456789abcdef12345678"
 checksum = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 installed_at = "agents/my-agent.md"
 "#;
-    fs::write(project.project_path().join("ccpm.lock"), lockfile_content)
+    fs::write(project.project_path().join("agpm.lock"), lockfile_content)
         .await
         .unwrap();
 
-    let output = project.run_ccpm(&["list", "--format", "invalid"]).unwrap();
+    let output = project.run_agpm(&["list", "--format", "invalid"]).unwrap();
     assert!(!output.success);
     assert!(output.stderr.contains("Invalid format") || output.stderr.contains("invalid"));
 }

--- a/tests/integration_lockfile_staleness.rs
+++ b/tests/integration_lockfile_staleness.rs
@@ -35,7 +35,7 @@ agent-two = {{ source = "test-source", path = "agents/agent-two.md", version = "
     project.write_manifest(&manifest).await?;
 
     // Install first to create lockfile
-    let output = project.run_ccpm(&["install", "--quiet"])?;
+    let output = project.run_agpm(&["install", "--quiet"])?;
     assert!(output.success, "Initial install failed: {}", output.stderr);
 
     // Now remove one agent from lockfile to simulate staleness
@@ -59,7 +59,7 @@ agent-two = {{ source = "test-source", path = "agents/agent-two.md", version = "
     }
 
     // Install should auto-update the lockfile (Cargo-style behavior)
-    let output = project.run_ccpm(&["install", "--quiet"])?;
+    let output = project.run_agpm(&["install", "--quiet"])?;
     assert!(
         output.success,
         "Install should auto-update lockfile: {}",
@@ -108,7 +108,7 @@ test-agent = {{ source = "test-source", path = "agents/test-agent.md", version =
     project.write_manifest(&manifest).await?;
 
     // Install v1.0.0
-    let output = project.run_ccpm(&["install", "--quiet"])?;
+    let output = project.run_agpm(&["install", "--quiet"])?;
     assert!(output.success, "Initial install failed: {}", output.stderr);
 
     // Update manifest to v2.0.0
@@ -116,7 +116,7 @@ test-agent = {{ source = "test-source", path = "agents/test-agent.md", version =
     project.write_manifest(&manifest_v2).await?;
 
     // Normal install should auto-update (Cargo-style)
-    let output = project.run_ccpm(&["install", "--quiet"])?;
+    let output = project.run_agpm(&["install", "--quiet"])?;
     assert!(
         output.success,
         "Normal install should auto-update: {}",
@@ -125,7 +125,7 @@ test-agent = {{ source = "test-source", path = "agents/test-agent.md", version =
 
     // Revert to v1.0.0 lockfile
     project.write_manifest(&manifest).await?;
-    let output = project.run_ccpm(&["install", "--quiet"])?;
+    let output = project.run_agpm(&["install", "--quiet"])?;
     assert!(output.success);
 
     // Change manifest back to v2.0.0
@@ -133,7 +133,7 @@ test-agent = {{ source = "test-source", path = "agents/test-agent.md", version =
 
     // --frozen mode should succeed (only checks corruption/security, not version changes)
     // It will use the lockfile as-is with v1.0.0 even though manifest has v2.0.0
-    let output = project.run_ccpm(&["install", "--frozen"])?;
+    let output = project.run_agpm(&["install", "--frozen"])?;
     assert!(
         output.success,
         "Frozen install should succeed (ignores version changes): {}",
@@ -173,7 +173,7 @@ agent-two = {{ source = "test-source", path = "agents/agent-two.md", version = "
     project.write_manifest(&manifest_two_agents).await?;
 
     // Install both agents
-    let output = project.run_ccpm(&["install", "--quiet"])?;
+    let output = project.run_agpm(&["install", "--quiet"])?;
     assert!(output.success, "Initial install failed: {}", output.stderr);
 
     // Remove agent-two from manifest (simulating it becoming only a transitive dependency)
@@ -190,7 +190,7 @@ agent-one = {{ source = "test-source", path = "agents/agent-one.md", version = "
 
     // Try to install with lockfile containing extra entry in CI mode
     // This should succeed now - extra entries are allowed for transitive dependencies
-    let output = project.run_ccpm_with_env(&["install"], &[("CI", "true")])?;
+    let output = project.run_agpm_with_env(&["install"], &[("CI", "true")])?;
     assert!(
         output.success,
         "Install should succeed with extra lockfile entries for transitive deps: {}",
@@ -233,7 +233,7 @@ test-agent = {{ source = "test-source", path = "agents/old-path.md", version = "
     project.write_manifest(&manifest_old).await?;
 
     // Install with old path
-    let output = project.run_ccpm(&["install", "--quiet"])?;
+    let output = project.run_agpm(&["install", "--quiet"])?;
     assert!(output.success, "Initial install failed: {}", output.stderr);
 
     // Update manifest to new path
@@ -241,7 +241,7 @@ test-agent = {{ source = "test-source", path = "agents/old-path.md", version = "
     project.write_manifest(&manifest_new).await?;
 
     // Normal install should auto-update
-    let output = project.run_ccpm(&["install", "--quiet"])?;
+    let output = project.run_agpm(&["install", "--quiet"])?;
     assert!(
         output.success,
         "Normal install should auto-update path change: {}",
@@ -250,14 +250,14 @@ test-agent = {{ source = "test-source", path = "agents/old-path.md", version = "
 
     // Revert to old path and reinstall
     project.write_manifest(&manifest_old).await?;
-    let output = project.run_ccpm(&["install", "--quiet"])?;
+    let output = project.run_agpm(&["install", "--quiet"])?;
     assert!(output.success);
 
     // Change back to new path
     project.write_manifest(&manifest_new).await?;
 
     // --frozen mode should fail
-    let output = project.run_ccpm(&["install", "--frozen"])?;
+    let output = project.run_agpm(&["install", "--frozen"])?;
     assert!(
         output.success,
         "Frozen mode should succeed (ignores path changes): {}",
@@ -300,7 +300,7 @@ test-agent = {{ source = "test-source", path = "agents/test-agent.md", version =
     project.write_manifest(&manifest_old).await?;
 
     // Install from old repo
-    let output = project.run_ccpm(&["install", "--quiet"])?;
+    let output = project.run_agpm(&["install", "--quiet"])?;
     assert!(output.success, "Initial install failed: {}", output.stderr);
 
     // Update manifest to point to new repo
@@ -316,7 +316,7 @@ test-agent = {{ source = "test-source", path = "agents/test-agent.md", version =
     project.write_manifest(&manifest_new).await?;
 
     // --frozen mode should fail on source URL change (security concern)
-    let output = project.run_ccpm(&["install", "--frozen"])?;
+    let output = project.run_agpm(&["install", "--frozen"])?;
     assert!(
         !output.success,
         "Should fail on source URL change (security)"
@@ -361,7 +361,7 @@ test-agent = {{ source = "test-source", path = "agents/test-agent.md", version =
     project.write_manifest(&manifest).await?;
 
     // First do a normal install to create a valid lockfile
-    let output = project.run_ccpm(&["install", "--quiet"])?;
+    let output = project.run_agpm(&["install", "--quiet"])?;
     assert!(output.success, "Initial install failed: {}", output.stderr);
 
     // Read the valid lockfile and manually duplicate an entry
@@ -386,7 +386,7 @@ test-agent = {{ source = "test-source", path = "agents/test-agent.md", version =
     }
 
     // --frozen mode should fail on corrupted lockfile
-    let output = project.run_ccpm(&["install", "--frozen"])?;
+    let output = project.run_agpm(&["install", "--frozen"])?;
     assert!(
         !output.success,
         "Expected failure due to duplicate entries, but command succeeded"
@@ -434,12 +434,12 @@ test-agent = {{ source = "test-source", path = "agents/test-agent.md", version =
     project.write_manifest(&manifest).await?;
 
     // Install to create lockfile
-    let output = project.run_ccpm(&["install", "--quiet"])?;
+    let output = project.run_agpm(&["install", "--quiet"])?;
     assert!(output.success, "Initial install failed: {}", output.stderr);
 
     // Try to install again - should succeed because branches are allowed to move
     // This is expected behavior with auto-update
-    let output = project.run_ccpm(&["install", "--quiet"])?;
+    let output = project.run_agpm(&["install", "--quiet"])?;
     assert!(
         output.success,
         "Install should succeed with branch references, got error: {}",

--- a/tests/integration_max_parallel_flag.rs
+++ b/tests/integration_max_parallel_flag.rs
@@ -51,7 +51,7 @@ agent3 = {{ source = "official", path = "agents/test-agent-3.md", version = "v1.
     // Test different --max-parallel values
     for max_parallel in [1, 2, 4, 8] {
         let output = project
-            .run_ccpm(&["install", "--max-parallel", &max_parallel.to_string()])
+            .run_agpm(&["install", "--max-parallel", &max_parallel.to_string()])
             .unwrap();
         assert!(
             output.success,
@@ -92,19 +92,19 @@ async fn test_max_parallel_invalid_values() {
 
     // Test zero value
     let output = project
-        .run_ccpm(&["install", "--max-parallel", "0"])
+        .run_agpm(&["install", "--max-parallel", "0"])
         .unwrap();
     assert!(!output.success);
 
     // Test negative value
     let output = project
-        .run_ccpm(&["install", "--max-parallel", "-1"])
+        .run_agpm(&["install", "--max-parallel", "-1"])
         .unwrap();
     assert!(!output.success);
 
     // Test non-numeric value
     let output = project
-        .run_ccpm(&["install", "--max-parallel", "abc"])
+        .run_agpm(&["install", "--max-parallel", "abc"])
         .unwrap();
     assert!(!output.success);
 }
@@ -137,7 +137,7 @@ agent = {{ source = "official", path = "agents/test-agent.md", version = "v1.0.0
     project.write_manifest(&manifest_content).await.unwrap();
 
     // Install without --max-parallel flag (should use default)
-    let output = project.run_ccpm(&["install"]).unwrap();
+    let output = project.run_agpm(&["install"]).unwrap();
     assert!(output.success);
     assert!(output.stdout.contains("Installing") || output.stdout.contains("Installed"));
 
@@ -179,19 +179,19 @@ agent = {{ source = "official", path = "agents/test-agent.md", version = "v1.0.0
 
     // Install with --max-parallel should work
     let output = project
-        .run_ccpm(&["install", "--max-parallel", "2"])
+        .run_agpm(&["install", "--max-parallel", "2"])
         .unwrap();
     assert!(output.success);
 
     // Update command should work without --max-parallel
-    let output = project.run_ccpm(&["update"]).unwrap();
+    let output = project.run_agpm(&["update"]).unwrap();
     assert!(output.success);
 }
 
 /// Test --max-parallel in help output for install command
 #[tokio::test]
 async fn test_max_parallel_help_coverage() {
-    let mut cmd = Command::cargo_bin("ccpm").unwrap();
+    let mut cmd = Command::cargo_bin("agpm").unwrap();
     cmd.arg("install")
         .arg("--help")
         .assert()

--- a/tests/integration_multi_resource.rs
+++ b/tests/integration_multi_resource.rs
@@ -11,7 +11,7 @@ use common::TestProject;
 #[tokio::test]
 async fn test_install_multiple_resources_with_versions() -> Result<()> {
     // Initialize test logging
-    ccpm::test_utils::init_test_logging(None);
+    agpm::test_utils::init_test_logging(None);
 
     let project = TestProject::new().await?;
 
@@ -113,10 +113,10 @@ redis = {{ source = "test_repo", path = "mcp-servers/redis.json", version = "v4.
 
     // Log the manifest content and working directory for debugging
     debug!("Generated manifest content:\n{}", manifest_content);
-    debug!("Running ccpm from directory: {:?}", project.project_path());
+    debug!("Running agpm from directory: {:?}", project.project_path());
 
     // Run install
-    let output = project.run_ccpm(&["install"])?;
+    let output = project.run_agpm(&["install"])?;
     output.assert_success();
 
     // Verify all 20 resources are installed with correct versions
@@ -149,28 +149,28 @@ redis = {{ source = "test_repo", path = "mcp-servers/redis.json", version = "v4.
     verify_file_contains(
         &project
             .project_path()
-            .join(".claude/ccpm/snippets/snippet1.md"),
+            .join(".claude/agpm/snippets/snippet1.md"),
         "Snippet 1 v1.0.0",
     )
     .await?;
     verify_file_contains(
         &project
             .project_path()
-            .join(".claude/ccpm/snippets/snippet2.md"),
+            .join(".claude/agpm/snippets/snippet2.md"),
         "Snippet 2 v1.1.0",
     )
     .await?;
     verify_file_contains(
         &project
             .project_path()
-            .join(".claude/ccpm/snippets/snippet3.md"),
+            .join(".claude/agpm/snippets/snippet3.md"),
         "Snippet 3 v3.0.0",
     )
     .await?;
     verify_file_contains(
         &project
             .project_path()
-            .join(".claude/ccpm/snippets/snippet4.md"),
+            .join(".claude/agpm/snippets/snippet4.md"),
         "Snippet 4 v4.0.0",
     )
     .await?;
@@ -201,19 +201,19 @@ redis = {{ source = "test_repo", path = "mcp-servers/redis.json", version = "v4.
     // Check scripts (3 resources)
     // Files use basename from path, not dependency name
     verify_file_contains(
-        &project.project_path().join(".claude/ccpm/scripts/build.sh"),
+        &project.project_path().join(".claude/agpm/scripts/build.sh"),
         "Build Script v1.2.0",
     )
     .await?;
     verify_file_contains(
-        &project.project_path().join(".claude/ccpm/scripts/test.js"),
+        &project.project_path().join(".claude/agpm/scripts/test.js"),
         "Test Script v2.2.0",
     )
     .await?;
     verify_file_contains(
         &project
             .project_path()
-            .join(".claude/ccpm/scripts/deploy.py"),
+            .join(".claude/agpm/scripts/deploy.py"),
         "Deploy Script v3.0.0",
     )
     .await?;
@@ -222,14 +222,14 @@ redis = {{ source = "test_repo", path = "mcp-servers/redis.json", version = "v4.
     verify_file_contains(
         &project
             .project_path()
-            .join(".claude/ccpm/hooks/pre-commit.json"),
+            .join(".claude/agpm/hooks/pre-commit.json"),
         "Pre-commit hook v2.1.0",
     )
     .await?;
     verify_file_contains(
         &project
             .project_path()
-            .join(".claude/ccpm/hooks/post-commit.json"),
+            .join(".claude/agpm/hooks/post-commit.json"),
         "Post-commit hook v3.1.0",
     )
     .await?;
@@ -238,28 +238,28 @@ redis = {{ source = "test_repo", path = "mcp-servers/redis.json", version = "v4.
     verify_file_contains(
         &project
             .project_path()
-            .join(".claude/ccpm/mcp-servers/filesystem.json"),
+            .join(".claude/agpm/mcp-servers/filesystem.json"),
         "\"version\": \"v2.2.0\"",
     )
     .await?;
     verify_file_contains(
         &project
             .project_path()
-            .join(".claude/ccpm/mcp-servers/postgres.json"),
+            .join(".claude/agpm/mcp-servers/postgres.json"),
         "\"version\": \"v3.0.0\"",
     )
     .await?;
     verify_file_contains(
         &project
             .project_path()
-            .join(".claude/ccpm/mcp-servers/redis.json"),
+            .join(".claude/agpm/mcp-servers/redis.json"),
         "\"version\": \"v4.0.0\"",
     )
     .await?;
 
     // Verify lockfile was created
-    assert!(project.project_path().join("ccpm.lock").exists());
-    let lockfile = fs::read_to_string(project.project_path().join("ccpm.lock")).await?;
+    assert!(project.project_path().join("agpm.lock").exists());
+    let lockfile = fs::read_to_string(project.project_path().join("agpm.lock")).await?;
 
     // Check that lockfile contains all 20 resources
     assert!(lockfile.contains("[[agents]]"));
@@ -549,7 +549,7 @@ fn update_breaking_v4(repo_dir: &Path) -> Result<()> {
 #[tokio::test]
 async fn test_install_with_version_conflicts() -> Result<()> {
     // Initialize test logging
-    ccpm::test_utils::init_test_logging(None);
+    agpm::test_utils::init_test_logging(None);
 
     let project = TestProject::new().await?;
 
@@ -605,17 +605,17 @@ agent-dependent = {{ source = "conflict_repo", path = "agents/dependent.md", ver
         repo_url
     );
 
-    fs::write(project.project_path().join("ccpm.toml"), &manifest_content).await?;
+    fs::write(project.project_path().join("agpm.toml"), &manifest_content).await?;
 
     // Log the manifest content and working directory for debugging
     debug!(
         "Generated manifest content for version conflict test:\n{}",
         manifest_content
     );
-    debug!("Running ccpm from directory: {:?}", project.project_path());
+    debug!("Running agpm from directory: {:?}", project.project_path());
 
     // Install should succeed but we can check for warnings in future versions
-    let output = project.run_ccpm(&["install"])?;
+    let output = project.run_agpm(&["install"])?;
     output.assert_success();
 
     // Verify both are installed with their specified versions
@@ -623,11 +623,11 @@ agent-dependent = {{ source = "conflict_repo", path = "agents/dependent.md", ver
     assert!(
         project
             .project_path()
-            .join(".claude/ccpm/snippets/base.md")
+            .join(".claude/agpm/snippets/base.md")
             .exists()
     );
     let snippet_content =
-        fs::read_to_string(project.project_path().join(".claude/ccpm/snippets/base.md")).await?;
+        fs::read_to_string(project.project_path().join(".claude/agpm/snippets/base.md")).await?;
     assert!(snippet_content.contains("v2.0.0"));
 
     assert!(

--- a/tests/integration_outdated.rs
+++ b/tests/integration_outdated.rs
@@ -20,7 +20,7 @@ version = 1
 
 [[sources]]
 name = "official"
-url = "https://github.com/example-org/ccpm-official.git"
+url = "https://github.com/example-org/agpm-official.git"
 commit = "abc123456789abcdef123456789abcdef12345678"
 fetched_at = "2024-01-01T00:00:00Z"
 
@@ -52,7 +52,7 @@ async fn test_outdated_with_updates_available() {
 
     // Create manifest with version constraints
     let manifest_content = r#"[sources]
-official = "https://github.com/example-org/ccpm-official.git"
+official = "https://github.com/example-org/agpm-official.git"
 
 [agents]
 my-agent = { source = "official", path = "agents/my-agent.md", version = "^1.0.0" }
@@ -65,7 +65,7 @@ version = 1
 
 [[sources]]
 name = "official"
-url = "https://github.com/example-org/ccpm-official.git"
+url = "https://github.com/example-org/agpm-official.git"
 commit = "abc123456789abcdef123456789abcdef12345678"
 fetched_at = "2024-01-01T00:00:00Z"
 
@@ -133,7 +133,7 @@ version = 1
 
 [[sources]]
 name = "official"
-url = "https://github.com/example-org/ccpm-official.git"
+url = "https://github.com/example-org/agpm-official.git"
 commit = "abc123456789abcdef123456789abcdef12345678"
 fetched_at = "2024-01-01T00:00:00Z"
 
@@ -185,7 +185,7 @@ version = 1
 
 [[sources]]
 name = "official"
-url = "https://github.com/example-org/ccpm-official.git"
+url = "https://github.com/example-org/agpm-official.git"
 commit = "abc123456789abcdef123456789abcdef12345678"
 fetched_at = "2024-01-01T00:00:00Z"
 
@@ -219,7 +219,7 @@ async fn test_outdated_specific_dependencies() {
 
     // Create manifest with multiple dependencies
     let manifest_content = r#"[sources]
-official = "https://github.com/example-org/ccpm-official.git"
+official = "https://github.com/example-org/agpm-official.git"
 
 [agents]
 my-agent = { source = "official", path = "agents/my-agent.md", version = "^1.0.0" }
@@ -233,7 +233,7 @@ version = 1
 
 [[sources]]
 name = "official"
-url = "https://github.com/example-org/ccpm-official.git"
+url = "https://github.com/example-org/agpm-official.git"
 commit = "abc123456789abcdef123456789abcdef12345678"
 fetched_at = "2024-01-01T00:00:00Z"
 

--- a/tests/integration_outdated.rs
+++ b/tests/integration_outdated.rs
@@ -34,12 +34,12 @@ checksum = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b
 installed_at = "agents/my-agent.md"
 resource_type = "agent"
 "#;
-    fs::write(project.project_path().join("ccpm.lock"), lockfile_content)
+    fs::write(project.project_path().join("agpm.lock"), lockfile_content)
         .await
         .unwrap();
 
     // Run outdated command
-    let output = project.run_ccpm(&["outdated", "--no-fetch"]).unwrap();
+    let output = project.run_agpm(&["outdated", "--no-fetch"]).unwrap();
     output
         .assert_success()
         .assert_stdout_contains("All dependencies are up to date!");
@@ -79,7 +79,7 @@ checksum = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b
 installed_at = "agents/my-agent.md"
 resource_type = "agent"
 "#;
-    fs::write(project.project_path().join("ccpm.lock"), lockfile_content)
+    fs::write(project.project_path().join("agpm.lock"), lockfile_content)
         .await
         .unwrap();
 
@@ -95,10 +95,10 @@ async fn test_outdated_no_lockfile() {
     let manifest_content = ManifestFixture::basic().content;
     project.write_manifest(&manifest_content).await.unwrap();
 
-    let output = project.run_ccpm(&["outdated"]).unwrap();
+    let output = project.run_agpm(&["outdated"]).unwrap();
     assert!(!output.success, "Expected command to fail without lockfile");
     assert!(
-        output.stderr.contains("ccpm.lock") || output.stderr.contains("Run 'ccpm install' first"),
+        output.stderr.contains("agpm.lock") || output.stderr.contains("Run 'agpm install' first"),
         "Expected lockfile error message, got: {}",
         output.stderr
     );
@@ -109,10 +109,10 @@ async fn test_outdated_no_lockfile() {
 async fn test_outdated_without_project() {
     let project = TestProject::new().await.unwrap();
 
-    let output = project.run_ccpm(&["outdated"]).unwrap();
+    let output = project.run_agpm(&["outdated"]).unwrap();
     assert!(!output.success, "Expected command to fail without project");
     assert!(
-        output.stderr.contains("ccpm.toml not found"),
+        output.stderr.contains("agpm.toml not found"),
         "Expected manifest not found error, got: {}",
         output.stderr
     );
@@ -147,13 +147,13 @@ checksum = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b
 installed_at = "agents/my-agent.md"
 resource_type = "agent"
 "#;
-    fs::write(project.project_path().join("ccpm.lock"), lockfile_content)
+    fs::write(project.project_path().join("agpm.lock"), lockfile_content)
         .await
         .unwrap();
 
     // Run outdated command with JSON format
     let output = project
-        .run_ccpm(&["outdated", "--format", "json", "--no-fetch"])
+        .run_agpm(&["outdated", "--format", "json", "--no-fetch"])
         .unwrap();
     output.assert_success();
 
@@ -199,13 +199,13 @@ checksum = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b
 installed_at = "agents/my-agent.md"
 resource_type = "agent"
 "#;
-    fs::write(project.project_path().join("ccpm.lock"), lockfile_content)
+    fs::write(project.project_path().join("agpm.lock"), lockfile_content)
         .await
         .unwrap();
 
     // Run outdated command with --check flag
     let output = project
-        .run_ccpm(&["outdated", "--check", "--no-fetch"])
+        .run_agpm(&["outdated", "--check", "--no-fetch"])
         .unwrap();
 
     // Should succeed when all dependencies are up to date
@@ -257,13 +257,13 @@ checksum = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b
 installed_at = "agents/helper.md"
 resource_type = "agent"
 "#;
-    fs::write(project.project_path().join("ccpm.lock"), lockfile_content)
+    fs::write(project.project_path().join("agpm.lock"), lockfile_content)
         .await
         .unwrap();
 
     // Run outdated command for specific dependency
     let output = project
-        .run_ccpm(&["outdated", "--no-fetch", "my-agent"])
+        .run_agpm(&["outdated", "--no-fetch", "my-agent"])
         .unwrap();
     output.assert_success();
 }

--- a/tests/integration_parallelism_stress.rs
+++ b/tests/integration_parallelism_stress.rs
@@ -51,7 +51,7 @@ official = "{}"
 
     // Test with extremely high parallelism (should be throttled by system)
     let output = project
-        .run_ccpm(&["install", "--max-parallel", "100"])
+        .run_agpm(&["install", "--max-parallel", "100"])
         .unwrap();
     assert!(output.success);
 
@@ -123,7 +123,7 @@ snippet = {{ source = "official", path = "snippets/rapid-snippet.md", version = 
 
     let start = Instant::now();
     for operation in operations {
-        let output = project.run_ccpm(&operation).unwrap();
+        let output = project.run_agpm(&operation).unwrap();
         assert!(output.success);
     }
     let total_duration = start.elapsed();
@@ -152,7 +152,7 @@ snippet = {{ source = "official", path = "snippets/rapid-snippet.md", version = 
     assert!(
         project
             .project_path()
-            .join(".claude/ccpm/snippets/rapid-snippet.md")
+            .join(".claude/agpm/snippets/rapid-snippet.md")
             .exists()
     );
 
@@ -207,7 +207,7 @@ official = "{}"
 
         let start = Instant::now();
         let output = project
-            .run_ccpm(&["install", "--max-parallel", &level.to_string()])
+            .run_agpm(&["install", "--max-parallel", &level.to_string()])
             .unwrap();
         assert!(output.success);
         let duration = start.elapsed();
@@ -273,7 +273,7 @@ official = "{}"
     // High parallelism with single source should work efficiently
     let start = Instant::now();
     let output = project
-        .run_ccpm(&["install", "--max-parallel", "10"])
+        .run_agpm(&["install", "--max-parallel", "10"])
         .unwrap();
     assert!(output.success);
     let duration = start.elapsed();
@@ -344,7 +344,7 @@ agent2 = {{ source = "official", path = "agents/limit-agent-2.md", version = "v1
         let _ = tokio::fs::remove_dir_all(project.project_path().join(".claude")).await;
 
         let output = project
-            .run_ccpm(&["install", "--max-parallel", max_parallel])
+            .run_agpm(&["install", "--max-parallel", max_parallel])
             .unwrap();
         assert!(
             output.success,

--- a/tests/integration_pattern.rs
+++ b/tests/integration_pattern.rs
@@ -10,7 +10,7 @@ use common::TestProject;
 /// Test installing dependencies using glob patterns.
 #[tokio::test]
 async fn test_pattern_based_installation() -> Result<()> {
-    ccpm::test_utils::init_test_logging(None);
+    agpm::test_utils::init_test_logging(None);
 
     let project = TestProject::new().await?;
 
@@ -89,7 +89,7 @@ all-agents = {{ source = "test-repo", path = "agents/**/*.md", version = "v1.0.0
     project.write_manifest(&manifest_content).await?;
 
     // Run install command
-    let output = project.run_ccpm(&["install"])?;
+    let output = project.run_agpm(&["install"])?;
     assert!(output.success);
 
     // Verify that all AI agents were installed
@@ -119,7 +119,7 @@ all-agents = {{ source = "test-repo", path = "agents/**/*.md", version = "v1.0.0
     );
 
     // Verify lockfile was created with all resources
-    let lockfile_path = project.project_path().join("ccpm.lock");
+    let lockfile_path = project.project_path().join("agpm.lock");
     assert!(lockfile_path.exists(), "Lockfile not created");
 
     let lockfile_content = fs::read_to_string(&lockfile_path).await?;
@@ -150,7 +150,7 @@ all-agents = {{ source = "test-repo", path = "agents/**/*.md", version = "v1.0.0
 /// Test pattern dependencies with custom target directories.
 #[tokio::test]
 async fn test_pattern_with_custom_target() -> Result<()> {
-    ccpm::test_utils::init_test_logging(None);
+    agpm::test_utils::init_test_logging(None);
 
     let project = TestProject::new().await?;
     let test_repo = project.create_source_repo("test-repo").await?;
@@ -187,14 +187,14 @@ utilities = {{ source = "test-repo", path = "snippets/util*.md", version = "v1.0
     project.write_manifest(&manifest_content).await?;
 
     // Run install
-    let output = project.run_ccpm(&["install"])?;
+    let output = project.run_agpm(&["install"])?;
     assert!(output.success);
 
     // Verify custom installation path
     // Custom target is relative to default snippets directory
     let custom_dir = project
         .project_path()
-        .join(".claude/ccpm/snippets/tools/utilities");
+        .join(".claude/agpm/snippets/tools/utilities");
     assert!(
         custom_dir.join("util1.md").exists(),
         "util1 not installed to custom path"
@@ -214,7 +214,7 @@ utilities = {{ source = "test-repo", path = "snippets/util*.md", version = "v1.0
 /// Test pattern dependencies with version constraints.
 #[tokio::test]
 async fn test_pattern_with_versions() -> Result<()> {
-    ccpm::test_utils::init_test_logging(None);
+    agpm::test_utils::init_test_logging(None);
 
     let project = TestProject::new().await?;
     let test_repo = project.create_source_repo("test-repo").await?;
@@ -250,7 +250,7 @@ v1-agents = {{ source = "test-repo", path = "agents/*.md", version = "v1.0.0" }}
     project.write_manifest(&manifest_content).await?;
 
     // Run install
-    let output = project.run_ccpm(&["install"])?;
+    let output = project.run_agpm(&["install"])?;
     assert!(output.success);
 
     // Verify v1.0.0 agents were installed
@@ -279,7 +279,7 @@ v1-agents = {{ source = "test-repo", path = "agents/*.md", version = "v1.0.0" }}
 /// Test local filesystem patterns.
 #[tokio::test]
 async fn test_local_pattern_dependencies() -> Result<()> {
-    ccpm::test_utils::init_test_logging(None);
+    agpm::test_utils::init_test_logging(None);
 
     let project = TestProject::new().await?;
 
@@ -304,7 +304,7 @@ local-agents = {{ path = "{}/agents/local*.md" }}
     project.write_manifest(&manifest_content).await?;
 
     // Run install
-    let output = project.run_ccpm(&["install"])?;
+    let output = project.run_agpm(&["install"])?;
 
     // Local patterns might not be supported in the same way as remote patterns
     // This test documents the current behavior
@@ -332,7 +332,7 @@ local-agents = {{ path = "{}/agents/local*.md" }}
 /// Test error handling for invalid patterns.
 #[tokio::test]
 async fn test_invalid_pattern_error() -> Result<()> {
-    ccpm::test_utils::init_test_logging(None);
+    agpm::test_utils::init_test_logging(None);
 
     let project = TestProject::new().await?;
 
@@ -348,7 +348,7 @@ unsafe = { source = "test-repo", path = "../../../etc/*.conf", version = "latest
     project.write_manifest(manifest_content).await?;
 
     // Run validate command
-    let output = project.run_ccpm(&["validate"])?;
+    let output = project.run_agpm(&["validate"])?;
 
     // Should fail validation due to path traversal
     assert!(!output.success);
@@ -359,7 +359,7 @@ unsafe = { source = "test-repo", path = "../../../etc/*.conf", version = "latest
 /// Test pattern matching performance with many files.
 #[tokio::test]
 async fn test_pattern_performance() -> Result<()> {
-    ccpm::test_utils::init_test_logging(None);
+    agpm::test_utils::init_test_logging(None);
 
     let project = TestProject::new().await?;
     let test_repo = project.create_source_repo("test-repo").await?;
@@ -395,7 +395,7 @@ all-agents = {{ source = "test-repo", path = "agents/*.md", version = "v1.0.0" }
     // Measure installation time
     let start = std::time::Instant::now();
 
-    let output = project.run_ccpm(&["install"])?;
+    let output = project.run_agpm(&["install"])?;
     assert!(output.success);
 
     let duration = start.elapsed();
@@ -408,7 +408,7 @@ all-agents = {{ source = "test-repo", path = "agents/*.md", version = "v1.0.0" }
     );
 
     // Verify all files were installed
-    let lockfile_content = fs::read_to_string(project.project_path().join("ccpm.lock")).await?;
+    let lockfile_content = fs::read_to_string(project.project_path().join("agpm.lock")).await?;
     let agent_count = lockfile_content.matches("agent").count();
     assert!(agent_count >= 100, "Not all agents were installed");
 

--- a/tests/integration_stress_test.rs
+++ b/tests/integration_stress_test.rs
@@ -1,13 +1,13 @@
 //! Stress tests for parallel installation with git worktrees
 
+use agpm::cache::Cache;
+use agpm::git::command_builder::GitCommand;
+use agpm::installer::{ResourceFilter, install_resources};
+use agpm::lockfile::{LockFile, LockedResource};
+use agpm::manifest::Manifest;
+use agpm::test_utils::init_test_logging;
+use agpm::utils::progress::MultiPhaseProgress;
 use anyhow::Result;
-use ccpm::cache::Cache;
-use ccpm::git::command_builder::GitCommand;
-use ccpm::installer::{ResourceFilter, install_resources};
-use ccpm::lockfile::{LockFile, LockedResource};
-use ccpm::manifest::Manifest;
-use ccpm::test_utils::init_test_logging;
-use ccpm::utils::progress::MultiPhaseProgress;
 use std::sync::Arc;
 use tempfile::TempDir;
 use tokio::fs;
@@ -52,7 +52,7 @@ async fn test_heavy_stress_500_dependencies() -> Result<()> {
                 checksum: format!("sha256:r{}a{}", repo_idx, i),
                 installed_at: format!(".claude/agents/repo{}_agent_{:03}.md", repo_idx, i),
                 dependencies: vec![],
-                resource_type: ccpm::core::ResourceType::Agent,
+                resource_type: agpm::core::ResourceType::Agent,
             });
             total_agents += 1;
         }
@@ -322,7 +322,7 @@ async fn test_heavy_stress_500_updates() -> Result<()> {
                 checksum: format!("sha256:r{}a{}v1", repo_idx, i),
                 installed_at: format!(".claude/agents/repo{}_agent_{:03}.md", repo_idx, i),
                 dependencies: vec![],
-                resource_type: ccpm::core::ResourceType::Agent,
+                resource_type: agpm::core::ResourceType::Agent,
             });
             total_agents += 1;
         }
@@ -371,7 +371,7 @@ async fn test_heavy_stress_500_updates() -> Result<()> {
                 checksum: format!("sha256:r{}a{}v2", repo_idx, i),
                 installed_at: format!(".claude/agents/repo{}_agent_{:03}.md", repo_idx, i),
                 dependencies: vec![],
-                resource_type: ccpm::core::ResourceType::Agent,
+                resource_type: agpm::core::ResourceType::Agent,
             });
         }
     }
@@ -468,8 +468,8 @@ async fn test_mixed_repos_file_and_https() -> Result<()> {
         repo_urls.push(format!("file://{}", repo_dir.display()));
     }
 
-    // Add the ccpm-community GitHub repository
-    repo_urls.push("https://github.com/aig787/ccpm-community.git".to_string());
+    // Add the agpm-community GitHub repository
+    repo_urls.push("https://github.com/aig787/agpm-community.git".to_string());
 
     let cache = Cache::with_dir(temp_dir.path().join("cache"))?;
     let mut lockfile = LockFile::new();
@@ -488,13 +488,13 @@ async fn test_mixed_repos_file_and_https() -> Result<()> {
                 checksum: format!("sha256:lr{}a{}", repo_idx, i),
                 installed_at: format!(".claude/agents/local_repo{}_agent_{:03}.md", repo_idx, i),
                 dependencies: vec![],
-                resource_type: ccpm::core::ResourceType::Agent,
+                resource_type: agpm::core::ResourceType::Agent,
             });
             total_resources += 1;
         }
     }
 
-    // Add real agents from ccpm-community repo (from setup_project.sh)
+    // Add real agents from agpm-community repo (from setup_project.sh)
     let community_agents = [
         "agents/awesome-claude-code-subagents/categories/01-core-development/api-designer.md",
         "agents/awesome-claude-code-subagents/categories/01-core-development/backend-developer.md",
@@ -512,14 +512,14 @@ async fn test_mixed_repos_file_and_https() -> Result<()> {
         lockfile.agents.push(LockedResource {
             name: format!("community_agent_{}", idx),
             source: Some("community".to_string()),
-            url: Some("https://github.com/aig787/ccpm-community.git".to_string()),
+            url: Some("https://github.com/aig787/agpm-community.git".to_string()),
             path: agent_path.to_string(),
             version: None, // Use main branch
             resolved_commit: None,
             checksum: format!("sha256:community_{}", idx),
             installed_at: format!(".claude/agents/community_agent_{}.md", idx),
             dependencies: vec![],
-            resource_type: ccpm::core::ResourceType::Agent,
+            resource_type: agpm::core::ResourceType::Agent,
         });
         total_resources += 1;
     }
@@ -588,7 +588,7 @@ async fn test_mixed_repos_file_and_https() -> Result<()> {
     Ok(())
 }
 
-/// COMMUNITY REPO TEST: Parallel checkout performance from real ccpm-community repository
+/// COMMUNITY REPO TEST: Parallel checkout performance from real agpm-community repository
 #[tokio::test]
 #[ignore = "Performance test - run manually"]
 async fn test_community_repo_parallel_checkout_performance() -> Result<()> {
@@ -670,14 +670,14 @@ async fn test_community_repo_parallel_checkout_performance() -> Result<()> {
         lockfile.agents.push(LockedResource {
             name: name.to_string(),
             source: Some("community".to_string()),
-            url: Some("https://github.com/aig787/ccpm-community.git".to_string()),
+            url: Some("https://github.com/aig787/agpm-community.git".to_string()),
             path: path.to_string(),
             version: None, // Use main branch
             resolved_commit: None,
             checksum: format!("sha256:community_{}", name),
             installed_at: format!(".claude/agents/{}.md", name),
             dependencies: vec![],
-            resource_type: ccpm::core::ResourceType::Agent,
+            resource_type: agpm::core::ResourceType::Agent,
         });
     }
 
@@ -685,8 +685,8 @@ async fn test_community_repo_parallel_checkout_performance() -> Result<()> {
     let manifest = Manifest::new();
     let progress = Arc::new(MultiPhaseProgress::new(false));
 
-    println!("📦 Testing parallel checkout from ccpm-community repository");
-    println!("   Repository: https://github.com/aig787/ccpm-community.git");
+    println!("📦 Testing parallel checkout from agpm-community repository");
+    println!("   Repository: https://github.com/aig787/agpm-community.git");
     println!("   Agents: {}", total_agents);
 
     let start = std::time::Instant::now();
@@ -760,7 +760,7 @@ async fn test_community_repo_500_dependencies() -> Result<()> {
     let cache = Cache::with_dir(temp_dir.path().join("cache"))?;
     let mut lockfile = LockFile::new();
 
-    // The 15 agents available in ccpm-community
+    // The 15 agents available in agpm-community
     let community_agents = [
         (
             "api-designer",
@@ -838,14 +838,14 @@ async fn test_community_repo_500_dependencies() -> Result<()> {
         let resource = LockedResource {
             name: unique_agent_name.clone(),
             source: Some("community".to_string()),
-            url: Some("https://github.com/aig787/ccpm-community.git".to_string()),
+            url: Some("https://github.com/aig787/agpm-community.git".to_string()),
             path: agent_path.to_string(),
             version: Some("main".to_string()),
             resolved_commit: Some("main".to_string()), // Will be resolved during installation
             checksum: "sha256:placeholder".to_string(), // Will be computed during installation
             installed_at: format!(".claude/agents/{}", unique_filename),
             dependencies: vec![],
-            resource_type: ccpm::core::ResourceType::Agent,
+            resource_type: agpm::core::ResourceType::Agent,
         };
 
         lockfile.agents.push(resource);

--- a/tests/integration_test_helpers_example.rs
+++ b/tests/integration_test_helpers_example.rs
@@ -9,7 +9,7 @@ use common::{DirAssert, FileAssert, TestProject};
 /// Example test showing TestProject usage
 #[tokio::test]
 async fn test_using_test_project_helper() -> Result<()> {
-    ccpm::test_utils::init_test_logging(None);
+    agpm::test_utils::init_test_logging(None);
     // Create a test project with all necessary directories
     let project = TestProject::new().await?;
 
@@ -37,8 +37,8 @@ test-agent = { source = "example", path = "agents/test.md", version = "v1.0.0" }
     DirAssert::exists(project.sources_path()).await;
 
     // Verify manifest was written
-    FileAssert::exists(project.project_path().join("ccpm.toml")).await;
-    FileAssert::contains(project.project_path().join("ccpm.toml"), "test-agent").await;
+    FileAssert::exists(project.project_path().join("agpm.toml")).await;
+    FileAssert::contains(project.project_path().join("agpm.toml"), "test-agent").await;
 
     // Verify local resource was created
     FileAssert::exists(project.project_path().join("agents/local-agent.md")).await;
@@ -48,10 +48,10 @@ test-agent = { source = "example", path = "agents/test.md", version = "v1.0.0" }
     )
     .await;
 
-    // Run a CCPM command (validate in this case)
-    let output = project.run_ccpm(&["validate"])?;
+    // Run a AGPM command (validate in this case)
+    let output = project.run_agpm(&["validate"])?;
     output.assert_success();
-    output.assert_stdout_contains("Valid ccpm.toml");
+    output.assert_stdout_contains("Valid agpm.toml");
 
     Ok(())
 }
@@ -59,7 +59,7 @@ test-agent = { source = "example", path = "agents/test.md", version = "v1.0.0" }
 /// Example test showing TestSourceRepo usage
 #[tokio::test]
 async fn test_using_test_source_repo_helper() -> Result<()> {
-    ccpm::test_utils::init_test_logging(None);
+    agpm::test_utils::init_test_logging(None);
     let project = TestProject::new().await?;
 
     // Create a source repository with standard resources
@@ -94,7 +94,7 @@ custom = {{ source = "test", path = "agents/custom.md", version = "v1.1.0" }}
     project.write_manifest(&manifest_content).await?;
 
     // Run install command
-    let output = project.run_ccpm(&["install"])?;
+    let output = project.run_agpm(&["install"])?;
     output.assert_success();
 
     // Verify resources were installed
@@ -105,7 +105,7 @@ custom = {{ source = "test", path = "agents/custom.md", version = "v1.1.0" }}
     DirAssert::contains_file(&agents_dir, "custom.md").await;
 
     // Verify lockfile was created
-    FileAssert::exists(project.project_path().join("ccpm.lock")).await;
+    FileAssert::exists(project.project_path().join("agpm.lock")).await;
 
     Ok(())
 }
@@ -113,7 +113,7 @@ custom = {{ source = "test", path = "agents/custom.md", version = "v1.1.0" }}
 /// Example test showing FileAssert and DirAssert usage
 #[tokio::test]
 async fn test_assertion_helpers() -> Result<()> {
-    ccpm::test_utils::init_test_logging(None);
+    agpm::test_utils::init_test_logging(None);
     let project = TestProject::new().await?;
 
     // Create some test files and directories

--- a/tests/integration_transitive.rs
+++ b/tests/integration_transitive.rs
@@ -11,7 +11,7 @@ use common::TestProject;
 /// Test basic transitive dependency resolution with real Git repos
 #[tokio::test]
 async fn test_transitive_resolution_basic() -> Result<()> {
-    ccpm::test_utils::init_test_logging(None);
+    agpm::test_utils::init_test_logging(None);
 
     let project = TestProject::new().await?;
 
@@ -67,7 +67,7 @@ main-app = {{ source = "community", path = "agents/main-app.md", version = "v1.0
     project.write_manifest(&manifest_content).await?;
 
     // Run install
-    project.run_ccpm(&["install"])?;
+    project.run_agpm(&["install"])?;
 
     // Verify both agents were installed (main + transitive helper)
     let lockfile_content = project.read_lockfile().await?;
@@ -111,7 +111,7 @@ main-app = {{ source = "community", path = "agents/main-app.md", version = "v1.0
 #[tokio::test]
 #[ignore = "Cross-source transitive dependencies with same names not yet supported"]
 async fn test_transitive_cross_source_same_names() -> Result<()> {
-    ccpm::test_utils::init_test_logging(None);
+    agpm::test_utils::init_test_logging(None);
 
     let project = TestProject::new().await?;
 
@@ -191,7 +191,7 @@ tool = {{ source = "source2", path = "agents/tool.md", version = "v1.0.0" }}
     // Run install - currently this fails with a path conflict error
     // because both "utils" transitive deps resolve to .claude/agents/utils.md
     // but have different commits (different sources)
-    let output = project.run_ccpm(&["install"])?;
+    let output = project.run_agpm(&["install"])?;
 
     // Expected behavior: Should detect path conflict
     assert!(
@@ -210,7 +210,7 @@ tool = {{ source = "source2", path = "agents/tool.md", version = "v1.0.0" }}
 /// Test that circular transitive dependencies are detected and rejected
 #[tokio::test]
 async fn test_transitive_cycle_detection() -> Result<()> {
-    ccpm::test_utils::init_test_logging(None);
+    agpm::test_utils::init_test_logging(None);
 
     let project = TestProject::new().await?;
 
@@ -286,7 +286,7 @@ agent-a = {{ source = "community", path = "agents/agent-a.md", version = "v1.0.0
     project.write_manifest(&manifest_content).await?;
 
     // Run install - should fail with cycle detection
-    let output = project.run_ccpm(&["install"])?;
+    let output = project.run_agpm(&["install"])?;
     assert!(
         !output.success,
         "Install should fail due to circular dependency"
@@ -303,7 +303,7 @@ agent-a = {{ source = "community", path = "agents/agent-a.md", version = "v1.0.0
 /// Test diamond dependencies (same resource via multiple paths)
 #[tokio::test]
 async fn test_transitive_diamond_dependencies() -> Result<()> {
-    ccpm::test_utils::init_test_logging(None);
+    agpm::test_utils::init_test_logging(None);
 
     let project = TestProject::new().await?;
 
@@ -398,7 +398,7 @@ agent-a = {{ source = "community", path = "agents/agent-a.md", version = "v1.0.0
     project.write_manifest(&manifest_content).await?;
 
     // Run install - should succeed
-    let output = project.run_ccpm(&["install"])?;
+    let output = project.run_agpm(&["install"])?;
     assert!(
         output.success,
         "Install should succeed with diamond dependencies: {}",

--- a/tests/integration_tree.rs
+++ b/tests/integration_tree.rs
@@ -1,4 +1,4 @@
-//! Integration tests for the `ccpm tree` command.
+//! Integration tests for the `agpm tree` command.
 
 use assert_cmd::Command;
 use predicates::prelude::*;
@@ -18,7 +18,7 @@ local-agent = { path = "../local/agent.md" }
 utils = { source = "community", path = "snippets/utils.md", version = "v1.0.0" }
 "#;
 
-    fs::write(dir.join("ccpm.toml"), manifest_content)
+    fs::write(dir.join("agpm.toml"), manifest_content)
         .await
         .unwrap();
 }
@@ -77,7 +77,7 @@ dependencies = []
 resource_type = "snippet"
 "#;
 
-    fs::write(dir.join("ccpm.lock"), lockfile_content)
+    fs::write(dir.join("agpm.lock"), lockfile_content)
         .await
         .unwrap();
 }
@@ -87,13 +87,13 @@ async fn test_tree_no_lockfile() {
     let temp = TempDir::new().unwrap();
     create_test_manifest(temp.path()).await;
 
-    let mut cmd = Command::cargo_bin("ccpm").unwrap();
+    let mut cmd = Command::cargo_bin("agpm").unwrap();
     cmd.current_dir(temp.path()).arg("tree");
 
     cmd.assert()
         .success()
         .stdout(predicate::str::contains("No lockfile found"))
-        .stdout(predicate::str::contains("ccpm install"));
+        .stdout(predicate::str::contains("agpm install"));
 }
 
 #[tokio::test]
@@ -102,7 +102,7 @@ async fn test_tree_basic() {
     create_test_manifest(temp.path()).await;
     create_test_lockfile(temp.path()).await;
 
-    let mut cmd = Command::cargo_bin("ccpm").unwrap();
+    let mut cmd = Command::cargo_bin("agpm").unwrap();
     cmd.current_dir(temp.path()).arg("tree");
 
     cmd.assert()
@@ -119,7 +119,7 @@ async fn test_tree_with_depth() {
     create_test_manifest(temp.path()).await;
     create_test_lockfile(temp.path()).await;
 
-    let mut cmd = Command::cargo_bin("ccpm").unwrap();
+    let mut cmd = Command::cargo_bin("agpm").unwrap();
     cmd.current_dir(temp.path())
         .arg("tree")
         .arg("--depth")
@@ -134,7 +134,7 @@ async fn test_tree_json_format() {
     create_test_manifest(temp.path()).await;
     create_test_lockfile(temp.path()).await;
 
-    let mut cmd = Command::cargo_bin("ccpm").unwrap();
+    let mut cmd = Command::cargo_bin("agpm").unwrap();
     cmd.current_dir(temp.path())
         .arg("tree")
         .arg("--format")
@@ -152,7 +152,7 @@ async fn test_tree_text_format() {
     create_test_manifest(temp.path()).await;
     create_test_lockfile(temp.path()).await;
 
-    let mut cmd = Command::cargo_bin("ccpm").unwrap();
+    let mut cmd = Command::cargo_bin("agpm").unwrap();
     cmd.current_dir(temp.path())
         .arg("tree")
         .arg("--format")
@@ -170,7 +170,7 @@ async fn test_tree_invalid_format() {
     create_test_manifest(temp.path()).await;
     create_test_lockfile(temp.path()).await;
 
-    let mut cmd = Command::cargo_bin("ccpm").unwrap();
+    let mut cmd = Command::cargo_bin("agpm").unwrap();
     cmd.current_dir(temp.path())
         .arg("tree")
         .arg("--format")
@@ -187,7 +187,7 @@ async fn test_tree_zero_depth() {
     create_test_manifest(temp.path()).await;
     create_test_lockfile(temp.path()).await;
 
-    let mut cmd = Command::cargo_bin("ccpm").unwrap();
+    let mut cmd = Command::cargo_bin("agpm").unwrap();
     cmd.current_dir(temp.path())
         .arg("tree")
         .arg("--depth")
@@ -204,7 +204,7 @@ async fn test_tree_filter_agents() {
     create_test_manifest(temp.path()).await;
     create_test_lockfile(temp.path()).await;
 
-    let mut cmd = Command::cargo_bin("ccpm").unwrap();
+    let mut cmd = Command::cargo_bin("agpm").unwrap();
     cmd.current_dir(temp.path()).arg("tree").arg("--agents");
 
     cmd.assert()
@@ -219,7 +219,7 @@ async fn test_tree_filter_snippets() {
     create_test_manifest(temp.path()).await;
     create_test_lockfile(temp.path()).await;
 
-    let mut cmd = Command::cargo_bin("ccpm").unwrap();
+    let mut cmd = Command::cargo_bin("agpm").unwrap();
     cmd.current_dir(temp.path()).arg("tree").arg("--snippets");
 
     cmd.assert()
@@ -234,7 +234,7 @@ async fn test_tree_specific_package() {
     create_test_manifest(temp.path()).await;
     create_test_lockfile(temp.path()).await;
 
-    let mut cmd = Command::cargo_bin("ccpm").unwrap();
+    let mut cmd = Command::cargo_bin("agpm").unwrap();
     cmd.current_dir(temp.path())
         .arg("tree")
         .arg("--package")
@@ -251,7 +251,7 @@ async fn test_tree_package_not_found() {
     create_test_manifest(temp.path()).await;
     create_test_lockfile(temp.path()).await;
 
-    let mut cmd = Command::cargo_bin("ccpm").unwrap();
+    let mut cmd = Command::cargo_bin("agpm").unwrap();
     cmd.current_dir(temp.path())
         .arg("tree")
         .arg("--package")
@@ -268,7 +268,7 @@ async fn test_tree_with_transitive_deps() {
     create_test_manifest(temp.path()).await;
     create_test_lockfile(temp.path()).await;
 
-    let mut cmd = Command::cargo_bin("ccpm").unwrap();
+    let mut cmd = Command::cargo_bin("agpm").unwrap();
     cmd.current_dir(temp.path()).arg("tree");
 
     // Should show code-reviewer with its dependencies
@@ -283,11 +283,11 @@ async fn test_tree_with_transitive_deps() {
 async fn test_tree_no_manifest() {
     let temp = TempDir::new().unwrap();
 
-    let mut cmd = Command::cargo_bin("ccpm").unwrap();
+    let mut cmd = Command::cargo_bin("agpm").unwrap();
     cmd.current_dir(temp.path()).arg("tree");
 
     cmd.assert().failure().stderr(predicate::str::contains(
-        "Manifest file ccpm.toml not found",
+        "Manifest file agpm.toml not found",
     ));
 }
 
@@ -297,7 +297,7 @@ async fn test_tree_with_duplicates_flag() {
     create_test_manifest(temp.path()).await;
     create_test_lockfile(temp.path()).await;
 
-    let mut cmd = Command::cargo_bin("ccpm").unwrap();
+    let mut cmd = Command::cargo_bin("agpm").unwrap();
     cmd.current_dir(temp.path()).arg("tree").arg("--duplicates");
 
     cmd.assert().success();
@@ -309,7 +309,7 @@ async fn test_tree_no_dedupe() {
     create_test_manifest(temp.path()).await;
     create_test_lockfile(temp.path()).await;
 
-    let mut cmd = Command::cargo_bin("ccpm").unwrap();
+    let mut cmd = Command::cargo_bin("agpm").unwrap();
     cmd.current_dir(temp.path()).arg("tree").arg("--no-dedupe");
 
     cmd.assert().success();

--- a/tests/integration_upd_progress.rs
+++ b/tests/integration_upd_progress.rs
@@ -22,7 +22,7 @@ test_source = "../test_resources"
 [agents]
 test_agent = { path = "../test_resources/agent.md" }
 "#;
-    fs::write(project_dir.join("ccpm.toml"), manifest_content)
+    fs::write(project_dir.join("agpm.toml"), manifest_content)
         .await
         .unwrap();
 
@@ -34,17 +34,17 @@ test_agent = { path = "../test_resources/agent.md" }
         .unwrap();
 
     // Run install first to create lockfile
-    let mut cmd = Command::cargo_bin("ccpm").unwrap();
+    let mut cmd = Command::cargo_bin("agpm").unwrap();
     cmd.current_dir(project_dir)
         .arg("install")
         .assert()
         .success();
 
     // Verify lockfile was created
-    assert!(project_dir.join("ccpm.lock").exists());
+    assert!(project_dir.join("agpm.lock").exists());
 
     // Run update - should show proper phases (or "up to date" message)
-    let mut cmd = Command::cargo_bin("ccpm").unwrap();
+    let mut cmd = Command::cargo_bin("agpm").unwrap();
     let output = cmd
         .current_dir(project_dir)
         .arg("update")
@@ -72,19 +72,19 @@ async fn test_update_empty_manifest() {
     let project_dir = temp.path();
 
     // Create empty manifest
-    fs::write(project_dir.join("ccpm.toml"), "[sources]\n[agents]\n")
+    fs::write(project_dir.join("agpm.toml"), "[sources]\n[agents]\n")
         .await
         .unwrap();
 
     // Run install first
-    let mut cmd = Command::cargo_bin("ccpm").unwrap();
+    let mut cmd = Command::cargo_bin("agpm").unwrap();
     cmd.current_dir(project_dir)
         .arg("install")
         .assert()
         .success();
 
     // Run update - should handle gracefully
-    let mut cmd = Command::cargo_bin("ccpm").unwrap();
+    let mut cmd = Command::cargo_bin("agpm").unwrap();
     cmd.current_dir(project_dir)
         .arg("update")
         .assert()
@@ -99,15 +99,15 @@ async fn test_update_no_lockfile_fresh_install() {
     let project_dir = temp.path();
 
     // Create manifest without running install
-    fs::write(project_dir.join("ccpm.toml"), "[sources]\n[agents]\n")
+    fs::write(project_dir.join("agpm.toml"), "[sources]\n[agents]\n")
         .await
         .unwrap();
 
     // Ensure no lockfile exists
-    assert!(!project_dir.join("ccpm.lock").exists());
+    assert!(!project_dir.join("agpm.lock").exists());
 
     // Run update - should perform fresh install
-    let mut cmd = Command::cargo_bin("ccpm").unwrap();
+    let mut cmd = Command::cargo_bin("agpm").unwrap();
     let output = cmd
         .current_dir(project_dir)
         .arg("update")
@@ -125,7 +125,7 @@ async fn test_update_no_lockfile_fresh_install() {
     );
 
     // Lockfile should be created
-    assert!(project_dir.join("ccpm.lock").exists());
+    assert!(project_dir.join("agpm.lock").exists());
 }
 
 /// Test that dry-run mode doesn't modify files
@@ -135,23 +135,23 @@ async fn test_update_dry_run_no_modifications() {
     let project_dir = temp.path();
 
     // Create manifest and lockfile
-    fs::write(project_dir.join("ccpm.toml"), "[sources]\n[agents]\n")
+    fs::write(project_dir.join("agpm.toml"), "[sources]\n[agents]\n")
         .await
         .unwrap();
 
     fs::write(
-        project_dir.join("ccpm.lock"),
+        project_dir.join("agpm.lock"),
         "version = 1\nsources = []\nagents = []\n",
     )
     .await
     .unwrap();
 
-    let original_lock = fs::read_to_string(project_dir.join("ccpm.lock"))
+    let original_lock = fs::read_to_string(project_dir.join("agpm.lock"))
         .await
         .unwrap();
 
     // Run update with --dry-run
-    let mut cmd = Command::cargo_bin("ccpm").unwrap();
+    let mut cmd = Command::cargo_bin("agpm").unwrap();
     cmd.current_dir(project_dir)
         .arg("update")
         .arg("--dry-run")
@@ -159,7 +159,7 @@ async fn test_update_dry_run_no_modifications() {
         .success();
 
     // Lockfile should be unchanged
-    let current_lock = fs::read_to_string(project_dir.join("ccpm.lock"))
+    let current_lock = fs::read_to_string(project_dir.join("agpm.lock"))
         .await
         .unwrap();
     assert_eq!(original_lock, current_lock);

--- a/tests/integration_upgrade.rs
+++ b/tests/integration_upgrade.rs
@@ -1,7 +1,7 @@
-use anyhow::Result;
-use ccpm::upgrade::{
+use agpm::upgrade::{
     SelfUpdater, VersionChecker, backup::BackupManager, verification::ChecksumVerifier,
 };
+use anyhow::Result;
 use std::path::PathBuf;
 use tempfile::TempDir;
 use tokio::fs;
@@ -10,8 +10,8 @@ use tokio::fs;
 #[tokio::test]
 async fn test_backup_create_and_restore() -> Result<()> {
     let temp_dir = TempDir::new()?;
-    let binary_path = temp_dir.path().join("ccpm");
-    let backup_path = temp_dir.path().join("ccpm.backup");
+    let binary_path = temp_dir.path().join("agpm");
+    let backup_path = temp_dir.path().join("agpm.backup");
 
     // Create a mock binary file
     fs::write(&binary_path, b"original binary content").await?;
@@ -64,7 +64,7 @@ async fn test_backup_missing_original() -> Result<()> {
 #[tokio::test]
 async fn test_restore_missing_backup() -> Result<()> {
     let temp_dir = TempDir::new()?;
-    let binary_path = temp_dir.path().join("ccpm");
+    let binary_path = temp_dir.path().join("agpm");
 
     // Create original file
     fs::write(&binary_path, b"original").await?;
@@ -156,7 +156,7 @@ async fn test_checksum_verification_failure() -> Result<()> {
 #[tokio::test]
 async fn test_version_checker_caching() -> Result<()> {
     let temp_dir = TempDir::new()?;
-    let cache_path = temp_dir.path().join(".ccpm").join(".version_cache");
+    let cache_path = temp_dir.path().join(".agpm").join(".version_cache");
 
     // Create cache directory
     if let Some(parent) = cache_path.parent() {
@@ -166,13 +166,13 @@ async fn test_version_checker_caching() -> Result<()> {
     // Set up environment to use temp directory
     unsafe {
         std::env::set_var(
-            "CCPM_CONFIG_PATH",
-            temp_dir.path().join(".ccpm").join("config.toml"),
+            "AGPM_CONFIG_PATH",
+            temp_dir.path().join(".agpm").join("config.toml"),
         );
     }
 
     // Test save and load cache
-    let cache = ccpm::upgrade::version_check::VersionCheckCache {
+    let cache = agpm::upgrade::version_check::VersionCheckCache {
         latest_version: "0.5.0".to_string(),
         current_version: env!("CARGO_PKG_VERSION").to_string(),
         checked_at: chrono::Utc::now(),
@@ -189,13 +189,13 @@ async fn test_version_checker_caching() -> Result<()> {
 
     // Verify cache content by reading the file
     let cache_content = tokio::fs::read_to_string(&cache_path).await?;
-    let loaded: ccpm::upgrade::version_check::VersionCheckCache =
+    let loaded: agpm::upgrade::version_check::VersionCheckCache =
         serde_json::from_str(&cache_content)?;
     assert_eq!(loaded.latest_version, "0.5.0");
 
     // Clean up environment
     unsafe {
-        std::env::remove_var("CCPM_CONFIG_PATH");
+        std::env::remove_var("AGPM_CONFIG_PATH");
     }
 
     Ok(())
@@ -240,11 +240,11 @@ async fn test_self_updater_init() -> Result<()> {
 /// Test backup path generation.
 #[tokio::test]
 async fn test_backup_path_generation() -> Result<()> {
-    let original = PathBuf::from("/usr/local/bin/ccpm");
+    let original = PathBuf::from("/usr/local/bin/agpm");
     let backup_manager = BackupManager::new(original.clone());
 
     let backup_path = backup_manager.backup_path();
-    assert_eq!(backup_path.file_name().unwrap(), "ccpm.backup");
+    assert_eq!(backup_path.file_name().unwrap(), "agpm.backup");
     assert_eq!(backup_path.parent(), original.parent());
 
     Ok(())
@@ -254,8 +254,8 @@ async fn test_backup_path_generation() -> Result<()> {
 #[tokio::test]
 async fn test_backup_special_characters() -> Result<()> {
     let temp_dir = TempDir::new()?;
-    let binary_path = temp_dir.path().join("ccpm-v1.2.3");
-    let backup_path = temp_dir.path().join("ccpm-v1.2.3.backup");
+    let binary_path = temp_dir.path().join("agpm-v1.2.3");
+    let backup_path = temp_dir.path().join("agpm-v1.2.3.backup");
 
     // Create file
     fs::write(&binary_path, b"content").await?;
@@ -277,7 +277,7 @@ async fn test_backup_special_characters() -> Result<()> {
 #[tokio::test]
 async fn test_concurrent_backup_operations() -> Result<()> {
     let temp_dir = TempDir::new()?;
-    let binary_path = temp_dir.path().join("ccpm");
+    let binary_path = temp_dir.path().join("agpm");
 
     // Create original file
     fs::write(&binary_path, b"original").await?;
@@ -325,7 +325,7 @@ async fn test_checksum_case_insensitive() -> Result<()> {
 #[tokio::test]
 async fn test_version_cache_expiry() -> Result<()> {
     let temp_dir = TempDir::new()?;
-    let cache_path = temp_dir.path().join(".ccpm").join(".version_cache");
+    let cache_path = temp_dir.path().join(".agpm").join(".version_cache");
 
     // Create cache directory
     if let Some(parent) = cache_path.parent() {
@@ -347,14 +347,14 @@ async fn test_version_cache_expiry() -> Result<()> {
     // Set up environment to use temp directory
     unsafe {
         std::env::set_var(
-            "CCPM_CONFIG_PATH",
-            temp_dir.path().join(".ccpm").join("config.toml"),
+            "AGPM_CONFIG_PATH",
+            temp_dir.path().join(".agpm").join("config.toml"),
         );
     }
 
     // Read cache and verify it's old
     let cache_content = tokio::fs::read_to_string(&cache_path).await?;
-    let loaded: ccpm::upgrade::version_check::VersionCheckCache =
+    let loaded: agpm::upgrade::version_check::VersionCheckCache =
         serde_json::from_str(&cache_content)?;
 
     // Verify the cache has old timestamp
@@ -363,7 +363,7 @@ async fn test_version_cache_expiry() -> Result<()> {
 
     // Clean up environment
     unsafe {
-        std::env::remove_var("CCPM_CONFIG_PATH");
+        std::env::remove_var("AGPM_CONFIG_PATH");
     }
 
     Ok(())
@@ -375,8 +375,8 @@ async fn test_backup_permission_preservation() -> Result<()> {
     use std::os::unix::fs::PermissionsExt;
 
     let temp_dir = TempDir::new()?;
-    let binary_path = temp_dir.path().join("ccpm");
-    let backup_path = temp_dir.path().join("ccpm.backup");
+    let binary_path = temp_dir.path().join("agpm");
+    let backup_path = temp_dir.path().join("agpm.backup");
 
     // Create file with specific permissions
     fs::write(&binary_path, b"content").await?;

--- a/tests/integration_validate.rs
+++ b/tests/integration_validate.rs
@@ -55,7 +55,7 @@ utils = {{ source = "official", path = "snippets/utils.md", version = "v1.0.0" }
 
     project.write_manifest(&manifest_content).await.unwrap();
 
-    let output = project.run_ccpm(&["validate"]).unwrap();
+    let output = project.run_agpm(&["validate"]).unwrap();
     assert!(output.success);
     assert!(output.stdout.contains("✓"));
     assert!(output.stdout.contains("Valid"));
@@ -66,10 +66,10 @@ utils = {{ source = "official", path = "snippets/utils.md", version = "v1.0.0" }
 async fn test_validate_no_manifest() {
     let project = TestProject::new().await.unwrap();
 
-    let output = project.run_ccpm(&["validate"]).unwrap();
+    let output = project.run_agpm(&["validate"]).unwrap();
     assert!(!output.success);
     assert!(output.stdout.contains("✗"));
-    assert!(output.stdout.contains("No ccpm.toml found"));
+    assert!(output.stdout.contains("No agpm.toml found"));
 }
 
 /// Test validating manifest with invalid syntax
@@ -79,7 +79,7 @@ async fn test_validate_invalid_syntax() {
     let manifest = ManifestFixture::invalid_syntax();
     project.write_manifest(&manifest.content).await.unwrap();
 
-    let output = project.run_ccpm(&["validate"]).unwrap();
+    let output = project.run_agpm(&["validate"]).unwrap();
     assert!(!output.success);
     assert!(output.stdout.contains("✗"));
     assert!(output.stdout.contains("Syntax error"));
@@ -93,7 +93,7 @@ async fn test_validate_missing_fields() {
     let manifest = ManifestFixture::missing_fields();
     project.write_manifest(&manifest.content).await.unwrap();
 
-    let output = project.run_ccpm(&["validate"]).unwrap();
+    let output = project.run_agpm(&["validate"]).unwrap();
     assert!(!output.success);
     assert!(output.stdout.contains("✗"));
     assert!(output.stdout.contains("Missing required field"));
@@ -152,7 +152,7 @@ utils = {{ source = "official", path = "snippets/utils.md", version = "v1.0.0" }
 
     project.write_manifest(&manifest_content).await.unwrap();
 
-    let output = project.run_ccpm(&["validate", "--sources"]).unwrap();
+    let output = project.run_agpm(&["validate", "--sources"]).unwrap();
     assert!(output.success);
     assert!(output.stdout.contains("✓"));
     assert!(output.stdout.contains("Sources accessible"));
@@ -179,7 +179,7 @@ utils = { source = "official", path = "snippets/utils.md", version = "v1.0.0" }
 
     project.write_manifest(manifest_content).await.unwrap();
 
-    let output = project.run_ccpm(&["validate", "--sources"]).unwrap();
+    let output = project.run_agpm(&["validate", "--sources"]).unwrap();
     assert!(!output.success);
     assert!(output.stdout.contains("✗"));
     assert!(output.stdout.contains("Source not accessible"));
@@ -234,7 +234,7 @@ utils = {{ source = "official", path = "snippets/utils.md", version = "v1.0.0" }
 
     project.write_manifest(&manifest_content).await.unwrap();
 
-    let output = project.run_ccpm(&["validate", "--resolve"]).unwrap();
+    let output = project.run_agpm(&["validate", "--resolve"]).unwrap();
     assert!(output.success);
     assert!(output.stdout.contains("✓"));
     assert!(output.stdout.contains("Dependencies resolvable"));
@@ -277,7 +277,7 @@ utils = {{ source = "official", path = "snippets/utils.md", version = "v1.0.0" }
 
     project.write_manifest(&manifest_content).await.unwrap();
 
-    let output = project.run_ccpm(&["validate", "--resolve"]).unwrap();
+    let output = project.run_agpm(&["validate", "--resolve"]).unwrap();
     assert!(output.success); // Current implementation validates source accessibility, not file existence
     assert!(output.stdout.contains("✓"));
     assert!(output.stdout.contains("Dependencies resolvable"));
@@ -312,7 +312,7 @@ async fn test_validate_local_paths() {
     .await
     .unwrap();
 
-    let output = project.run_ccpm(&["validate", "--paths"]).unwrap();
+    let output = project.run_agpm(&["validate", "--paths"]).unwrap();
     assert!(output.success);
     assert!(output.stdout.contains("✓"));
     assert!(output.stdout.contains("Local paths exist"));
@@ -327,7 +327,7 @@ async fn test_validate_missing_local_paths() {
 
     // Don't create the local files to test validation failure
 
-    let output = project.run_ccpm(&["validate", "--paths"]).unwrap();
+    let output = project.run_agpm(&["validate", "--paths"]).unwrap();
     assert!(!output.success);
     assert!(output.stdout.contains("✗"));
     assert!(output.stdout.contains("Local path not found"));
@@ -432,13 +432,13 @@ installed_at = "snippets/utils.md"
     );
 
     fs::write(
-        project.project_path().join("ccpm.lock"),
+        project.project_path().join("agpm.lock"),
         lockfile_content.trim(),
     )
     .await
     .unwrap();
 
-    let output = project.run_ccpm(&["validate", "--check-lock"]).unwrap();
+    let output = project.run_agpm(&["validate", "--check-lock"]).unwrap();
     assert!(output.success);
     assert!(output.stdout.contains("✓"));
     assert!(output.stdout.contains("Lockfile consistent"));
@@ -480,13 +480,13 @@ checksum = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b
 installed_at = "agents/different.md"
 "#;
     fs::write(
-        project.project_path().join("ccpm.lock"),
+        project.project_path().join("agpm.lock"),
         inconsistent_lockfile,
     )
     .await
     .unwrap();
 
-    let output = project.run_ccpm(&["validate", "--check-lock"]).unwrap();
+    let output = project.run_agpm(&["validate", "--check-lock"]).unwrap();
     assert!(!output.success);
     assert!(output.stdout.contains("✗"));
     assert!(output.stdout.contains("Lockfile inconsistent"));
@@ -509,13 +509,13 @@ my-agent = { source = "official", path = "agents/my-agent.md", version = "v1.0.0
 
     // Create corrupted lockfile
     fs::write(
-        project.project_path().join("ccpm.lock"),
+        project.project_path().join("agpm.lock"),
         "corrupted content",
     )
     .await
     .unwrap();
 
-    let output = project.run_ccpm(&["validate", "--check-lock"]).unwrap();
+    let output = project.run_agpm(&["validate", "--check-lock"]).unwrap();
     assert!(!output.success);
     assert!(output.stdout.contains("✗"));
     assert!(output.stdout.contains("Failed to parse lockfile"));
@@ -619,14 +619,14 @@ installed_at = "snippets/utils.md"
     );
 
     fs::write(
-        project.project_path().join("ccpm.lock"),
+        project.project_path().join("agpm.lock"),
         lockfile_content.trim(),
     )
     .await
     .unwrap();
 
     let output = project
-        .run_ccpm(&["validate", "--resolve", "--check-lock"])
+        .run_agpm(&["validate", "--resolve", "--check-lock"])
         .unwrap();
     assert!(output.success);
     assert!(output.stdout.contains("✓"));
@@ -646,7 +646,7 @@ my-agent = { source = "official", path = "agents/my-agent.md", version = "v1.0.0
 "#;
     project.write_manifest(manifest_content).await.unwrap();
 
-    let output = project.run_ccpm(&["validate", "--verbose"]).unwrap();
+    let output = project.run_agpm(&["validate", "--verbose"]).unwrap();
     assert!(output.success);
     assert!(output.stdout.contains("Validating"));
     assert!(output.stdout.contains("✓"));
@@ -666,7 +666,7 @@ my-agent = { source = "official", path = "agents/my-agent.md", version = "v1.0.0
 "#;
     project.write_manifest(manifest_content).await.unwrap();
 
-    let output = project.run_ccpm(&["validate", "--quiet"]).unwrap();
+    let output = project.run_agpm(&["validate", "--quiet"]).unwrap();
     assert!(output.success);
 
     // Should have minimal output in quiet mode
@@ -686,7 +686,7 @@ my-agent = { source = "official", path = "agents/my-agent.md", version = "v1.0.0
 "#;
     project.write_manifest(manifest_content).await.unwrap();
 
-    let output = project.run_ccpm(&["validate", "--format", "json"]).unwrap();
+    let output = project.run_agpm(&["validate", "--format", "json"]).unwrap();
     assert!(output.success);
     assert!(output.stdout.contains("{"));
     assert!(output.stdout.contains("\"valid\""));
@@ -720,13 +720,13 @@ utils = {{ source = "official", path = "snippets/utils.md", version = "v1.0.0" }
 "#
     );
 
-    let manifest_path = project.project_path().join("ccpm.toml");
+    let manifest_path = project.project_path().join("agpm.toml");
     fs::write(&manifest_path, manifest_content.trim())
         .await
         .unwrap();
 
     let output = project
-        .run_ccpm(&["validate", manifest_path.to_str().unwrap()])
+        .run_agpm(&["validate", manifest_path.to_str().unwrap()])
         .unwrap();
     assert!(output.success);
     assert!(output.stdout.contains("✓"));
@@ -745,7 +745,7 @@ official = "https://github.com/example-org/ccpm-official.git"
 "#;
     project.write_manifest(manifest_content).await.unwrap();
 
-    let output = project.run_ccpm(&["validate"]).unwrap();
+    let output = project.run_agpm(&["validate"]).unwrap();
     assert!(output.success);
     assert!(output.stdout.contains("✓"));
     assert!(output.stdout.contains("Valid"));
@@ -765,7 +765,7 @@ official = "https://github.com/example-org/ccpm-official.git"
 "#;
     project.write_manifest(manifest_content).await.unwrap();
 
-    let output = project.run_ccpm(&["validate", "--strict"]).unwrap();
+    let output = project.run_agpm(&["validate", "--strict"]).unwrap();
     assert!(!output.success);
     assert!(output.stdout.contains("✗"));
     assert!(output.stdout.contains("Strict mode"));
@@ -775,7 +775,7 @@ official = "https://github.com/example-org/ccpm-official.git"
 /// Test validate help command
 #[tokio::test]
 async fn test_validate_help() {
-    let mut cmd = assert_cmd::Command::cargo_bin("ccpm").unwrap();
+    let mut cmd = assert_cmd::Command::cargo_bin("agpm").unwrap();
     cmd.arg("validate")
         .arg("--help")
         .assert()
@@ -795,7 +795,7 @@ async fn test_validate_empty_manifest() {
 ";
     project.write_manifest(empty_manifest).await.unwrap();
 
-    let output = project.run_ccpm(&["validate"]).unwrap();
+    let output = project.run_agpm(&["validate"]).unwrap();
     assert!(output.success);
     assert!(output.stdout.contains("✓"));
     assert!(output.stdout.contains("Valid"));
@@ -820,7 +820,7 @@ agent-b = { source = "source2", path = "agents/b.md", version = "v1.0.0" }
 "#;
     project.write_manifest(manifest_content).await.unwrap();
 
-    let output = project.run_ccpm(&["validate", "--dependencies"]).unwrap();
+    let output = project.run_agpm(&["validate", "--dependencies"]).unwrap();
     assert!(output.success); // Should handle gracefully
     assert!(output.stdout.contains("✓"));
 }

--- a/tests/integration_validate.rs
+++ b/tests/integration_validate.rs
@@ -741,7 +741,7 @@ async fn test_validate_with_warnings() {
     // Create manifest with no dependencies (triggers "no dependencies" warning)
     let manifest_content = r#"
 [sources]
-official = "https://github.com/example-org/ccpm-official.git"
+official = "https://github.com/example-org/agpm-official.git"
 "#;
     project.write_manifest(manifest_content).await.unwrap();
 
@@ -761,7 +761,7 @@ async fn test_validate_strict_mode() {
     // Create manifest with no dependencies (triggers "no dependencies" warning)
     let manifest_content = r#"
 [sources]
-official = "https://github.com/example-org/ccpm-official.git"
+official = "https://github.com/example-org/agpm-official.git"
 "#;
     project.write_manifest(manifest_content).await.unwrap();
 

--- a/tests/integration_versioning.rs
+++ b/tests/integration_versioning.rs
@@ -123,7 +123,7 @@ example = {{ source = "versioned", path = "agents/example.md", version = "v1.0.0
     project.write_manifest(&manifest).await.unwrap();
 
     // Run install
-    let output = project.run_ccpm(&["install"]).unwrap();
+    let output = project.run_agpm(&["install"]).unwrap();
     output.assert_success();
 
     // Check installed file contains v1.0.0 content
@@ -155,7 +155,7 @@ example = {{ source = "versioned", path = "agents/example.md", version = "^1.0.0
     );
     project.write_manifest(&manifest).await.unwrap();
 
-    let output = project.run_ccpm(&["install"]).unwrap();
+    let output = project.run_agpm(&["install"]).unwrap();
     output.assert_success();
 
     // Should get v1.2.0 (highest compatible version)
@@ -186,7 +186,7 @@ example = {{ source = "versioned", path = "agents/example.md", version = "~1.1.0
     );
     project.write_manifest(&manifest).await.unwrap();
 
-    let output = project.run_ccpm(&["install"]).unwrap();
+    let output = project.run_agpm(&["install"]).unwrap();
     output.assert_success();
 
     // Should get v1.1.0 (only patch updates allowed)
@@ -218,7 +218,7 @@ experimental = {{ source = "versioned", path = "agents/experimental.md", branch 
     );
     project.write_manifest(&manifest).await.unwrap();
 
-    let output = project.run_ccpm(&["install"]).unwrap();
+    let output = project.run_agpm(&["install"]).unwrap();
     output.assert_success();
 
     // Check we got develop branch content
@@ -259,7 +259,7 @@ feature = {{ source = "versioned", path = "agents/feature.md", branch = "feature
     );
     project.write_manifest(&manifest).await.unwrap();
 
-    let output = project.run_ccpm(&["install"]).unwrap();
+    let output = project.run_agpm(&["install"]).unwrap();
     output.assert_success();
 
     // Check feature agent was installed
@@ -293,7 +293,7 @@ pinned = {{ source = "versioned", path = "agents/example.md", rev = "{}" }}
     );
     project.write_manifest(&manifest).await.unwrap();
 
-    let output = project.run_ccpm(&["install"]).unwrap();
+    let output = project.run_agpm(&["install"]).unwrap();
     output.assert_success();
 
     // Should get exact v1.0.0 content
@@ -325,7 +325,7 @@ any = {{ source = "versioned", path = "agents/example.md", version = "*" }}
     );
     project.write_manifest(&manifest).await.unwrap();
 
-    let output = project.run_ccpm(&["install"]).unwrap();
+    let output = project.run_agpm(&["install"]).unwrap();
     output.assert_success();
 
     // Should get v2.0.0 (highest available)
@@ -360,7 +360,7 @@ pinned = {{ source = "versioned", path = "agents/example.md", rev = "{}" }}
     );
     project.write_manifest(&manifest).await.unwrap();
 
-    let output = project.run_ccpm(&["install"]).unwrap();
+    let output = project.run_agpm(&["install"]).unwrap();
     // Should fail due to version conflict - same resource with different versions
     assert!(
         !output.success,
@@ -396,7 +396,7 @@ example = {{ source = "versioned", path = "agents/example.md", version = ">=1.1.
     );
     project.write_manifest(&manifest).await.unwrap();
 
-    let output = project.run_ccpm(&["install"]).unwrap();
+    let output = project.run_agpm(&["install"]).unwrap();
     output.assert_success();
 
     // Should get v2.0.0 (highest that satisfies >=1.1.0)
@@ -426,7 +426,7 @@ example = {{ source = "versioned", path = "agents/example.md", version = ">=1.1.
     );
     project.write_manifest(&manifest).await.unwrap();
 
-    let output = project.run_ccpm(&["install"]).unwrap();
+    let output = project.run_agpm(&["install"]).unwrap();
     output.assert_success();
 
     // Should get v1.2.0 (highest that satisfies the range)
@@ -458,7 +458,7 @@ dev = {{ source = "versioned", path = "agents/example.md", branch = "develop" }}
     project.write_manifest(&manifest).await.unwrap();
 
     // Initial install
-    let output = project.run_ccpm(&["install"]).unwrap();
+    let output = project.run_agpm(&["install"]).unwrap();
     output.assert_success();
 
     // Modify the develop branch
@@ -475,7 +475,7 @@ dev = {{ source = "versioned", path = "agents/example.md", branch = "develop" }}
     source_repo.git.commit("Update develop branch").unwrap();
 
     // Run update to get latest develop branch
-    let output = project.run_ccpm(&["update"]).unwrap();
+    let output = project.run_agpm(&["update"]).unwrap();
     output.assert_success();
 
     // Check we got the updated content
@@ -523,7 +523,7 @@ committed = {{ source = "versioned", path = "agents/feature.md", rev = "{}" }}
     );
     project.write_manifest(&manifest).await.unwrap();
 
-    let output = project.run_ccpm(&["install"]).unwrap();
+    let output = project.run_agpm(&["install"]).unwrap();
     // Should succeed - all dependencies have different paths
     output.assert_success();
 
@@ -555,7 +555,7 @@ example = {{ source = "versioned", path = "agents/example.md", version = "v99.0.
     project.write_manifest(&manifest).await.unwrap();
 
     // This should fail
-    let output = project.run_ccpm(&["install"]).unwrap();
+    let output = project.run_agpm(&["install"]).unwrap();
     assert!(!output.success, "Expected command to fail but it succeeded");
     assert!(
         output.stderr.contains("Git operation failed")
@@ -585,7 +585,7 @@ example = {{ source = "versioned", path = "agents/example.md", branch = "nonexis
     );
     project.write_manifest(&manifest).await.unwrap();
 
-    let output = project.run_ccpm(&["install"]).unwrap();
+    let output = project.run_agpm(&["install"]).unwrap();
     assert!(!output.success, "Expected command to fail but it succeeded");
 }
 
@@ -610,10 +610,10 @@ example = {{ source = "versioned", path = "agents/example.md", version = "^1.0.0
     project.write_manifest(&manifest).await.unwrap();
 
     // Initial install (should get v1.2.0)
-    let output = project.run_ccpm(&["install"]).unwrap();
+    let output = project.run_agpm(&["install"]).unwrap();
     output.assert_success();
 
-    let lockfile = fs::read_to_string(project.project_path().join("ccpm.lock"))
+    let lockfile = fs::read_to_string(project.project_path().join("agpm.lock"))
         .await
         .unwrap();
     assert!(lockfile.contains("version = \"v1.2.0\""));
@@ -624,7 +624,7 @@ example = {{ source = "versioned", path = "agents/example.md", version = "^1.0.0
         .unwrap();
 
     // Run frozen install - should use lockfile version (v1.2.0) not latest (v2.0.0)
-    let output = project.run_ccpm(&["install", "--frozen"]).unwrap();
+    let output = project.run_agpm(&["install", "--frozen"]).unwrap();
     output.assert_success();
 
     let installed = fs::read_to_string(project.project_path().join(".claude/agents/example.md"))
@@ -655,7 +655,7 @@ version-two = {{ source = "versioned", path = "agents/example.md", version = "v2
     );
     project.write_manifest(&manifest).await?;
 
-    let output = project.run_ccpm(&["install"])?;
+    let output = project.run_agpm(&["install"])?;
     assert!(!output.success, "Expected collision for same path");
     // Should detect version conflict (same resource, different versions)
     assert!(
@@ -672,7 +672,7 @@ version-two = {{ source = "versioned", path = "agents/example.md", version = "v2
     if claude_dir.exists() {
         fs::remove_dir_all(&claude_dir).await?;
     }
-    let lock_file = project.project_path().join("ccpm.lock");
+    let lock_file = project.project_path().join("agpm.lock");
     if lock_file.exists() {
         fs::remove_file(&lock_file).await?;
     }
@@ -693,7 +693,7 @@ version-two = {{ source = "versioned", path = "snippets/utils.md", version = "v1
     );
     project.write_manifest(&manifest).await?;
 
-    let output = project.run_ccpm(&["install"])?;
+    let output = project.run_agpm(&["install"])?;
     output.assert_success();
 
     // Verify both files are installed with custom targets
@@ -702,7 +702,7 @@ version-two = {{ source = "versioned", path = "snippets/utils.md", version = "v1
     let v1_path = project.project_path().join(".claude/agents/v1/example.md");
     let v2_path = project
         .project_path()
-        .join(".claude/ccpm/snippets/v2/utils.md");
+        .join(".claude/agpm/snippets/v2/utils.md");
 
     let v1 = fs::read_to_string(&v1_path)
         .await
@@ -719,7 +719,7 @@ version-two = {{ source = "versioned", path = "snippets/utils.md", version = "v1
     if claude_dir.exists() {
         fs::remove_dir_all(&claude_dir).await?;
     }
-    let lock_file = project.project_path().join("ccpm.lock");
+    let lock_file = project.project_path().join("agpm.lock");
     if lock_file.exists() {
         fs::remove_file(&lock_file).await?;
     }
@@ -738,7 +738,7 @@ snippet-one = {{ source = "versioned", path = "snippets/utils.md", version = "v1
     );
     project.write_manifest(&manifest).await?;
 
-    let output = project.run_ccpm(&["install"])?;
+    let output = project.run_agpm(&["install"])?;
     output.assert_success();
 
     Ok(())

--- a/tests/test_config.rs
+++ b/tests/test_config.rs
@@ -15,20 +15,20 @@ static INIT: Once = Once::new();
 pub fn init_test_env() {
     INIT.call_once(|| {
         // Use the shared logging initialization
-        ccpm::test_utils::init_test_logging(None);
+        agpm::test_utils::init_test_logging(None);
 
         // Set test-specific environment variables
         unsafe {
-            std::env::set_var("CCPM_TEST_MODE", "1");
-            std::env::set_var("CCPM_NO_PROGRESS", "1"); // Disable progress bars in tests
-            std::env::set_var("CCPM_PARALLEL_TESTS", "1");
+            std::env::set_var("AGPM_TEST_MODE", "1");
+            std::env::set_var("AGPM_NO_PROGRESS", "1"); // Disable progress bars in tests
+            std::env::set_var("AGPM_PARALLEL_TESTS", "1");
 
             // Ensure consistent behavior across platforms
-            std::env::set_var("CCPM_FORCE_COLOR", "0"); // Disable colors in test output
+            std::env::set_var("AGPM_FORCE_COLOR", "0"); // Disable colors in test output
 
             // Set reasonable timeouts for tests
-            std::env::set_var("CCPM_NETWORK_TIMEOUT", "30");
-            std::env::set_var("CCPM_GIT_TIMEOUT", "30");
+            std::env::set_var("AGPM_NETWORK_TIMEOUT", "30");
+            std::env::set_var("AGPM_GIT_TIMEOUT", "30");
         }
     });
 }


### PR DESCRIPTION
## Summary
- Rename project from CCPM (Claude Code Package Manager) to AGPM (AGentic Package Manager)
- Update all references to CCPM/ccpm throughout codebase, documentation, and examples
- Rename configuration files from `ccpm.toml`/`ccpm.lock` to `agpm.toml`/`agpm.lock`
- Update binary name, cache paths, and all user-facing strings

## Changes
- **Codebase**: Updated 136 files with comprehensive string replacements
- **Documentation**: Renamed all references in README.md, CLAUDE.md, AGENTS.md, and docs/ directory
- **Configuration**: Changed config file names and cache directory from `~/.ccpm/` to `~/.agpm/`
- **Examples**: Updated setup/cleanup scripts and example dependencies
- **Tests**: Updated all integration and unit tests to use new naming
- **Error messages**: Updated all error messages and user-facing strings
- **CI/CD**: Updated GitHub workflows and build configuration
- **Dependencies**: Updated Cargo.toml package name and metadata

## Test plan
- [ ] Verify `cargo build --release` succeeds
- [ ] Run full test suite: `cargo nextest run && cargo test --doc`
- [ ] Test basic commands: `agpm init`, `agpm install`, `agpm list`
- [ ] Verify cache directory created at `~/.agpm/`
- [ ] Confirm manifest files use `agpm.toml` and `agpm.lock`
- [ ] Check documentation rendering and accuracy
- [ ] Validate cross-platform compatibility (Windows, macOS, Linux paths)